### PR TITLE
fix: add @types/pg to resolve type-check failure

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -106,6 +106,7 @@
     "@types/cors": "^2.8.19",
     "@types/node": "^25.0.3",
     "@types/nodemailer": "^7.0.4",
+    "@types/pg": "^8.15.4",
     "@types/semver": "^7.7.0",
     "eslint": "^9.39.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@types/nodemailer':
         specifier: ^7.0.4
         version: 7.0.10
+      '@types/pg':
+        specifier: ^8.15.4
+        version: 8.16.0
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.1


### PR DESCRIPTION
pg@8.18.0 doesn't ship its own type declarations, so @types/pg is needed for TypeScript to find declaration files for the pg module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change adding type declarations; no runtime code paths or behavior are modified.
> 
> **Overview**
> Fixes TypeScript type-check failures in `apps/api` by adding `@types/pg` as a dev dependency, providing declaration files for the `pg` module.
> 
> Updates `pnpm-lock.yaml` accordingly to lock the new typings package/version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71d534eaf8440d7fe1a8fc729ef03ffd3942ab41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->