### PR TITLE
feat: replace client polling with trpc sse subscriptions

### DIFF
--- a/apps/api/src/core/utils.ts
+++ b/apps/api/src/core/utils.ts
@@ -28,6 +28,24 @@ export function getUserDisplayName(user: {
 }
 
 /**
+ * Sleep for a given number of milliseconds, resolving early if the signal is aborted.
+ * Use in subscription loops to avoid blocking clean shutdown.
+ */
+export function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(t);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+}
+
+/**
  * Format invitedBy user for API response
  * Returns null if the user is null, otherwise returns formatted object
  */

--- a/apps/api/src/core/utils.ts
+++ b/apps/api/src/core/utils.ts
@@ -32,6 +32,7 @@ export function getUserDisplayName(user: {
  * Use in subscription loops to avoid blocking clean shutdown.
  */
 export function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
   return new Promise((resolve) => {
     const t = setTimeout(resolve, ms);
     signal.addEventListener(

--- a/apps/api/src/core/utils.ts
+++ b/apps/api/src/core/utils.ts
@@ -34,15 +34,15 @@ export function getUserDisplayName(user: {
 export function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
   if (signal.aborted) return Promise.resolve();
   return new Promise((resolve) => {
-    const t = setTimeout(resolve, ms);
-    signal.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(t);
-        resolve();
-      },
-      { once: true }
-    );
+    const onAbort = () => {
+      clearTimeout(t);
+      resolve();
+    };
+    const t = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
   });
 }
 

--- a/apps/api/src/trpc/routers/rabbitmq/alerts.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/alerts.ts
@@ -539,6 +539,16 @@ export const alertsRouter = router({
 
       const vhost = vhostParam ? decodeURIComponent(vhostParam) : "/";
       const sig = signal ?? new AbortController().signal;
+      let lastPayload:
+        | {
+            success: boolean;
+            alerts: unknown[];
+            summary: unknown;
+            thresholds: unknown;
+            total: number;
+            timestamp: string;
+          }
+        | undefined;
 
       while (!sig.aborted) {
         try {
@@ -553,7 +563,7 @@ export const alertsRouter = router({
             await alertService.getWorkspaceThresholds(workspaceId);
 
           if (userPlan === UserPlan.FREE) {
-            yield {
+            lastPayload = {
               success: true,
               alerts: [],
               summary,
@@ -567,7 +577,7 @@ export const alertsRouter = router({
               query
             );
 
-            yield {
+            lastPayload = {
               success: true,
               alerts: paginatedAlerts,
               summary,
@@ -576,8 +586,12 @@ export const alertsRouter = router({
               timestamp: new Date().toISOString(),
             };
           }
+          yield lastPayload;
         } catch (err) {
           ctx.logger.warn({ err, serverId }, "watchAlerts fetch error");
+          if (lastPayload) {
+            yield { ...lastPayload, stale: true };
+          }
         }
 
         await abortableSleep(10000, sig);

--- a/apps/api/src/trpc/routers/rabbitmq/alerts.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/alerts.ts
@@ -538,7 +538,13 @@ export const alertsRouter = router({
       }
 
       const vhost = vhostParam ? decodeURIComponent(vhostParam) : "/";
-      const sig = signal ?? new AbortController().signal;
+      if (!signal) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Subscription requires an abort signal",
+        });
+      }
+      const sig = signal;
       let lastPayload:
         | {
             success: boolean;

--- a/apps/api/src/trpc/routers/rabbitmq/metrics.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/metrics.ts
@@ -308,7 +308,13 @@ export const metricsRouter = router({
         });
       }
 
-      const sig = signal ?? new AbortController().signal;
+      if (!signal) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Subscription requires an abort signal",
+        });
+      }
+      const sig = signal;
       type MappedOverview = ReturnType<typeof OverviewMapper.toApiResponse>;
       type MappedNodes = ReturnType<typeof NodeMapper.toApiResponseArray>;
       let lastMappedOverview: MappedOverview | undefined;
@@ -390,7 +396,13 @@ export const metricsRouter = router({
         });
       }
 
-      const sig = signal ?? new AbortController().signal;
+      if (!signal) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Subscription requires an abort signal",
+        });
+      }
+      const sig = signal;
       let lastRatesPayload:
         | {
             messagesRates: ReturnType<

--- a/apps/api/src/trpc/routers/rabbitmq/queues.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/queues.ts
@@ -756,7 +756,7 @@ export const queuesRouter = router({
     }),
 
   /**
-   * Live queue stream — SSE subscription replacing 5s polling (ALL USERS)
+   * Live queue stream — SSE subscription replacing client polling (ALL USERS)
    * Fetches queues from RabbitMQ every 4s and pushes updates to the client.
    */
   watchQueues: workspaceProcedure
@@ -775,6 +775,9 @@ export const queuesRouter = router({
 
       const vhost = vhostParam ? decodeURIComponent(vhostParam) : undefined;
       const sig = signal ?? new AbortController().signal;
+      let lastPayload:
+        | Awaited<ReturnType<typeof buildQueuesResponse>>
+        | undefined;
 
       while (!sig.aborted) {
         try {
@@ -793,9 +796,17 @@ export const queuesRouter = router({
 
           await persistQueueData(queues, serverId);
 
-          yield await buildQueuesResponse(queues, freshServer, ctx.user.id);
+          lastPayload = await buildQueuesResponse(
+            queues,
+            freshServer,
+            ctx.user.id
+          );
+          yield lastPayload;
         } catch (err) {
           ctx.logger.warn({ err, serverId }, "watchQueues fetch error");
+          if (lastPayload) {
+            yield { ...lastPayload, stale: true };
+          }
         }
 
         await abortableSleep(4000, sig);

--- a/apps/api/src/trpc/routers/rabbitmq/queues.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/queues.ts
@@ -62,18 +62,22 @@ async function persistQueueData(
       serverId,
     };
 
-    const existingQueue = await prisma.queue.findFirst({
-      where: { name: queue.name, vhost: queue.vhost, serverId },
-    });
+    await prisma.$transaction(async (tx) => {
+      const upsertedQueue = await tx.queue.upsert({
+        where: {
+          name_vhost_serverId: {
+            name: queue.name,
+            vhost: queue.vhost,
+            serverId,
+          },
+        },
+        update: queueData,
+        create: queueData,
+      });
 
-    if (existingQueue) {
-      await prisma.queue.update({
-        where: { id: existingQueue.id },
-        data: queueData,
-      });
-      await prisma.queueMetric.create({
+      await tx.queueMetric.create({
         data: {
-          queueId: existingQueue.id,
+          queueId: upsertedQueue.id,
           messages: queue.messages || 0,
           messagesReady: queue.messages_ready || 0,
           messagesUnack: queue.messages_unacknowledged || 0,
@@ -81,19 +85,7 @@ async function persistQueueData(
           consumeRate: queue.message_stats?.deliver_details?.rate || 0,
         },
       });
-    } else {
-      const newQueue = await prisma.queue.create({ data: queueData });
-      await prisma.queueMetric.create({
-        data: {
-          queueId: newQueue.id,
-          messages: queue.messages || 0,
-          messagesReady: queue.messages_ready || 0,
-          messagesUnack: queue.messages_unacknowledged || 0,
-          publishRate: queue.message_stats?.publish_details?.rate || 0,
-          consumeRate: queue.message_stats?.deliver_details?.rate || 0,
-        },
-      });
-    }
+    });
   }
 }
 

--- a/apps/api/src/trpc/routers/rabbitmq/queues.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/queues.ts
@@ -51,18 +51,18 @@ async function persistQueueData(
   queues: RawQueue[],
   serverId: string
 ): Promise<void> {
-  for (const queue of queues) {
-    const queueData = {
-      name: queue.name,
-      vhost: queue.vhost,
-      messages: queue.messages || 0,
-      messagesReady: queue.messages_ready || 0,
-      messagesUnack: queue.messages_unacknowledged || 0,
-      lastFetched: new Date(),
-      serverId,
-    };
+  await prisma.$transaction(async (tx) => {
+    for (const queue of queues) {
+      const queueData = {
+        name: queue.name,
+        vhost: queue.vhost,
+        messages: queue.messages || 0,
+        messagesReady: queue.messages_ready || 0,
+        messagesUnack: queue.messages_unacknowledged || 0,
+        lastFetched: new Date(),
+        serverId,
+      };
 
-    await prisma.$transaction(async (tx) => {
       const upsertedQueue = await tx.queue.upsert({
         where: {
           name_vhost_serverId: {
@@ -85,8 +85,8 @@ async function persistQueueData(
           consumeRate: queue.message_stats?.deliver_details?.rate || 0,
         },
       });
-    });
-  }
+    }
+  });
 }
 
 /**
@@ -99,6 +99,7 @@ async function buildQueuesResponse(
   userId: string
 ): Promise<{
   queues: ReturnType<typeof QueueMapper.toApiResponseArray>;
+  stale?: boolean;
   warning?: {
     isOverLimit: boolean;
     message: string;
@@ -766,7 +767,13 @@ export const queuesRouter = router({
       }
 
       const vhost = vhostParam ? decodeURIComponent(vhostParam) : undefined;
-      const sig = signal ?? new AbortController().signal;
+      if (!signal) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Subscription requires an abort signal",
+        });
+      }
+      const sig = signal;
       let lastPayload:
         | Awaited<ReturnType<typeof buildQueuesResponse>>
         | undefined;

--- a/apps/app/src/hooks/queries/useAlerts.ts
+++ b/apps/app/src/hooks/queries/useAlerts.ts
@@ -1,15 +1,9 @@
 import { useState } from "react";
 
 import { trpc } from "@/lib/trpc/client";
+import { SubData } from "@/lib/trpc/types";
 
 import { useWorkspace } from "../ui/useWorkspace";
-
-/** Extract the data type yielded by a tRPC subscription hook. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SubData<T extends { useSubscription: (input: any, opts: any) => void }> =
-  Parameters<T["useSubscription"]>[1] extends { onData?: (d: infer D) => void }
-    ? D
-    : never;
 
 /**
  * Alert-related hooks
@@ -100,7 +94,10 @@ export const useRabbitMQAlerts = (
     },
     {
       enabled,
-      onData: setData,
+      onData: (d) => {
+        setError(null);
+        setData(d);
+      },
       onError: setError,
     }
   );

--- a/apps/app/src/hooks/queries/useAlerts.ts
+++ b/apps/app/src/hooks/queries/useAlerts.ts
@@ -70,11 +70,16 @@ export const useRabbitMQAlerts = (
     category?: string;
     resolved?: boolean;
     enabled?: boolean;
-  }
+  },
+  serverExists: boolean = true
 ) => {
   const { workspace } = useWorkspace();
   const enabled =
-    (options?.enabled ?? true) && !!serverId && !!workspace?.id && !!vhost;
+    serverExists &&
+    (options?.enabled ?? true) &&
+    !!serverId &&
+    !!workspace?.id &&
+    !!vhost;
 
   const [data, setData] = useState<
     SubData<typeof trpc.rabbitmq.alerts.watchAlerts> | undefined

--- a/apps/app/src/hooks/queries/useRabbitMQ.ts
+++ b/apps/app/src/hooks/queries/useRabbitMQ.ts
@@ -1,17 +1,11 @@
 import { useState } from "react";
 
 import { trpc } from "@/lib/trpc/client";
+import { SubData } from "@/lib/trpc/types";
 
 import { TimeRange } from "@/components/TimeRangeSelector";
 
 import { useWorkspace } from "../ui/useWorkspace";
-
-/** Extract the data type yielded by a tRPC subscription hook. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SubData<T extends { useSubscription: (input: any, opts: any) => void }> =
-  Parameters<T["useSubscription"]>[1] extends { onData?: (d: infer D) => void }
-    ? D
-    : never;
 
 /**
  * RabbitMQ data hooks
@@ -53,7 +47,10 @@ export const useQueues = (serverId: string | null, vhost?: string | null) => {
     },
     {
       enabled,
-      onData: setData,
+      onData: (d) => {
+        setError(null);
+        setData(d);
+      },
       onError: setError,
     }
   );
@@ -119,7 +116,10 @@ export const useMetrics = (serverId: string | null) => {
     },
     {
       enabled,
-      onData: setData,
+      onData: (d) => {
+        setError(null);
+        setData(d);
+      },
       onError: setError,
     }
   );
@@ -288,7 +288,10 @@ export const useLiveRatesMetrics = (
     },
     {
       enabled,
-      onData: setData,
+      onData: (d) => {
+        setError(null);
+        setData(d);
+      },
       onError: setError,
     }
   );

--- a/apps/app/src/hooks/queries/useRabbitMQ.ts
+++ b/apps/app/src/hooks/queries/useRabbitMQ.ts
@@ -30,9 +30,13 @@ export const useOverview = (serverId: string | null) => {
   return query;
 };
 
-export const useQueues = (serverId: string | null, vhost?: string | null) => {
+export const useQueues = (
+  serverId: string | null,
+  vhost?: string | null,
+  serverExists: boolean = true
+) => {
   const { workspace } = useWorkspace();
-  const enabled = !!serverId && !!workspace?.id;
+  const enabled = serverExists && !!serverId && !!workspace?.id;
 
   const [data, setData] = useState<
     SubData<typeof trpc.rabbitmq.queues.watchQueues> | undefined
@@ -100,9 +104,12 @@ export const useQueue = (
   return query;
 };
 
-export const useMetrics = (serverId: string | null) => {
+export const useMetrics = (
+  serverId: string | null,
+  serverExists: boolean = true
+) => {
   const { workspace } = useWorkspace();
-  const enabled = !!serverId && !!workspace?.id;
+  const enabled = serverExists && !!serverId && !!workspace?.id;
 
   const [data, setData] = useState<
     SubData<typeof trpc.rabbitmq.metrics.watchMetrics> | undefined
@@ -270,10 +277,11 @@ export const useQueueBindings = (
 
 export const useLiveRatesMetrics = (
   serverId: string | null,
-  timeRange: TimeRange = "1d"
+  timeRange: TimeRange = "1d",
+  serverExists: boolean = true
 ) => {
   const { workspace } = useWorkspace();
-  const enabled = !!serverId && !!workspace?.id;
+  const enabled = serverExists && !!serverId && !!workspace?.id;
 
   const [data, setData] = useState<
     SubData<typeof trpc.rabbitmq.metrics.watchRates> | undefined

--- a/apps/app/src/lib/trpc/types.ts
+++ b/apps/app/src/lib/trpc/types.ts
@@ -1,0 +1,9 @@
+/** Extract the data type yielded by a tRPC subscription hook. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SubData<
+  T extends { useSubscription: (input: any, opts: any) => void },
+> = Parameters<T["useSubscription"]>[1] extends {
+  onData?: (d: infer D) => void;
+}
+  ? D
+  : never;


### PR DESCRIPTION
add watchQueues (4s), watchMetrics (10s), watchRates (4s), and watchAlerts (10s) subscription procedures to the API. replace the corresponding useQuery + refetchInterval hooks on the frontend with useSubscription via httpSubscriptionLink + splitLink. server-side polling loops reduce N-client poll-interval RabbitMQ API calls to a single loop per active subscription.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live streaming: real-time updates for alerts, system metrics, message rates, and queues with configurable polling and improved subscription routing.
  * Queues: live updates with persistence, over-limit warnings and upgrade recommendations.

* **Bug Fixes / Reliability**
  * More resilient streaming with abortable polling, improved permission handling, and stale-data fallbacks.

* **UX**
  * Hooks now return explicit {data, error, isLoading, isError}; subscription typings improved for safer data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->