### PR TITLE
style: add cursor pointer to all buttons and links

### DIFF
--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -285,7 +285,7 @@
   }
 
   a:not([aria-disabled="true"]),
-  button:not(:disabled):not([aria-disabled="true"]),
+  button:not(:disabled, [aria-disabled="true"]),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -285,13 +285,14 @@
   }
 
   a:not([aria-disabled="true"]),
-  button:not(:disabled),
+  button:not(:disabled):not([aria-disabled="true"]),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }
 
   a[aria-disabled="true"],
   button:disabled,
+  button[aria-disabled="true"],
   [role="button"][aria-disabled="true"] {
     cursor: not-allowed;
   }

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -283,4 +283,10 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  a,
+  button,
+  [role="button"] {
+    cursor: pointer;
+  }
 }

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -284,12 +284,13 @@
     @apply bg-background text-foreground;
   }
 
-  a,
+  a:not([aria-disabled="true"]),
   button:not(:disabled),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }
 
+  a[aria-disabled="true"],
   button:disabled,
   [role="button"][aria-disabled="true"] {
     cursor: not-allowed;

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -285,8 +285,13 @@
   }
 
   a,
-  button,
-  [role="button"] {
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
+  }
+
+  button:disabled,
+  [role="button"][aria-disabled="true"] {
+    cursor: not-allowed;
   }
 }

--- a/apps/portal/src/styles/index.css
+++ b/apps/portal/src/styles/index.css
@@ -357,13 +357,14 @@
   }
 
   a:not([aria-disabled="true"]),
-  button:not(:disabled),
+  button:not(:disabled):not([aria-disabled="true"]),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }
 
   a[aria-disabled="true"],
   button:disabled,
+  button[aria-disabled="true"],
   [role="button"][aria-disabled="true"] {
     cursor: not-allowed;
   }

--- a/apps/portal/src/styles/index.css
+++ b/apps/portal/src/styles/index.css
@@ -357,7 +357,7 @@
   }
 
   a:not([aria-disabled="true"]),
-  button:not(:disabled):not([aria-disabled="true"]),
+  button:not(:disabled, [aria-disabled="true"]),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }

--- a/apps/portal/src/styles/index.css
+++ b/apps/portal/src/styles/index.css
@@ -356,12 +356,13 @@
     @apply bg-background text-foreground;
   }
 
-  a,
+  a:not([aria-disabled="true"]),
   button:not(:disabled),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }
 
+  a[aria-disabled="true"],
   button:disabled,
   [role="button"][aria-disabled="true"] {
     cursor: not-allowed;

--- a/apps/portal/src/styles/index.css
+++ b/apps/portal/src/styles/index.css
@@ -355,4 +355,10 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  a,
+  button,
+  [role="button"] {
+    cursor: pointer;
+  }
 }

--- a/apps/portal/src/styles/index.css
+++ b/apps/portal/src/styles/index.css
@@ -357,8 +357,13 @@
   }
 
   a,
-  button,
-  [role="button"] {
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
+  }
+
+  button:disabled,
+  [role="button"][aria-disabled="true"] {
+    cursor: not-allowed;
   }
 }

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -325,13 +325,14 @@
   }
 
   a:not([aria-disabled="true"]),
-  button:not(:disabled),
+  button:not(:disabled):not([aria-disabled="true"]),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }
 
   a[aria-disabled="true"],
   button:disabled,
+  button[aria-disabled="true"],
   [role="button"][aria-disabled="true"] {
     cursor: not-allowed;
   }

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -325,7 +325,7 @@
   }
 
   a:not([aria-disabled="true"]),
-  button:not(:disabled):not([aria-disabled="true"]),
+  button:not(:disabled, [aria-disabled="true"]),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -325,8 +325,13 @@
   }
 
   a,
-  button,
-  [role="button"] {
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
+  }
+
+  button:disabled,
+  [role="button"][aria-disabled="true"] {
+    cursor: not-allowed;
   }
 }

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -324,12 +324,13 @@
     @apply bg-background text-foreground;
   }
 
-  a,
+  a:not([aria-disabled="true"]),
   button:not(:disabled),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }
 
+  a[aria-disabled="true"],
   button:disabled,
   [role="button"][aria-disabled="true"] {
     cursor: not-allowed;

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -323,4 +323,10 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  a,
+  button,
+  [role="button"] {
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
## Summary
- Add a global CSS base rule (`cursor: pointer`) for `a`, `button`, and `[role="button"]` elements across all three apps (`web`, `app`, `portal`)
- Ensures the hand cursor appears on hover for every interactive element without needing per-component `cursor-pointer` classes

## Test plan
- [ ] Hover over buttons and links in `apps/web` (landing page CTAs, nav links, pricing buttons)
- [ ] Hover over buttons and links in `apps/app` (Add Server, sidebar nav, etc.)
- [ ] Hover over buttons and links in `apps/portal` (license management, billing)
- [ ] Verify hand cursor appears consistently on all interactive elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Interactive elements across web, app, and portal now show a pointer cursor when actionable to improve affordance and clarity.
  * Disabled or aria-disabled controls now display a not-allowed cursor to better indicate unavailable actions and reduce confusion.
  * Presentation-only change; no runtime or behavior logic altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->