### PR TITLE
chore: upgrade react-router-dom v6 to react-router v7

### DIFF
--- a/.cursor/rules/import-ordering.mdc
+++ b/.cursor/rules/import-ordering.mdc
@@ -10,7 +10,7 @@ All imports in TypeScript/JavaScript files must follow this strict ordering:
 2. **Node.js built-in modules** - Node.js core modules (e.g., `node:path`, `node:fs`, `node:url`)
    - **REQUIRED**: All Node.js built-in modules MUST use the `node:` prefix (e.g., `node:path`, `node:fs`, `node:crypto`, `node:os`)
    - **NEVER** use bare imports like `import path from "path"` - always use `import path from "node:path"`
-3. **React modules** - React and React-related packages (e.g., `react`, `react-dom`, `react-router-dom`, `@react-oauth/google`, `@tanstack/react-query`)
+3. **React modules** - React and React-related packages (e.g., `react`, `react-dom`, `react-router`, `@react-oauth/google`, `@tanstack/react-query`)
 4. **External npm packages** - Other third-party packages (e.g., `zod`, `date-fns`, `lucide-react`, `@radix-ui/*`)
 5. **Lib modules** - Internal library functionality (`@/lib/*`)
 6. **Components modules** - React components (`@/components/*`)
@@ -35,7 +35,7 @@ import { readFileSync } from "node:fs";
 // IMPORTANT: Always use named imports for React hooks (useState, useEffect, etc.)
 // NEVER use React.useState or React.useEffect - this causes production build errors
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 
 // 4. External npm packages

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -63,7 +63,7 @@
     "react-dom": "^19.2.3",
     "react-ga4": "^2.1.0",
     "react-hook-form": "^7.70.0",
-    "react-router-dom": "^6.30.2",
+    "react-router": "^7.13.0",
     "recharts": "^3.6.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router";
 
 import { queryClient } from "@/lib/queryClient";
 import { SentryErrorBoundary, withSentryProfiling } from "@/lib/sentry";
@@ -66,12 +66,7 @@ const AppCore = () => (
                   <TooltipProvider>
                     <Toaster />
                     <Sonner />
-                    <BrowserRouter
-                      future={{
-                        v7_startTransition: true,
-                        v7_relativeSplatPath: true,
-                      }}
-                    >
+                    <BrowserRouter>
                       <TawkTo />
                       <ScrollToTop />
                       <Suspense fallback={<PageLoader />}>

--- a/apps/app/src/components/AddServerButton.tsx
+++ b/apps/app/src/components/AddServerButton.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Lock } from "lucide-react";
 

--- a/apps/app/src/components/AppSidebar.tsx
+++ b/apps/app/src/components/AppSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 
 import {
   Activity,

--- a/apps/app/src/components/ConnectedNodes.tsx
+++ b/apps/app/src/components/ConnectedNodes.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { ArrowRight, Cpu, HardDrive, Server, Wifi } from "lucide-react";
 

--- a/apps/app/src/components/Layout.tsx
+++ b/apps/app/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { ExternalLink, HelpCircle } from "lucide-react";
 

--- a/apps/app/src/components/ProtectedRoute.tsx
+++ b/apps/app/src/components/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router";
 
 import { Loader2 } from "lucide-react";
 

--- a/apps/app/src/components/PublicRoute.tsx
+++ b/apps/app/src/components/PublicRoute.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router";
 
 import { useAuth } from "@/contexts/AuthContextDefinition";
 

--- a/apps/app/src/components/RecentAlerts.tsx
+++ b/apps/app/src/components/RecentAlerts.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 
 import { AlertTriangle, ArrowRight } from "lucide-react";
 

--- a/apps/app/src/components/ScrollToTop.tsx
+++ b/apps/app/src/components/ScrollToTop.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 /**
  * ScrollToTop component that automatically scrolls to the top of the page

--- a/apps/app/src/components/ServerManagement.tsx
+++ b/apps/app/src/components/ServerManagement.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 import {
   Edit,

--- a/apps/app/src/components/TawkTo.tsx
+++ b/apps/app/src/components/TawkTo.tsx
@@ -1,6 +1,8 @@
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 import TawkMessengerReact from "@tawk.to/tawk-messenger-react";
+
+const noop = () => {};
 
 export const TawkTo = () => {
   const location = useLocation();
@@ -19,6 +21,26 @@ export const TawkTo = () => {
     <TawkMessengerReact
       propertyId="68b6ac54065fda19279ca7e6"
       widgetId="1j44p2ar4"
+      onLoad={noop}
+      onStatusChange={noop}
+      onBeforeLoad={noop}
+      onChatMaximized={noop}
+      onChatMinimized={noop}
+      onChatHidden={noop}
+      onChatStarted={noop}
+      onChatEnded={noop}
+      onPrechatSubmit={noop}
+      onOfflineSubmit={noop}
+      onChatMessageVisitor={noop}
+      onChatMessageAgent={noop}
+      onChatMessageSystem={noop}
+      onAgentJoinChat={noop}
+      onAgentLeaveChat={noop}
+      onChatSatisfaction={noop}
+      onVisitorNameChanged={noop}
+      onFileUpload={noop}
+      onTagsUpdated={noop}
+      onUnreadCountChanged={noop}
     />
   );
 };

--- a/apps/app/src/components/WorkspaceSelector.tsx
+++ b/apps/app/src/components/WorkspaceSelector.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Building2, ChevronDown, Crown, Lock, Plus, User } from "lucide-react";
 import { toast } from "sonner";

--- a/apps/app/src/components/alerts/ActiveAlertsList.tsx
+++ b/apps/app/src/components/alerts/ActiveAlertsList.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { AlertTriangle, CheckCircle } from "lucide-react";
 

--- a/apps/app/src/components/auth/GoogleInvitationButton.tsx
+++ b/apps/app/src/components/auth/GoogleInvitationButton.tsx
@@ -2,7 +2,7 @@ import "@/styles/google-auth.css";
 
 import React from "react";
 import { CredentialResponse, GoogleLogin } from "@react-oauth/google";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { logger } from "@/lib/logger";
 import { trpc } from "@/lib/trpc/client";

--- a/apps/app/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/app/src/components/auth/GoogleLoginButton.tsx
@@ -2,7 +2,7 @@ import "@/styles/google-auth.css";
 
 import React from "react";
 import { CredentialResponse, GoogleLogin } from "@react-oauth/google";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { trackSignUp } from "@/lib/ga";
 import { logger } from "@/lib/logger";

--- a/apps/app/src/components/billing/BillingHeader.tsx
+++ b/apps/app/src/components/billing/BillingHeader.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { ArrowLeft } from "lucide-react";
 

--- a/apps/app/src/components/profile/EnhancedTeamTab.tsx
+++ b/apps/app/src/components/profile/EnhancedTeamTab.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Clock, Lock, Mail, UserPlus, Users, X } from "lucide-react";
 

--- a/apps/app/src/components/profile/PlansSummaryTab.tsx
+++ b/apps/app/src/components/profile/PlansSummaryTab.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { Crown, Loader2, Server, TrendingUp, Users, Zap } from "lucide-react";
 

--- a/apps/app/src/hooks/queries/useProfile.ts
+++ b/apps/app/src/hooks/queries/useProfile.ts
@@ -71,10 +71,16 @@ export const useVerificationStatus = () => {
 };
 
 // Password reset hooks
-export const useRequestPasswordReset = () => {
-  return trpc.auth.password.requestPasswordReset.useMutation();
+export const useRequestPasswordReset = (
+  options?: Parameters<
+    typeof trpc.auth.password.requestPasswordReset.useMutation
+  >[0]
+) => {
+  return trpc.auth.password.requestPasswordReset.useMutation(options);
 };
 
-export const useResetPassword = () => {
-  return trpc.auth.password.resetPassword.useMutation();
+export const useResetPassword = (
+  options?: Parameters<typeof trpc.auth.password.resetPassword.useMutation>[0]
+) => {
+  return trpc.auth.password.resetPassword.useMutation(options);
 };

--- a/apps/app/src/hooks/ui/usePlanUpgrade.ts
+++ b/apps/app/src/hooks/ui/usePlanUpgrade.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { logger } from "@/lib/logger";
 import { trpc } from "@/lib/trpc/client";

--- a/apps/app/src/pages/AcceptInvitation.tsx
+++ b/apps/app/src/pages/AcceptInvitation.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Building, Loader2, Mail, Users } from "lucide-react";

--- a/apps/app/src/pages/Alerts.tsx
+++ b/apps/app/src/pages/Alerts.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router";
 
 import { AlertTriangle, Loader2, Mail, Settings } from "lucide-react";
 
@@ -40,7 +40,7 @@ const Alerts = () => {
     useFeatureFlags();
   // const [showConfigureModal, setShowConfigureModal] = useState(false);
   const [showNotificationSettingsModal, setShowNotificationSettingsModal] =
-    useState(false);
+    useState(() => searchParams.get("openNotificationSettings") === "true");
   const [showAlertRulesModal, setShowAlertRulesModal] = useState(false);
   const [viewMode, setViewMode] = useState<"active" | "resolved">("active");
 
@@ -86,14 +86,9 @@ const Alerts = () => {
 
   const currentServerId = serverId || selectedServerId;
 
-  // Check for query parameter to open notification settings modal
+  // Clean up the openNotificationSettings query parameter from URL after initial read
   useEffect(() => {
-    const openNotificationSettings = searchParams.get(
-      "openNotificationSettings"
-    );
-    if (openNotificationSettings === "true") {
-      setShowNotificationSettingsModal(true);
-      // Remove the query parameter from URL after opening modal
+    if (searchParams.get("openNotificationSettings") === "true") {
       searchParams.delete("openNotificationSettings");
       setSearchParams(searchParams, { replace: true });
     }

--- a/apps/app/src/pages/ForgotPassword.tsx
+++ b/apps/app/src/pages/ForgotPassword.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { Link, useNavigate } from "react-router";
 
 import { ArrowLeft, Mail, Send } from "lucide-react";
 import { toast } from "sonner";
@@ -25,22 +25,16 @@ const ForgotPassword: React.FC = () => {
   const [email, setEmail] = useState("");
   const [emailSent, setEmailSent] = useState(false);
 
-  const resetPasswordMutation = useRequestPasswordReset();
-
-  // Handle success/error with useEffect or in the mutation
-  useEffect(() => {
-    if (resetPasswordMutation.isSuccess) {
+  const resetPasswordMutation = useRequestPasswordReset({
+    onSuccess: () => {
       setEmailSent(true);
       toast.success("Password reset instructions sent to your email");
-    }
-    if (resetPasswordMutation.isError) {
-      logger.error(
-        "Password reset request error:",
-        resetPasswordMutation.error
-      );
+    },
+    onError: (error: Error) => {
+      logger.error("Password reset request error:", error);
       toast.error("Failed to send password reset email. Please try again.");
-    }
-  }, [resetPasswordMutation.isSuccess, resetPasswordMutation.isError]);
+    },
+  });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/apps/app/src/pages/HelpSupport.tsx
+++ b/apps/app/src/pages/HelpSupport.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import {
   Book,

--- a/apps/app/src/pages/Index.tsx
+++ b/apps/app/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Server } from "lucide-react";
 

--- a/apps/app/src/pages/NotFound.tsx
+++ b/apps/app/src/pages/NotFound.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 import { logger } from "@/lib/logger";
 

--- a/apps/app/src/pages/PaymentCancelled.tsx
+++ b/apps/app/src/pages/PaymentCancelled.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { ArrowLeft, CreditCard, Loader2, XCircle } from "lucide-react";
 

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import {
   ArrowLeft,

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useState } from "react";
+import { useSearchParams } from "react-router";
 
 import { Crown, MessageSquare, Shield, User } from "lucide-react";
 import { toast } from "sonner";
@@ -127,33 +127,34 @@ const Profile = () => {
     return currentUserCount + pendingInvitationCount < planFeatures.maxUsers;
   };
 
-  // Initialize forms when profile data loads
-  useEffect(() => {
-    if (profile) {
-      setProfileForm({
-        firstName: profile.firstName || "",
-        lastName: profile.lastName || "",
-      });
-    }
-    if (workspace) {
-      setWorkspaceForm({
-        name: workspace.name || "",
-        contactEmail: workspace.contactEmail || "",
-      });
-    }
-  }, [profile, workspace]);
+  // Initialize forms when profile/workspace data first loads
+  // Uses React's "adjusting state when a prop changes" pattern
+  const [prevProfileId, setPrevProfileId] = useState<string | null>(null);
+  if (profile?.id && profile.id !== prevProfileId) {
+    setPrevProfileId(profile.id);
+    setProfileForm({
+      firstName: profile.firstName || "",
+      lastName: profile.lastName || "",
+    });
+  }
+  const [prevWorkspaceId, setPrevWorkspaceId] = useState<string | null>(null);
+  if (workspace?.id && workspace.id !== prevWorkspaceId) {
+    setPrevWorkspaceId(workspace.id);
+    setWorkspaceForm({
+      name: workspace.name || "",
+      contactEmail: workspace.contactEmail || "",
+    });
+  }
 
   // Sync tab state with URL parameter changes
-  useEffect(() => {
-    const urlTab = searchParams.get("tab");
-    if (
-      urlTab &&
-      VALID_TABS.includes(urlTab as TabValue) &&
-      urlTab !== activeTab
-    ) {
-      setActiveTab(urlTab as TabValue);
-    }
-  }, [searchParams, activeTab]);
+  const urlTab = searchParams.get("tab");
+  const validUrlTab =
+    urlTab && VALID_TABS.includes(urlTab as TabValue)
+      ? (urlTab as TabValue)
+      : null;
+  if (validUrlTab && validUrlTab !== activeTab) {
+    setActiveTab(validUrlTab);
+  }
 
   const handleUpdateProfile = async () => {
     try {

--- a/apps/app/src/pages/QueueDetail.tsx
+++ b/apps/app/src/pages/QueueDetail.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 import { logger } from "@/lib/logger";
 

--- a/apps/app/src/pages/Queues.tsx
+++ b/apps/app/src/pages/Queues.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { logger } from "@/lib/logger";
 

--- a/apps/app/src/pages/ResetPassword.tsx
+++ b/apps/app/src/pages/ResetPassword.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router";
 
 import { Check, Eye, EyeOff, Lock, Shield, X } from "lucide-react";
 import { toast } from "sonner";
@@ -44,23 +44,20 @@ const ResetPassword: React.FC = () => {
     }
   }, [token, navigate]);
 
-  const resetPasswordMutation = useResetPassword();
-
-  // Handle success/error with useEffect
-  useEffect(() => {
-    if (resetPasswordMutation.isSuccess) {
+  const resetPasswordMutation = useResetPassword({
+    onSuccess: () => {
       setResetSuccess(true);
       toast.success(
         "Password reset successfully! You can now sign in with your new password."
       );
-    }
-    if (resetPasswordMutation.isError) {
-      logger.error("Password reset error:", resetPasswordMutation.error);
+    },
+    onError: (error) => {
+      logger.error("Password reset error:", error);
       toast.error(
         "Failed to reset password. The link may be expired or invalid."
       );
-    }
-  }, [resetPasswordMutation.isSuccess, resetPasswordMutation.isError]);
+    },
+  });
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {};

--- a/apps/app/src/pages/SignIn.tsx
+++ b/apps/app/src/pages/SignIn.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 

--- a/apps/app/src/pages/SignUp.tsx
+++ b/apps/app/src/pages/SignUp.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 

--- a/apps/app/src/pages/UsersPage.tsx
+++ b/apps/app/src/pages/UsersPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 import {
   AlertCircle,

--- a/apps/app/src/pages/VHostDetailsPage.tsx
+++ b/apps/app/src/pages/VHostDetailsPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router";
 
 import { AlertCircle, ArrowLeft, Lock } from "lucide-react";
 import { toast } from "sonner";
@@ -51,7 +51,10 @@ export default function VHostDetailsPage() {
   const [showEditModal, setShowEditModal] = useState(false);
 
   // Form states
-  const [selectedUser, setSelectedUser] = useState("admin");
+  // null means "use derived default from data", string means "user explicitly chose this"
+  const [selectedUserOverride, setSelectedUserOverride] = useState<
+    string | null
+  >(null);
   const [configureRegexp, setConfigureRegexp] = useState(".*");
   const [writeRegexp, setWriteRegexp] = useState(".*");
   const [readRegexp, setReadRegexp] = useState(".*");
@@ -83,12 +86,16 @@ export default function VHostDetailsPage() {
   const clearPermissionsMutation = useDeleteVHostPermissions();
   const { workspace } = useWorkspace();
 
-  // Set default user when users are loaded
-  useEffect(() => {
-    if (usersData?.users?.length && !selectedUser) {
-      setSelectedUser(usersData.users[0].name);
+  // Derive the default user from loaded data
+  const derivedDefaultUser = useMemo(() => {
+    if (usersData?.users?.length) {
+      return usersData.users[0].name;
     }
-  }, [usersData, selectedUser]);
+    return "admin";
+  }, [usersData]);
+
+  const selectedUser = selectedUserOverride ?? derivedDefaultUser;
+  const setSelectedUser = setSelectedUserOverride;
 
   // Handle form submissions
   const handleSetPermissions = async () => {

--- a/apps/app/src/pages/VHostsPage.tsx
+++ b/apps/app/src/pages/VHostsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 import {
   AlertCircle,

--- a/apps/app/src/pages/VerifyEmail.tsx
+++ b/apps/app/src/pages/VerifyEmail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { CheckCircle, Mail, RefreshCw, XCircle } from "lucide-react";
 import { toast } from "sonner";
@@ -33,15 +33,25 @@ export default function VerifyEmail() {
   const queryClient = useQueryClient();
   const { isAuthenticated, updateUser } = useAuth();
   const verificationAttempted = useRef(false);
+  const token = searchParams.get("token");
   const [verificationState, setVerificationState] = useState<{
     loading: boolean;
     result: VerificationResult | null;
-  }>({
-    loading: true,
-    result: null,
+  }>(() => {
+    if (!token) {
+      return {
+        loading: false,
+        result: {
+          success: false,
+          error: "No verification token provided",
+        },
+      };
+    }
+    return {
+      loading: true,
+      result: null,
+    };
   });
-
-  const token = searchParams.get("token");
 
   // tRPC mutations
   const verifyEmailMutation = trpc.auth.verification.verifyEmail.useMutation({
@@ -108,13 +118,6 @@ export default function VerifyEmail() {
 
     if (!token) {
       logger.log("No token found in URL");
-      setVerificationState({
-        loading: false,
-        result: {
-          success: false,
-          error: "No verification token provided",
-        },
-      });
       return;
     }
 
@@ -131,7 +134,6 @@ export default function VerifyEmail() {
       tokenPrefix: token.substring(0, 8),
     });
 
-    setVerificationState({ loading: true, result: null });
     verifyEmailMutation.mutate({ token });
   }, [token]);
 

--- a/apps/app/src/pages/Workspace.tsx
+++ b/apps/app/src/pages/Workspace.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { CheckCircle, Loader2, Plus } from "lucide-react";

--- a/apps/app/src/pages/public/PrivacyPolicy.tsx
+++ b/apps/app/src/pages/public/PrivacyPolicy.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { ArrowLeft, Shield } from "lucide-react";
 

--- a/apps/app/src/pages/public/TermsOfService.tsx
+++ b/apps/app/src/pages/public/TermsOfService.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { ArrowLeft, FileText } from "lucide-react";
 

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         manualChunks: {
           // CRITICAL: React must be in its own chunk to prevent bundling issues
           // This ensures React is properly resolved and prevents production errors
-          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-react": ["react", "react-dom", "react-router"],
           // UI components chunk
           "vendor-ui": [
             "@radix-ui/react-dialog",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -39,7 +39,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.70.0",
-    "react-router-dom": "^6.30.2",
+    "react-router": "^7.13.0",
     "react-syntax-highlighter": "^16.1.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",

--- a/apps/portal/src/App.tsx
+++ b/apps/portal/src/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 
 import { queryClient } from "@/lib/queryClient";
 import { TRPCProvider } from "@/lib/trpc/provider";
@@ -43,12 +43,7 @@ const App = () => {
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
           <Toaster />
-          <BrowserRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
+          <BrowserRouter>
             <Routes>
               {/* Redirect old routes for backward compatibility */}
               <Route

--- a/apps/portal/src/components/Layout.tsx
+++ b/apps/portal/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Link, Outlet, useLocation, useNavigate } from "react-router";
 
 import {
   BookOpen,

--- a/apps/portal/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/portal/src/components/auth/GoogleLoginButton.tsx
@@ -2,7 +2,7 @@ import "@/styles/google-auth.css";
 
 import React from "react";
 import { CredentialResponse, GoogleLogin } from "@react-oauth/google";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { toast } from "sonner";
 

--- a/apps/portal/src/pages/LicenseManagement.tsx
+++ b/apps/portal/src/pages/LicenseManagement.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { format } from "date-fns";
 import { CheckCircle, Copy, Download, XCircle } from "lucide-react";

--- a/apps/portal/src/pages/Login.tsx
+++ b/apps/portal/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Github } from "lucide-react";

--- a/apps/portal/src/pages/SignUp.tsx
+++ b/apps/portal/src/pages/SignUp.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Github } from "lucide-react";

--- a/apps/portal/src/pages/VerifyEmail.tsx
+++ b/apps/portal/src/pages/VerifyEmail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { CheckCircle, Mail, RefreshCw, XCircle } from "lucide-react";
 import { toast } from "sonner";

--- a/apps/portal/vite.config.ts
+++ b/apps/portal/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         manualChunks: {
           // CRITICAL: React must be in its own chunk to prevent bundling issues
           // This ensures React is properly resolved and prevents production errors
-          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-react": ["react", "react-dom", "react-router"],
           // UI components chunk
           "vendor-ui": ["@radix-ui/react-label", "@radix-ui/react-slot"],
           // Data fetching and state management

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,7 +40,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.3",
     "react-helmet-async": "^2.0.5",
-    "react-router-dom": "^6.30.2",
+    "react-router": "^7.13.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { HelmetProvider } from "react-helmet-async";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router";
 
 import { TawkTo } from "@/components/TawkTo";
 import { Toaster as Sonner } from "@/components/ui/sonner";
@@ -34,12 +34,7 @@ const App = () => {
         <TooltipProvider>
           <Toaster />
           <Sonner />
-          <BrowserRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
+          <BrowserRouter>
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/privacy-policy" element={<PrivacyPolicy />} />

--- a/apps/web/src/components/TawkTo.tsx
+++ b/apps/web/src/components/TawkTo.tsx
@@ -1,10 +1,32 @@
 import TawkMessengerReact from "@tawk.to/tawk-messenger-react";
 
+const noop = () => {};
+
 export const TawkTo = () => {
   return (
     <TawkMessengerReact
       propertyId="68b6ac54065fda19279ca7e6"
       widgetId="1j44p2ar4"
+      onLoad={noop}
+      onStatusChange={noop}
+      onBeforeLoad={noop}
+      onChatMaximized={noop}
+      onChatMinimized={noop}
+      onChatHidden={noop}
+      onChatStarted={noop}
+      onChatEnded={noop}
+      onPrechatSubmit={noop}
+      onOfflineSubmit={noop}
+      onChatMessageVisitor={noop}
+      onChatMessageAgent={noop}
+      onChatMessageSystem={noop}
+      onAgentJoinChat={noop}
+      onAgentLeaveChat={noop}
+      onChatSatisfaction={noop}
+      onVisitorNameChanged={noop}
+      onFileUpload={noop}
+      onTagsUpdated={noop}
+      onUnreadCountChanged={noop}
     />
   );
 };

--- a/apps/web/src/types/tawk-messenger-react.d.ts
+++ b/apps/web/src/types/tawk-messenger-react.d.ts
@@ -4,6 +4,29 @@ declare module "@tawk.to/tawk-messenger-react" {
   interface TawkMessengerReactProps {
     propertyId: string;
     widgetId: string;
+    customStyle?: object | null;
+    embedId?: string;
+    basePath?: string;
+    onLoad?: () => void;
+    onStatusChange?: (status: string) => void;
+    onBeforeLoad?: () => void;
+    onChatMaximized?: () => void;
+    onChatMinimized?: () => void;
+    onChatHidden?: () => void;
+    onChatStarted?: () => void;
+    onChatEnded?: () => void;
+    onPrechatSubmit?: (data: unknown) => void;
+    onOfflineSubmit?: (data: unknown) => void;
+    onChatMessageVisitor?: (message: unknown) => void;
+    onChatMessageAgent?: (message: unknown) => void;
+    onChatMessageSystem?: (message: unknown) => void;
+    onAgentJoinChat?: (data: unknown) => void;
+    onAgentLeaveChat?: (data: unknown) => void;
+    onChatSatisfaction?: (satisfaction: unknown) => void;
+    onVisitorNameChanged?: (visitorName: unknown) => void;
+    onFileUpload?: (link: unknown) => void;
+    onTagsUpdated?: (data: unknown) => void;
+    onUnreadCountChanged?: (data: unknown) => void;
   }
 
   export default class TawkMessengerReact extends Component<TawkMessengerReactProps> {}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         manualChunks: {
           // CRITICAL: React must be in its own chunk to prevent bundling issues
           // This ensures React is properly resolved and prevents production errors
-          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-react": ["react", "react-dom", "react-router"],
           // UI components chunk - only include installed packages
           "vendor-ui": [
             "@radix-ui/react-accordion",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,9 +282,9 @@ importers:
       react-hook-form:
         specifier: ^7.70.0
         version: 7.71.1(react@19.2.4)
-      react-router-dom:
-        specifier: ^6.30.2
-        version: 6.30.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router:
+        specifier: ^7.13.0
+        version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       recharts:
         specifier: ^3.6.0
         version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
@@ -421,9 +421,9 @@ importers:
       react-hook-form:
         specifier: ^7.70.0
         version: 7.71.1(react@19.2.4)
-      react-router-dom:
-        specifier: ^6.30.2
-        version: 6.30.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router:
+        specifier: ^7.13.0
+        version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.0(react@19.2.4)
@@ -539,9 +539,9 @@ importers:
       react-helmet-async:
         specifier: ^2.0.5
         version: 2.0.5(react@19.2.4)
-      react-router-dom:
-        specifier: ^6.30.2
-        version: 6.30.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router:
+        specifier: ^7.13.0
+        version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2797,10 +2797,6 @@ packages:
       react-redux:
         optional: true
 
-  '@remix-run/router@1.23.1':
-    resolution: {integrity: sha512-vDbaOzF7yT2Qs4vO6XV1MHcJv+3dgR1sT+l3B8xxOVhUC336prMvqrvsLL/9Dnw2xr6Qhz4J0dmS0llNAbnUmQ==}
-    engines: {node: '>=14.0.0'}
-
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -3984,6 +3980,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -5999,18 +5999,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@6.30.2:
-    resolution: {integrity: sha512-l2OwHn3UUnEVUqc6/1VMmR1cvZryZ3j3NzapC2eUXO1dB0sYp5mvwdjiXhpUbRb21eFow3qSxpP8Yv6oAU824Q==}
-    engines: {node: '>=14.0.0'}
+  react-router@7.13.0:
+    resolution: {integrity: sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
-  react-router@6.30.2:
-    resolution: {integrity: sha512-H2Bm38Zu1bm8KUE5NVWRMzuIyAV8p/JrOaBJAwVmp37AXG72+CZJlEBw6pdn9i5TBgLMhNDgijS4ZlblpHyWTA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -6206,6 +6203,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -9640,8 +9640,6 @@ snapshots:
       react: 19.2.4
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
 
-  '@remix-run/router@1.23.1': {}
-
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.53.5':
@@ -10964,6 +10962,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
 
@@ -13067,17 +13067,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-router-dom@6.30.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@remix-run/router': 1.23.1
+      cookie: 1.1.1
       react: 19.2.4
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
-      react-router: 6.30.2(react@19.2.4)
-
-  react-router@6.30.2(react@19.2.4):
-    dependencies:
-      '@remix-run/router': 1.23.1
-      react: 19.2.4
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -13296,6 +13292,8 @@ snapshots:
 
   set-blocking@2.0.0:
     optional: true
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace `react-router-dom` (v6) with `react-router` (v7) across all 3 frontend apps (app, web, portal)
- Remove `v7_startTransition` and `v7_relativeSplatPath` future flags from `BrowserRouter` (now default behavior in v7)
- Update Vite manual chunks and cursor rules to reference `react-router` instead of `react-router-dom`
- Fix pre-existing `react-hooks/set-state-in-effect` violations surfaced by lint-staged in touched files

## Breaking changes handled
- Package rename: `react-router-dom` → `react-router` (51 files updated)
- Future flags removed from all 3 `BrowserRouter` instances
- All existing imports (`BrowserRouter`, `Route`, `Routes`, `Link`, `Navigate`, `Outlet`, `useNavigate`, `useLocation`, `useParams`, `useSearchParams`) work from `react-router`

## Test plan
- [x] `pnpm type-check` passes (all 4 apps)
- [x] `pnpm build:app && pnpm build:web && pnpm build:portal` all succeed
- [x] `pnpm syncpack:check` passes
- [x] `pnpm knip` passes
- [ ] Manual smoke test: navigation, route params, search params

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide-scope routing library upgrade across three apps could introduce subtle navigation or URL handling regressions despite mostly mechanical import changes.
> 
> **Overview**
> Upgrades routing across `app`, `web`, and `portal` by replacing `react-router-dom@6` with `react-router@7`, updating all router-related imports/usages and Vite `manualChunks` to bundle `react-router` instead.
> 
> Removes `BrowserRouter` v7 “future” flags (now default in v7) and includes small follow-up fixes in touched screens: switch password-reset hooks to accept mutation callbacks, prevent duplicate purchase analytics via a ref, initialize some state from URL/data without `useEffect`, make Alerts open its notification settings modal via query param, and expand `@tawk.to/tawk-messenger-react` typings while wiring no-op event handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7db5c2d741bcda02f317c14a2bd0224d2f98bc54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->