### PR TITLE
fix: action deployment pipeline

### DIFF
--- a/apps/api/eslint.config.cjs
+++ b/apps/api/eslint.config.cjs
@@ -60,7 +60,11 @@ module.exports = tseslint.config(
   },
   // Allow any types in test files
   {
-    files: ["**/__tests__/**/*.{ts,tsx}", "**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+    files: [
+      "**/__tests__/**/*.{ts,tsx}",
+      "**/*.test.{ts,tsx}",
+      "**/*.spec.{ts,tsx}",
+    ],
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
     },

--- a/apps/api/src/cron/license-file-cleanup.cron.ts
+++ b/apps/api/src/cron/license-file-cleanup.cron.ts
@@ -65,9 +65,7 @@ class LicenseFileCleanupCronService {
   private async cleanup(): Promise<void> {
     // Prevent overlapping cycles
     if (this.isCleaning) {
-      logger.debug(
-        "Skipping cleanup cycle - previous cycle still in progress"
-      );
+      logger.debug("Skipping cleanup cycle - previous cycle still in progress");
       return;
     }
 

--- a/apps/api/src/workers/license-monitor.ts
+++ b/apps/api/src/workers/license-monitor.ts
@@ -18,8 +18,15 @@ if (isCloudMode() || process.env.ENABLE_SENTRY === "true") {
  * Dedicated process for:
  * - Monitoring license expirations and sending renewal reminders
  * - Cleaning up expired license file versions
+ *
+ * Only runs in cloud mode — self-hosted users don't need this.
  */
 async function startWorker() {
+  if (!isCloudMode()) {
+    logger.info("License Monitor worker skipped — only runs in cloud mode");
+    return;
+  }
+
   try {
     logger.info("Starting License Monitor worker process...");
 

--- a/apps/api/src/workers/update-monitor.ts
+++ b/apps/api/src/workers/update-monitor.ts
@@ -15,8 +15,15 @@ if (isCloudMode() || process.env.ENABLE_SENTRY === "true") {
 /**
  * Update Monitor Worker Process
  * Dedicated process for checking available Qarote updates and notifying admins
+ *
+ * Only runs in cloud mode — self-hosted users don't need this.
  */
 async function startWorker() {
+  if (!isCloudMode()) {
+    logger.info("Update Monitor worker skipped — only runs in cloud mode");
+    return;
+  }
+
   try {
     logger.info("Starting Update Monitor worker process...");
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is limited to disabling two background workers when not in cloud mode; otherwise changes are formatting/log-only.
> 
> **Overview**
> Prevents `license-monitor` and `update-monitor` worker processes from running in self-hosted deployments by adding an early `isCloudMode()` guard with a clear skip log.
> 
> Includes small formatting-only tweaks: a one-line debug log in `license-file-cleanup.cron.ts` and multiline formatting for the test-file glob list in `eslint.config.cjs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab047a09c07f385a7079eee301651e8fde1b87cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->