### PR TITLE
fix: remove pnpm version from ci workflows

### DIFF
--- a/.github/workflows/deploy-api-production.yml
+++ b/.github/workflows/deploy-api-production.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-api-staging.yml
+++ b/.github/workflows/deploy-api-staging.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-frontend-production.yml
+++ b/.github/workflows/deploy-frontend-production.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6
@@ -69,8 +67,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-frontend-staging.yml
+++ b/.github/workflows/deploy-frontend-staging.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6
@@ -66,8 +64,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-landing-production.yml
+++ b/.github/workflows/deploy-landing-production.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6
@@ -65,8 +63,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-landing-staging.yml
+++ b/.github/workflows/deploy-landing-staging.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6
@@ -62,8 +60,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-portal-production.yml
+++ b/.github/workflows/deploy-portal-production.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6
@@ -65,8 +63,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-portal-staging.yml
+++ b/.github/workflows/deploy-portal-staging.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6
@@ -62,8 +60,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-worker-production.yml
+++ b/.github/workflows/deploy-worker-production.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-worker-staging.yml
+++ b/.github/workflows/deploy-worker-staging.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -25,13 +25,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/.github/workflows/validate-commits.yml
+++ b/.github/workflows/validate-commits.yml
@@ -14,18 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🔍 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all commits for PR validation
           fetch-depth: 0
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"


### PR DESCRIPTION
## Summary
- Remove `with: version: 9` from all `pnpm/action-setup@v4` steps across 12 workflow files (18 occurrences)
- `pnpm/action-setup@v4` automatically reads the pnpm version from the `packageManager` field in `package.json`, so specifying `version: 9` manually causes a "Multiple versions of pnpm specified" error
- Upgrade `validate-commits.yml` from `pnpm/action-setup@v2` to `@v4`
- Upgrade `validate-commits.yml` and `release-binary.yml` from `actions/checkout@v4` and `actions/setup-node@v4` to `@v6`

## Test plan
- [ ] Verify CI passes on this PR (validate-commits workflow)
- [ ] After merge, verify staging deploy workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many CI/deploy workflows, so misconfiguration could block releases or deployments. The change is narrowly scoped to action versions and pnpm setup behavior.
> 
> **Overview**
> Removes the explicit `with: version: 9` from all `pnpm/action-setup@v4` steps so workflows rely on the repo’s `packageManager` field, preventing “multiple versions of pnpm specified” CI failures.
> 
> Modernizes CI tooling by upgrading `validate-commits.yml` to `pnpm/action-setup@v4` and bumping `actions/checkout`/`actions/setup-node` to `@v6` in `validate-commits.yml` and `release-binary.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb248646a46bef5278dd919eafdc3a822b4e0027. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->