### PR TITLE
test: add critical stripe webhook and service test coverage

### DIFF
--- a/apps/api/src/services/stripe/__tests__/core-service.test.ts
+++ b/apps/api/src/services/stripe/__tests__/core-service.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CoreStripeService } from "../core.service";
+
+// Mock dependencies required at module level by core.service.ts
+vi.mock("@/config", () => ({
+  stripeConfig: {
+    secretKey: null,
+    priceIds: {
+      developer: { monthly: null, yearly: null },
+      enterprise: { monthly: null, yearly: null },
+    },
+  },
+}));
+
+vi.mock("@/services/sentry", () => ({
+  Sentry: { withScope: vi.fn(), captureException: vi.fn() },
+  setSentryContext: vi.fn(),
+  trackPaymentError: vi.fn(),
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe("CoreStripeService", () => {
+  describe("extractSubscriptionIdFromInvoice", () => {
+    it("extracts string subscription from parent.subscription_details", () => {
+      const invoice = {
+        parent: {
+          type: "subscription_details",
+          subscription_details: {
+            subscription: "sub_abc123",
+          },
+        },
+      } as any;
+
+      expect(CoreStripeService.extractSubscriptionIdFromInvoice(invoice)).toBe(
+        "sub_abc123"
+      );
+    });
+
+    it("extracts subscription id from object", () => {
+      const invoice = {
+        parent: {
+          type: "subscription_details",
+          subscription_details: {
+            subscription: { id: "sub_obj456" },
+          },
+        },
+      } as any;
+
+      expect(CoreStripeService.extractSubscriptionIdFromInvoice(invoice)).toBe(
+        "sub_obj456"
+      );
+    });
+
+    it("returns null when parent type is not subscription_details", () => {
+      const invoice = {
+        parent: {
+          type: "quote_details",
+          quote_details: {},
+        },
+      } as any;
+
+      expect(
+        CoreStripeService.extractSubscriptionIdFromInvoice(invoice)
+      ).toBeNull();
+    });
+
+    it("returns null when parent is missing", () => {
+      const invoice = {} as any;
+
+      expect(
+        CoreStripeService.extractSubscriptionIdFromInvoice(invoice)
+      ).toBeNull();
+    });
+
+    it("returns null when subscription is null", () => {
+      const invoice = {
+        parent: {
+          type: "subscription_details",
+          subscription_details: {
+            subscription: null,
+          },
+        },
+      } as any;
+
+      expect(
+        CoreStripeService.extractSubscriptionIdFromInvoice(invoice)
+      ).toBeNull();
+    });
+  });
+
+  describe("extractCustomerIdFromSubscription", () => {
+    it("extracts string customer id", () => {
+      const sub = { customer: "cus_abc123" } as any;
+      expect(CoreStripeService.extractCustomerIdFromSubscription(sub)).toBe(
+        "cus_abc123"
+      );
+    });
+
+    it("extracts customer id from object", () => {
+      const sub = { customer: { id: "cus_obj456" } } as any;
+      expect(CoreStripeService.extractCustomerIdFromSubscription(sub)).toBe(
+        "cus_obj456"
+      );
+    });
+
+    it("returns null when customer is null", () => {
+      const sub = { customer: null } as any;
+      expect(
+        CoreStripeService.extractCustomerIdFromSubscription(sub)
+      ).toBeNull();
+    });
+  });
+
+  describe("mapStripeStatusToSubscriptionStatus", () => {
+    it("maps active status", () => {
+      expect(
+        CoreStripeService.mapStripeStatusToSubscriptionStatus("active")
+      ).toBe("ACTIVE");
+    });
+
+    it("maps past_due status", () => {
+      expect(
+        CoreStripeService.mapStripeStatusToSubscriptionStatus("past_due")
+      ).toBe("PAST_DUE");
+    });
+
+    it("maps canceled status", () => {
+      expect(
+        CoreStripeService.mapStripeStatusToSubscriptionStatus("canceled")
+      ).toBe("CANCELED");
+    });
+
+    it("maps cancelled (british spelling)", () => {
+      expect(
+        CoreStripeService.mapStripeStatusToSubscriptionStatus("cancelled")
+      ).toBe("CANCELED");
+    });
+
+    it("maps incomplete status", () => {
+      expect(
+        CoreStripeService.mapStripeStatusToSubscriptionStatus("incomplete")
+      ).toBe("INCOMPLETE");
+    });
+
+    it("maps incomplete_expired status", () => {
+      expect(
+        CoreStripeService.mapStripeStatusToSubscriptionStatus(
+          "incomplete_expired"
+        )
+      ).toBe("INCOMPLETE_EXPIRED");
+    });
+
+    it("defaults to INCOMPLETE for unknown status", () => {
+      expect(
+        CoreStripeService.mapStripeStatusToSubscriptionStatus("unknown_status")
+      ).toBe("INCOMPLETE");
+    });
+  });
+
+  describe("mapStripePlanToUserPlan", () => {
+    // STRIPE_PRICE_IDS is null in tests (no secret key), so only string fallback is tested
+    it("maps price id containing 'developer'", () => {
+      expect(
+        CoreStripeService.mapStripePlanToUserPlan("price_developer_monthly")
+      ).toBe("DEVELOPER");
+    });
+
+    it("maps price id containing 'enterprise'", () => {
+      expect(
+        CoreStripeService.mapStripePlanToUserPlan("price_enterprise_yearly")
+      ).toBe("ENTERPRISE");
+    });
+
+    it("maps price id containing 'free'", () => {
+      expect(CoreStripeService.mapStripePlanToUserPlan("price_free_tier")).toBe(
+        "FREE"
+      );
+    });
+
+    it("returns null for unknown price id", () => {
+      expect(
+        CoreStripeService.mapStripePlanToUserPlan("price_unknown_xyz")
+      ).toBeNull();
+    });
+  });
+
+  describe("mapSubscriptionStatusFromTrial", () => {
+    it("returns TRIALING when trial exists", () => {
+      expect(
+        CoreStripeService.mapSubscriptionStatusFromTrial(1000000, 2000000)
+      ).toBe("TRIALING");
+    });
+
+    it("returns ACTIVE when no trial", () => {
+      expect(CoreStripeService.mapSubscriptionStatusFromTrial(null, null)).toBe(
+        "ACTIVE"
+      );
+    });
+
+    it("returns ACTIVE when trial start is null", () => {
+      expect(
+        CoreStripeService.mapSubscriptionStatusFromTrial(null, 2000000)
+      ).toBe("ACTIVE");
+    });
+  });
+
+  describe("mapStripeBillingIntervalToBillingInterval", () => {
+    it("maps 'yearly' to YEAR", () => {
+      expect(
+        CoreStripeService.mapStripeBillingIntervalToBillingInterval("yearly")
+      ).toBe("YEAR");
+    });
+
+    it("maps 'year' to YEAR", () => {
+      expect(
+        CoreStripeService.mapStripeBillingIntervalToBillingInterval("year")
+      ).toBe("YEAR");
+    });
+
+    it("maps 'monthly' to MONTH", () => {
+      expect(
+        CoreStripeService.mapStripeBillingIntervalToBillingInterval("monthly")
+      ).toBe("MONTH");
+    });
+
+    it("defaults to MONTH for undefined", () => {
+      expect(
+        CoreStripeService.mapStripeBillingIntervalToBillingInterval(undefined)
+      ).toBe("MONTH");
+    });
+  });
+
+  describe("mapInvoiceToFailureReason", () => {
+    it("returns finalization error message when available", () => {
+      const invoice = {
+        last_finalization_error: { message: "Card declined" },
+      } as any;
+      expect(CoreStripeService.mapInvoiceToFailureReason(invoice)).toBe(
+        "Card declined"
+      );
+    });
+
+    it("returns default message when no error details", () => {
+      const invoice = {} as any;
+      expect(CoreStripeService.mapInvoiceToFailureReason(invoice)).toBe(
+        "Payment failed"
+      );
+    });
+  });
+
+  describe("transformPaymentDescription", () => {
+    it("generates description when input is null", () => {
+      expect(
+        CoreStripeService.transformPaymentDescription(
+          null,
+          "DEVELOPER",
+          "MONTH"
+        )
+      ).toBe("Payment for developer plan (monthly)");
+    });
+
+    it("generates yearly description when input is null", () => {
+      expect(
+        CoreStripeService.transformPaymentDescription(
+          null,
+          "ENTERPRISE",
+          "YEAR"
+        )
+      ).toBe("Payment for enterprise plan (yearly)");
+    });
+
+    it("transforms technical description with sub_ id", () => {
+      expect(
+        CoreStripeService.transformPaymentDescription(
+          "Payment for sub_123",
+          "DEVELOPER",
+          "MONTH"
+        )
+      ).toBe("Payment for developer plan (monthly)");
+    });
+
+    it("detects failed in technical description", () => {
+      expect(
+        CoreStripeService.transformPaymentDescription(
+          "Failed payment for sub_456",
+          "ENTERPRISE",
+          "YEAR"
+        )
+      ).toBe("Failed for enterprise plan (yearly)");
+    });
+
+    it("returns user-friendly description as-is", () => {
+      const desc = "Payment for developer plan (monthly)";
+      expect(
+        CoreStripeService.transformPaymentDescription(
+          desc,
+          "DEVELOPER",
+          "MONTH"
+        )
+      ).toBe(desc);
+    });
+
+    it("returns non-technical description as-is", () => {
+      expect(
+        CoreStripeService.transformPaymentDescription(
+          "Custom charge",
+          "DEVELOPER",
+          "MONTH"
+        )
+      ).toBe("Custom charge");
+    });
+  });
+});

--- a/apps/api/src/services/stripe/__tests__/webhook-handlers.test.ts
+++ b/apps/api/src/services/stripe/__tests__/webhook-handlers.test.ts
@@ -1,0 +1,469 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prisma } from "@/core/prisma";
+
+import { EmailService } from "@/services/email/email.service";
+
+import {
+  handleCheckoutSessionCompleted,
+  handleCustomerSubscriptionDeleted,
+  handleCustomerUpdated,
+  handleInvoicePaymentFailed,
+} from "../webhook-handlers";
+
+// --- Mocks ---
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: {
+      update: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    subscription: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    license: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    licenseFileVersion: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/services/license/license.service", () => ({
+  licenseService: {
+    generateLicense: vi.fn(),
+    renewLicense: vi.fn(),
+    generateLicenseFile: vi.fn(),
+    saveLicenseFileVersion: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/license/license-features.service", () => ({
+  getLicenseFeaturesForTier: vi.fn().mockReturnValue(["feature1"]),
+}));
+
+vi.mock("@/services/email/email.service", () => ({
+  EmailService: {
+    sendUpgradeConfirmationEmail: vi.fn().mockResolvedValue(undefined),
+    sendPaymentConfirmationEmail: vi.fn().mockResolvedValue(undefined),
+    sendLicenseCancellationEmail: vi.fn().mockResolvedValue(undefined),
+    sendPaymentFailedEmail: vi.fn().mockResolvedValue(undefined),
+    sendLicensePaymentFailedEmail: vi.fn().mockResolvedValue(undefined),
+    sendLicenseExpiredEmail: vi.fn().mockResolvedValue(undefined),
+    sendLicenseDeliveryEmail: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/services/sentry", () => ({
+  trackPaymentError: vi.fn(),
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/config", () => ({
+  emailConfig: { portalFrontendUrl: "https://portal.test.com" },
+  stripeConfig: {
+    secretKey: null,
+    priceIds: {
+      developer: { monthly: null, yearly: null },
+      enterprise: { monthly: null, yearly: null },
+    },
+  },
+  licenseConfig: { privateKey: null },
+}));
+
+vi.mock("@/core/utils", () => ({
+  getUserDisplayName: vi.fn().mockReturnValue("Test User"),
+}));
+
+// --- Tests ---
+
+describe("handleCheckoutSessionCompleted", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns early when metadata is missing", async () => {
+    await handleCheckoutSessionCompleted({ metadata: {} } as any);
+
+    expect(prisma.user.update).not.toHaveBeenCalled();
+    expect(prisma.subscription.create).not.toHaveBeenCalled();
+  });
+
+  it("creates subscription record for subscription-type checkout", async () => {
+    const session = {
+      metadata: {
+        userId: "user-1",
+        plan: "DEVELOPER",
+        billingInterval: "monthly",
+      },
+      customer: "cus_123",
+      subscription: {
+        id: "sub_new",
+        items: {
+          data: [
+            {
+              price: { id: "price_dev_monthly", unit_amount: 2900 },
+              current_period_start: 1700000000,
+              current_period_end: 1702592000,
+            },
+          ],
+        },
+        trial_start: null,
+        trial_end: null,
+        cancel_at_period_end: false,
+      },
+    } as any;
+
+    vi.mocked(prisma.user.update).mockResolvedValue({} as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-1",
+      email: "user@test.com",
+      firstName: "Test",
+      lastName: "User",
+    } as any);
+    // No existing subscription (not a duplicate)
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.subscription.create).mockResolvedValue({} as any);
+
+    await handleCheckoutSessionCompleted(session);
+
+    // User updated with Stripe IDs
+    expect(prisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: expect.objectContaining({
+          stripeCustomerId: "cus_123",
+          stripeSubscriptionId: "sub_new",
+        }),
+      })
+    );
+
+    // Subscription created
+    expect(prisma.subscription.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user-1",
+          stripeSubscriptionId: "sub_new",
+          plan: "DEVELOPER",
+        }),
+      })
+    );
+
+    // Welcome email sent
+    expect(EmailService.sendUpgradeConfirmationEmail).toHaveBeenCalled();
+  });
+
+  it("skips duplicate when subscription already exists (idempotency)", async () => {
+    const session = {
+      metadata: { userId: "user-1", plan: "DEVELOPER" },
+      customer: "cus_123",
+      subscription: "sub_existing",
+    } as any;
+
+    vi.mocked(prisma.user.update).mockResolvedValue({} as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-1",
+      email: "user@test.com",
+    } as any);
+    // Subscription already exists
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+      id: "existing-sub",
+      stripeSubscriptionId: "sub_existing",
+    } as any);
+
+    await handleCheckoutSessionCompleted(session);
+
+    // Should NOT create a new subscription
+    expect(prisma.subscription.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleCustomerSubscriptionDeleted", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks subscription as canceled and deactivates licenses", async () => {
+    const subscription = {
+      id: "sub_cancel_123",
+      customer: "cus_123",
+    } as any;
+
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 30);
+
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+      id: "db-sub-id",
+      stripeSubscriptionId: "sub_cancel_123",
+      user: { id: "user-1", email: "user@test.com" },
+    } as any);
+    vi.mocked(prisma.subscription.update).mockResolvedValue({} as any);
+    vi.mocked(prisma.license.findMany).mockResolvedValue([
+      {
+        id: "lic-1",
+        licenseKey: "KEY-001",
+        tier: "ENTERPRISE",
+        customerEmail: "user@test.com",
+        expiresAt: futureDate,
+        isActive: true,
+      },
+    ] as any);
+    vi.mocked(prisma.license.updateMany).mockResolvedValue({
+      count: 1,
+    } as any);
+
+    await handleCustomerSubscriptionDeleted(subscription);
+
+    // Subscription marked canceled
+    expect(prisma.subscription.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { stripeSubscriptionId: "sub_cancel_123" },
+        data: { status: "CANCELED" },
+      })
+    );
+
+    // Licenses deactivated
+    expect(prisma.license.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { stripeSubscriptionId: "sub_cancel_123" },
+        data: { isActive: false },
+      })
+    );
+
+    // Cancellation email sent
+    expect(EmailService.sendLicenseCancellationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user@test.com",
+        licenseKey: "KEY-001",
+        tier: "ENTERPRISE",
+      })
+    );
+  });
+
+  it("handles subscription with no licenses (subscription-only plan)", async () => {
+    const subscription = { id: "sub_no_lic", customer: "cus_123" } as any;
+
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+      id: "db-sub-id",
+      stripeSubscriptionId: "sub_no_lic",
+      user: { id: "user-1" },
+    } as any);
+    vi.mocked(prisma.subscription.update).mockResolvedValue({} as any);
+    vi.mocked(prisma.license.findMany).mockResolvedValue([]);
+
+    await handleCustomerSubscriptionDeleted(subscription);
+
+    expect(prisma.subscription.update).toHaveBeenCalled();
+    expect(prisma.license.updateMany).not.toHaveBeenCalled();
+    expect(EmailService.sendLicenseCancellationEmail).not.toHaveBeenCalled();
+  });
+
+  it("handles missing subscription gracefully", async () => {
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue(null);
+
+    await handleCustomerSubscriptionDeleted({
+      id: "sub_nonexistent",
+    } as any);
+
+    expect(prisma.subscription.update).not.toHaveBeenCalled();
+    expect(prisma.license.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleInvoicePaymentFailed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const makeInvoice = (subscriptionId: string) =>
+    ({
+      id: "in_fail_123",
+      parent: {
+        type: "subscription_details",
+        subscription_details: { subscription: subscriptionId },
+      },
+      amount_due: 100000,
+      currency: "usd",
+    }) as any;
+
+  it("sets subscription to PAST_DUE", async () => {
+    const invoice = makeInvoice("sub_pastdue");
+
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+      id: "db-sub",
+      stripeSubscriptionId: "sub_pastdue",
+      currentPeriodEnd: new Date(), // Period just ended
+      user: {
+        id: "user-1",
+        email: "user@test.com",
+        firstName: "Test",
+        lastName: "User",
+      },
+    } as any);
+    vi.mocked(prisma.subscription.update).mockResolvedValue({} as any);
+    vi.mocked(prisma.license.findMany).mockResolvedValue([]);
+
+    await handleInvoicePaymentFailed(invoice);
+
+    expect(prisma.subscription.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { status: "PAST_DUE" },
+      })
+    );
+  });
+
+  it("keeps licenses active during grace period", async () => {
+    const invoice = makeInvoice("sub_grace");
+
+    // Period ended recently — still within 14-day grace period
+    const recentPeriodEnd = new Date();
+    recentPeriodEnd.setDate(recentPeriodEnd.getDate() - 2); // 2 days ago
+
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+      id: "db-sub",
+      stripeSubscriptionId: "sub_grace",
+      currentPeriodEnd: recentPeriodEnd,
+      user: {
+        id: "user-1",
+        email: "user@test.com",
+        firstName: "Test",
+        lastName: "User",
+      },
+    } as any);
+    vi.mocked(prisma.subscription.update).mockResolvedValue({} as any);
+    vi.mocked(prisma.license.findMany).mockResolvedValue([
+      {
+        id: "lic-1",
+        licenseKey: "KEY-001",
+        tier: "ENTERPRISE",
+        isActive: true,
+        expiresAt: new Date("2027-01-01"),
+      },
+    ] as any);
+
+    await handleInvoicePaymentFailed(invoice);
+
+    // Licenses NOT deactivated (still in grace period)
+    expect(prisma.license.updateMany).not.toHaveBeenCalled();
+
+    // Grace period warning email sent
+    expect(EmailService.sendLicensePaymentFailedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isInGracePeriod: true,
+      })
+    );
+  });
+
+  it("deactivates licenses after grace period expires", async () => {
+    const invoice = makeInvoice("sub_expired");
+
+    // Period ended 20 days ago — past 14-day grace period
+    const expiredPeriodEnd = new Date();
+    expiredPeriodEnd.setDate(expiredPeriodEnd.getDate() - 20);
+
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+      id: "db-sub",
+      stripeSubscriptionId: "sub_expired",
+      currentPeriodEnd: expiredPeriodEnd,
+      user: {
+        id: "user-1",
+        email: "user@test.com",
+        firstName: "Test",
+        lastName: "User",
+      },
+    } as any);
+    vi.mocked(prisma.subscription.update).mockResolvedValue({} as any);
+    vi.mocked(prisma.license.findMany).mockResolvedValue([
+      {
+        id: "lic-1",
+        licenseKey: "KEY-001",
+        tier: "ENTERPRISE",
+        isActive: true,
+        expiresAt: new Date("2026-01-01"),
+      },
+    ] as any);
+    vi.mocked(prisma.license.updateMany).mockResolvedValue({
+      count: 1,
+    } as any);
+
+    await handleInvoicePaymentFailed(invoice);
+
+    // Licenses DEACTIVATED (grace period expired)
+    expect(prisma.license.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { isActive: false },
+      })
+    );
+
+    // Expired email sent (not grace period warning)
+    expect(EmailService.sendLicenseExpiredEmail).toHaveBeenCalled();
+    expect(EmailService.sendLicensePaymentFailedEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns early when no subscription ID in invoice", async () => {
+    await handleInvoicePaymentFailed({ id: "in_no_sub" } as any);
+
+    expect(prisma.subscription.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleCustomerUpdated", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("syncs email when Stripe customer email changes", async () => {
+    vi.mocked(prisma.user.findFirst).mockResolvedValue({
+      id: "user-1",
+      email: "old@test.com",
+      stripeCustomerId: "cus_sync",
+    } as any);
+    vi.mocked(prisma.user.update).mockResolvedValue({} as any);
+
+    await handleCustomerUpdated({
+      id: "cus_sync",
+      email: "new@test.com",
+    } as any);
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { email: "new@test.com" },
+    });
+  });
+
+  it("skips update when email has not changed", async () => {
+    vi.mocked(prisma.user.findFirst).mockResolvedValue({
+      id: "user-1",
+      email: "same@test.com",
+      stripeCustomerId: "cus_same",
+    } as any);
+
+    await handleCustomerUpdated({
+      id: "cus_same",
+      email: "same@test.com",
+    } as any);
+
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("handles missing user gracefully", async () => {
+    vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+
+    await handleCustomerUpdated({
+      id: "cus_unknown",
+      email: "ghost@test.com",
+    } as any);
+
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/stripe/__tests__/webhook-processor.test.ts
+++ b/apps/api/src/services/stripe/__tests__/webhook-processor.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { processStripeWebhook } from "../webhook-processor";
+
+// Mock all webhook handlers
+vi.mock("../webhook-handlers", () => ({
+  handleCheckoutSessionCompleted: vi.fn().mockResolvedValue(undefined),
+  handleSubscriptionChange: vi.fn().mockResolvedValue(undefined),
+  handleCustomerSubscriptionDeleted: vi.fn().mockResolvedValue(undefined),
+  handleInvoicePaymentSucceeded: vi.fn().mockResolvedValue(undefined),
+  handleInvoicePaymentFailed: vi.fn().mockResolvedValue(undefined),
+  handleTrialWillEnd: vi.fn().mockResolvedValue(undefined),
+  handlePaymentActionRequired: vi.fn().mockResolvedValue(undefined),
+  handleUpcomingInvoice: vi.fn().mockResolvedValue(undefined),
+  handlePaymentIntentFailed: vi.fn().mockResolvedValue(undefined),
+  handlePaymentIntentSucceeded: vi.fn().mockResolvedValue(undefined),
+  handleCustomerUpdated: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Import handlers after mocking so we get the mocked versions
+const handlers = await import("../webhook-handlers");
+
+function makeEvent(type: string, data: unknown = {}) {
+  return { type, data: { object: data } } as any;
+}
+
+describe("processStripeWebhook", () => {
+  it("routes checkout.session.completed", async () => {
+    const data = { id: "cs_123" };
+    await processStripeWebhook(makeEvent("checkout.session.completed", data));
+    expect(handlers.handleCheckoutSessionCompleted).toHaveBeenCalledWith(data);
+  });
+
+  it("routes customer.subscription.created to handleSubscriptionChange", async () => {
+    const data = { id: "sub_123" };
+    await processStripeWebhook(
+      makeEvent("customer.subscription.created", data)
+    );
+    expect(handlers.handleSubscriptionChange).toHaveBeenCalledWith(data);
+  });
+
+  it("routes customer.subscription.updated to handleSubscriptionChange", async () => {
+    const data = { id: "sub_456" };
+    await processStripeWebhook(
+      makeEvent("customer.subscription.updated", data)
+    );
+    expect(handlers.handleSubscriptionChange).toHaveBeenCalledWith(data);
+  });
+
+  it("routes customer.subscription.deleted", async () => {
+    const data = { id: "sub_del" };
+    await processStripeWebhook(
+      makeEvent("customer.subscription.deleted", data)
+    );
+    expect(handlers.handleCustomerSubscriptionDeleted).toHaveBeenCalledWith(
+      data
+    );
+  });
+
+  it("routes invoice.payment_succeeded", async () => {
+    const data = { id: "in_success" };
+    await processStripeWebhook(makeEvent("invoice.payment_succeeded", data));
+    expect(handlers.handleInvoicePaymentSucceeded).toHaveBeenCalledWith(data);
+  });
+
+  it("routes invoice.payment_failed", async () => {
+    const data = { id: "in_fail" };
+    await processStripeWebhook(makeEvent("invoice.payment_failed", data));
+    expect(handlers.handleInvoicePaymentFailed).toHaveBeenCalledWith(data);
+  });
+
+  it("routes customer.updated", async () => {
+    const data = { id: "cus_123" };
+    await processStripeWebhook(makeEvent("customer.updated", data));
+    expect(handlers.handleCustomerUpdated).toHaveBeenCalledWith(data);
+  });
+
+  it("does not throw for unknown event types", async () => {
+    await expect(
+      processStripeWebhook(makeEvent("unknown.event.type"))
+    ).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Add **57 new tests** across 3 new test files for the Stripe service layer (previously only 2 tests)
- Fix the 2 existing failing tests in `webhook-idempotency.test.ts` (supersedes #119)

### New test files

| File | Tests | Covers |
|------|-------|--------|
| `core-service.test.ts` | 34 | `extractSubscriptionIdFromInvoice`, `extractCustomerIdFromSubscription`, `mapStripeStatusToSubscriptionStatus`, `mapStripePlanToUserPlan`, `mapSubscriptionStatusFromTrial`, `mapStripeBillingIntervalToBillingInterval`, `mapInvoiceToFailureReason`, `transformPaymentDescription` |
| `webhook-handlers.test.ts` | 13 | `handleCheckoutSessionCompleted` (subscription creation, idempotency, missing metadata), `handleCustomerSubscriptionDeleted` (cancellation + license deactivation), `handleInvoicePaymentFailed` (PAST_DUE, grace period active vs expired), `handleCustomerUpdated` (email sync) |
| `webhook-processor.test.ts` | 8 | Event routing for all critical webhook types + unknown event handling |

### Existing test fix
- Update mock invoices in `webhook-idempotency.test.ts` to use Stripe v20 `parent.subscription_details` format
- Add missing mocks for `licenseService`, `EmailService`, `config`, `logger`, `sentry`
- Update assertions to verify `licenseService` calls instead of raw prisma calls

## Test plan
- [x] `pnpm --filter=qarote-api run test:run` — 146 tests pass (8 files, 0 failures)
- [x] Type-check passes
- [x] Pre-push hooks pass (syncpack, type-check, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)