### PR TITLE
fix: allow prisma generate to run without a database url at build time

### DIFF
--- a/apps/api/prisma.config.ts
+++ b/apps/api/prisma.config.ts
@@ -1,16 +1,16 @@
 import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL environment variable is required");
-}
-
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
   },
-  datasource: {
-    url: process.env.DATABASE_URL,
-  },
+  // Omitted when DATABASE_URL is absent (e.g. during `prisma generate` at build time).
+  // Migrations and runtime always have the real URL available.
+  ...(process.env.DATABASE_URL && {
+    datasource: {
+      url: process.env.DATABASE_URL,
+    },
+  }),
 });


### PR DESCRIPTION
prisma generate does not open a database connection so it does not need a URL. Making datasource conditional lets the Dokku build (and any other build environment) run the postinstall script without DATABASE_URL being set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed startup-time errors that occurred when database configuration was unavailable, enabling graceful handling of missing environment variables.

* **Improvements**
  * Database configuration is now optional during build-time operations and development phases, improving flexibility for development workflows, CI/CD pipelines, and build processes that don't require an active database connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->