### PR TITLE
feat(api): auto-migrate database on binary startup

### DIFF
--- a/.env.selfhosted.example
+++ b/.env.selfhosted.example
@@ -3,6 +3,11 @@
 # Or copy manually: cp .env.selfhosted.example .env
 
 # =============================================================================
+# REQUIRED - Environment
+# =============================================================================
+NODE_ENV=production
+
+# =============================================================================
 # REQUIRED - Deployment Mode
 # =============================================================================
 # Set to 'community' for open-source edition or 'enterprise' for licensed edition

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -67,6 +67,10 @@ jobs:
           mkdir -p dist-package/qarote
           cp qarote-${{ matrix.platform }} dist-package/qarote/qarote
           cp -r apps/api/dist/public dist-package/qarote/public
+
+          # Include Prisma migration files for auto-migration on first start
+          ./scripts/copy-migrations.sh dist-package/qarote/migrations
+
           tar czf qarote-${{ matrix.platform }}.tar.gz -C dist-package qarote
           rm -rf dist-package
 

--- a/apps/api/src/core/migrate.ts
+++ b/apps/api/src/core/migrate.ts
@@ -1,0 +1,152 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { logger } from "./logger";
+import { getDirname } from "./utils";
+
+/**
+ * Lightweight migration runner for binary/standalone deployments.
+ *
+ * Reads SQL files from a `migrations/` directory (shipped alongside the binary)
+ * and applies them in order, tracking state in the same `_prisma_migrations`
+ * table that `prisma migrate deploy` uses.  This means a database bootstrapped
+ * by the binary is fully compatible with future Prisma CLI migrations.
+ *
+ * Uses `pg` directly because Prisma's `$executeRawUnsafe` only handles
+ * single-statement SQL, while migration files contain multiple statements.
+ */
+export async function runMigrations(databaseUrl: string): Promise<void> {
+  // Locate the migrations/ directory.
+  // Resolution order mirrors the public/ directory lookup in server.ts:
+  //   1. Next to the script (node dist/server.js → dist/migrations/)
+  //   2. Next to the binary (compiled Bun binary → <binary-dir>/migrations/)
+  //   3. Current working directory (./migrations/)
+  const candidates = [
+    path.resolve(getDirname(import.meta.url), "migrations"),
+    path.resolve(path.dirname(process.execPath), "migrations"),
+    path.resolve(process.cwd(), "migrations"),
+  ];
+  const migrationsDir = candidates.find(
+    (dir) => fs.existsSync(dir) && fs.statSync(dir).isDirectory()
+  );
+
+  if (!migrationsDir) {
+    logger.debug("No migrations/ directory found — skipping auto-migration");
+    return;
+  }
+
+  // Import pg (already a project dependency via @prisma/adapter-pg)
+  const pg = await import("pg");
+  const Pool = pg.default?.Pool || pg.Pool;
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  try {
+    // Acquire an advisory lock to prevent concurrent migration runs
+    const lockClient = await pool.connect();
+    try {
+      await lockClient.query(
+        "SELECT pg_advisory_lock(hashtext('qarote_migrations'))"
+      );
+
+      // Ensure the Prisma migration-tracking table exists
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS "_prisma_migrations" (
+          "id"                  VARCHAR(36)  NOT NULL PRIMARY KEY,
+          "checksum"            VARCHAR(64)  NOT NULL,
+          "finished_at"         TIMESTAMPTZ,
+          "migration_name"      VARCHAR(255) NOT NULL,
+          "logs"                TEXT,
+          "rolled_back_at"      TIMESTAMPTZ,
+          "started_at"          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+          "applied_steps_count" INTEGER      NOT NULL DEFAULT 0
+        );
+      `);
+
+      // Load already-applied migrations
+      const { rows: applied } = await pool.query<{ migration_name: string }>(
+        `SELECT "migration_name" FROM "_prisma_migrations"
+         WHERE "rolled_back_at" IS NULL
+         ORDER BY "migration_name"`
+      );
+      const appliedSet = new Set(applied.map((r) => r.migration_name));
+
+      // Discover migration directories (sorted lexicographically = chronological)
+      const entries = fs
+        .readdirSync(migrationsDir)
+        .filter((e) => {
+          const full = path.join(migrationsDir, e);
+          return fs.statSync(full).isDirectory();
+        })
+        .sort();
+
+      let appliedCount = 0;
+
+      for (const entry of entries) {
+        if (appliedSet.has(entry)) continue;
+
+        const sqlPath = path.join(migrationsDir, entry, "migration.sql");
+        if (!fs.existsSync(sqlPath)) continue;
+
+        const sql = fs.readFileSync(sqlPath, "utf-8");
+        const checksum = createHash("sha256").update(sql).digest("hex");
+
+        logger.info(`Applying migration: ${entry}`);
+
+        // Some DDL cannot run inside a transaction (e.g. CREATE INDEX CONCURRENTLY,
+        // ALTER TYPE ... ADD VALUE). Detect these and skip BEGIN/COMMIT for them.
+        const nonTransactional =
+          /CREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY|ALTER\s+TYPE\s+\S+\s+ADD\s+VALUE|VACUUM|CLUSTER|REINDEX/i.test(
+            sql
+          );
+
+        const client = await pool.connect();
+        try {
+          if (nonTransactional) {
+            await client.query(sql);
+            await client.query(
+              `INSERT INTO "_prisma_migrations"
+                 ("id", "checksum", "migration_name", "finished_at", "applied_steps_count")
+               VALUES ($1, $2, $3, now(), 1)`,
+              [randomUUID(), checksum, entry]
+            );
+          } else {
+            await client.query("BEGIN");
+            await client.query(sql);
+            await client.query(
+              `INSERT INTO "_prisma_migrations"
+                 ("id", "checksum", "migration_name", "finished_at", "applied_steps_count")
+               VALUES ($1, $2, $3, now(), 1)`,
+              [randomUUID(), checksum, entry]
+            );
+            await client.query("COMMIT");
+          }
+          appliedCount++;
+        } catch (err) {
+          if (!nonTransactional) {
+            await client.query("ROLLBACK").catch(() => {});
+          }
+          throw new Error(
+            `Migration ${entry} failed: ${err instanceof Error ? err.message : String(err)}`,
+            { cause: err }
+          );
+        } finally {
+          client.release();
+        }
+      }
+
+      if (appliedCount > 0) {
+        logger.info(`Applied ${appliedCount} migration(s) successfully`);
+      } else {
+        logger.debug("Database schema is up to date");
+      }
+    } finally {
+      await lockClient
+        .query("SELECT pg_advisory_unlock(hashtext('qarote_migrations'))")
+        .catch(() => {});
+      lockClient.release();
+    }
+  } finally {
+    await pool.end();
+  }
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -10,6 +10,7 @@ import { prettyJSON } from "hono/pretty-json";
 import { secureHeaders } from "hono/secure-headers";
 
 import { logger } from "@/core/logger";
+import { runMigrations } from "@/core/migrate";
 import { prisma } from "@/core/prisma";
 import { getDirname } from "@/core/utils";
 
@@ -21,9 +22,8 @@ import {
   requestIdMiddleware,
 } from "@/middlewares/request";
 
-import { serverConfig, ssoConfig } from "@/config";
-import { isCloudMode } from "@/config/deployment";
-import { validateDeploymentMode } from "@/config/deployment";
+import { config, serverConfig, ssoConfig } from "@/config";
+import { isCloudMode, validateDeploymentMode } from "@/config/deployment";
 
 import { createContext } from "@/trpc/context";
 import { appRouter } from "@/trpc/router";
@@ -138,12 +138,19 @@ if (!isCloudMode() && publicDir) {
 const { port, host } = serverConfig;
 
 async function startServer() {
+  let dbConnected = false;
   try {
     // Validate deployment mode and required services
     validateDeploymentMode();
     logger.info("Deployment mode validation passed");
 
+    // Apply pending database migrations if a migrations/ directory exists.
+    // Only the binary tarball ships this directory — Docker/Dokku/cloud
+    // deployments use `prisma migrate deploy` via their own scripts instead.
+    await runMigrations(config.DATABASE_URL);
+
     await prisma.$connect();
+    dbConnected = true;
     logger.info("Connected to database");
 
     // Initialize SSO service if enabled
@@ -162,8 +169,10 @@ async function startServer() {
       }
     );
   } catch (error) {
-    logger.error(error, "Failed to start server");
-    await prisma.$disconnect();
+    logger.error({ error }, "Failed to start server");
+    if (dbConnected) {
+      await prisma.$disconnect();
+    }
     process.exit(1);
   }
 }

--- a/apps/portal/src/components/documentation/InstallationGuideSection.tsx
+++ b/apps/portal/src/components/documentation/InstallationGuideSection.tsx
@@ -600,6 +600,7 @@ cd qarote`}
                 <h5 className="text-sm font-medium">3. Start Qarote</h5>
                 <CodeBlock
                   code={`# Start the server (reads .env automatically)
+# Database migrations run automatically on first start
 ./qarote`}
                   language="bash"
                 />
@@ -1177,14 +1178,16 @@ sudo cp -r apps/app/dist/* /var/www/qarote/`}
 
             <TabsContent value="update-binary" className="mt-4">
               <CodeBlock
-                code={`# Download and extract the latest release
-curl -L https://github.com/getqarote/Qarote/releases/latest/download/qarote-linux-x64.tar.gz | tar xz
-
-# Stop the running instance, swap binary and assets, restart
-# (your .env file is preserved — no reconfiguration needed)
+                code={`# Stop the running instance
 kill $(pgrep -f './qarote') 2>/dev/null || true
-cp qarote/qarote ./qarote-bin && cp -r qarote/public ./public
-mv qarote-bin qarote
+
+# Download and extract in-place (overwrites binary, public/, migrations/)
+# Replace linux-x64 with: linux-arm64, darwin-x64, or darwin-arm64
+curl -L https://github.com/getqarote/Qarote/releases/latest/download/qarote-linux-x64.tar.gz \\
+  | tar xz --strip-components=1
+
+# Restart — new migrations are applied automatically on startup
+# (your .env file is preserved — no reconfiguration needed)
 ./qarote`}
                 language="bash"
               />

--- a/apps/portal/src/constants/documentation.constants.ts
+++ b/apps/portal/src/constants/documentation.constants.ts
@@ -93,6 +93,11 @@ export const envExampleContent = `# Qarote Self-Hosted Deployment
 # Set DEPLOYMENT_MODE=enterprise for Enterprise Edition (licensed)
 
 # =============================================================================
+# REQUIRED - Environment
+# =============================================================================
+NODE_ENV=production
+
+# =============================================================================
 # REQUIRED - Deployment Mode
 # =============================================================================
 # Set to 'community' for open-source edition or 'enterprise' for licensed edition

--- a/docs/SELF_HOSTED_DEPLOYMENT.md
+++ b/docs/SELF_HOSTED_DEPLOYMENT.md
@@ -252,7 +252,7 @@ The `setup` command will:
 3. Generate secure secrets (`JWT_SECRET`, `ENCRYPTION_KEY`)
 4. Write a `.env` file in the current directory
 
-The binary serves both the API and frontend on a single port (default: 3000).
+The binary serves both the API and frontend on a single port (default: 3000). Database migrations run automatically on startup — no manual migration step needed. The `migrations/` directory must remain alongside the binary; do not move only the `qarote` executable to another location (e.g. `/usr/local/bin`), or automatic migrations will not run.
 
 ### CLI Flags
 
@@ -276,17 +276,21 @@ The binary uses the **same environment variables** as Docker Compose and other d
 ### Updating
 
 ```bash
-# Download the latest release
-curl -L https://github.com/getqarote/Qarote/releases/latest/download/qarote-linux-x64.tar.gz | tar xz
-
-# Stop the running instance, swap, and restart
+# Stop the running instance
 kill $(pgrep -f './qarote') 2>/dev/null || true
-cp qarote/qarote ./qarote-bin && cp qarote/public ./public -r
-mv qarote-bin qarote
+
+# Download and extract in-place (overwrites binary, public/, migrations/)
+# Replace linux-x64 with your platform: linux-arm64, darwin-x64, or darwin-arm64
+curl -L https://github.com/getqarote/Qarote/releases/latest/download/qarote-linux-x64.tar.gz \
+  | tar xz --strip-components=1
+
+# Restart — new migrations are applied automatically on startup
 ./qarote
 ```
 
-Your `.env` file is preserved — no reconfiguration needed.
+> **Note:** Make sure to download the correct artifact for your platform. Using the wrong one will produce an incompatible binary that fails to start.
+
+Your `.env` file is preserved — no reconfiguration needed. New database migrations are applied automatically on startup.
 
 ---
 

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Qarote Single Binary Build Script
 # Compiles the API + frontend into a standalone distribution using Bun.
 #
-# Output: a .tar.gz containing the binary + public/ directory.
+# Output: a .tar.gz containing the binary + public/ + migrations/ directories.
 # bun build --compile bundles the JS module graph but NOT files accessed via
 # fs at runtime, so static frontend assets must ship alongside the binary.
 #
@@ -81,13 +81,16 @@ BUN_BUILD_ARGS+=("--outfile" "$OUTNAME")
 
 bun build "${BUN_BUILD_ARGS[@]}"
 
-# --- Step 5: Package binary + frontend assets into tarball ---
+# --- Step 5: Package binary + frontend assets + migrations into tarball ---
 info "Step 5/5: Packaging distribution..."
 
 DIST_DIR="$(mktemp -d)"
 mkdir -p "$DIST_DIR/qarote"
 cp "$OUTNAME" "$DIST_DIR/qarote/qarote"
 cp -r apps/api/dist/public "$DIST_DIR/qarote/public"
+
+# Include Prisma migration files so the binary can auto-migrate on first start
+"$SCRIPT_DIR/copy-migrations.sh" "$DIST_DIR/qarote/migrations"
 
 TARBALL="${OUTNAME}.tar.gz"
 tar czf "$TARBALL" -C "$DIST_DIR" qarote

--- a/scripts/copy-migrations.sh
+++ b/scripts/copy-migrations.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# Copies Prisma migration SQL files into a target directory for binary packaging.
+# Usage: ./scripts/copy-migrations.sh <target-dir>
+#   e.g. ./scripts/copy-migrations.sh dist-package/qarote/migrations
+
+TARGET_DIR="${1:?Usage: copy-migrations.sh <target-dir>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATIONS_SRC="$SCRIPT_DIR/../apps/api/prisma/migrations"
+
+if [ ! -d "$MIGRATIONS_SRC" ]; then
+  echo "Error: migrations source not found: $MIGRATIONS_SRC" >&2
+  exit 1
+fi
+
+migrations_copied=0
+mkdir -p "$TARGET_DIR"
+for dir in "$MIGRATIONS_SRC"/*/; do
+  name="$(basename "$dir")"
+  if [ -f "$dir/migration.sql" ]; then
+    mkdir -p "$TARGET_DIR/$name"
+    cp "$dir/migration.sql" "$TARGET_DIR/$name/"
+    migrations_copied=$((migrations_copied + 1))
+  fi
+done
+
+if [ "$migrations_copied" -eq 0 ]; then
+  echo "Error: no migration.sql files found in $MIGRATIONS_SRC" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Add lightweight migration runner (`core/migrate.ts`) that applies Prisma migration SQL files on server startup, so the binary creates the database schema automatically on first run
- Ship `migrations/` directory in the binary tarball (build script + CI workflow)
- Add `NODE_ENV=production` to `.env.selfhosted.example` and portal env example
- Update binary docs (deployment guide + portal installation guide) with auto-migration notes and `migrations/` copy in update commands

## Test plan

- [x] Built linux-arm64 binary locally, deployed on clean Multipass VM
- [x] Fresh database: all 54 migrations applied in ~280ms on first start
- [x] Restart: no migrations re-applied (idempotent — checks `_prisma_migrations` table)
- [x] Health check returns 200, database connected, frontend served
- [x] `_prisma_migrations` table populated with correct checksums (compatible with `prisma migrate deploy`)
- [ ] CI builds all 4 platform tarballs with migrations/ included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic database migrations are applied on first startup.
  * Release packages now include migration files so updates can run migrations in-place.

* **Documentation**
  * Installation and update guides updated to describe automatic migrations and an in-place binary update flow.
  * Environment examples now include a required NODE_ENV=production entry.

* **Chores**
  * Packaging updated to include migrations and a helper script to copy migration files into release artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->