### PR TITLE
feat: self-hosted first-admin experience

### DIFF
--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -10,6 +10,7 @@
     "userNotFound": "User not found",
     "mustAcceptTerms": "You must accept the terms of service to register",
     "emailAlreadyInUse": "Email already in use",
+    "registrationDisabled": "Public registration is currently disabled. Please contact your administrator for an invitation.",
     "failedToRegister": "Failed to register user",
     "googleOAuthNotEnabled": "Google OAuth is not enabled for this deployment",
     "googleOAuthRequiredForCloud": "Google OAuth is required for cloud deployments",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -10,6 +10,7 @@
     "userNotFound": "Usuario no encontrado",
     "mustAcceptTerms": "Debe aceptar los términos de servicio para registrarse",
     "emailAlreadyInUse": "El correo electrónico ya está en uso",
+    "registrationDisabled": "El registro público está actualmente deshabilitado. Contacte con su administrador para obtener una invitación.",
     "failedToRegister": "Error al registrar el usuario",
     "googleOAuthNotEnabled": "La autenticación Google OAuth no está habilitada para este despliegue",
     "googleOAuthRequiredForCloud": "La autenticación Google OAuth es obligatoria para los despliegues en la nube",

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -10,6 +10,7 @@
     "userNotFound": "Utilisateur introuvable",
     "mustAcceptTerms": "Vous devez accepter les conditions d'utilisation pour vous inscrire",
     "emailAlreadyInUse": "Cette adresse e-mail est déjà utilisée",
+    "registrationDisabled": "L'inscription publique est actuellement désactivée. Veuillez contacter votre administrateur pour obtenir une invitation.",
     "failedToRegister": "Échec de l'inscription de l'utilisateur",
     "googleOAuthNotEnabled": "L'authentification Google OAuth n'est pas activée pour ce déploiement",
     "googleOAuthRequiredForCloud": "L'authentification Google OAuth est requise pour les déploiements cloud",

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -10,6 +10,7 @@
     "userNotFound": "未找到用户",
     "mustAcceptTerms": "您必须接受服务条款才能注册",
     "emailAlreadyInUse": "该邮箱地址已被使用",
+    "registrationDisabled": "公开注册目前已被禁用。请联系您的管理员获取邀请。",
     "failedToRegister": "用户注册失败",
     "googleOAuthNotEnabled": "此部署未启用 Google OAuth 认证",
     "googleOAuthRequiredForCloud": "云部署需要 Google OAuth 认证",

--- a/apps/api/src/cli/setup.ts
+++ b/apps/api/src/cli/setup.ts
@@ -216,6 +216,11 @@ export async function runSetup(): Promise<void> {
         console.log(c.red("    Must be at least 8 characters."));
         continue;
       }
+      const confirm2 = await askSecret("Confirm admin password");
+      if (input !== confirm2) {
+        console.log(c.red("    Passwords do not match. Try again."));
+        continue;
+      }
       adminPassword = input;
     }
   }

--- a/apps/api/src/cli/setup.ts
+++ b/apps/api/src/cli/setup.ts
@@ -163,6 +163,51 @@ export async function runSetup(): Promise<void> {
     smtpPass = await ask("SMTP password");
   }
 
+  // ─── Admin Account ───────────────────────────────────────────────
+  section("Admin Account");
+
+  const createAdmin = await confirm(
+    "Create an admin account during first boot?",
+    true
+  );
+
+  let adminEmail = "";
+  let adminPassword = "";
+
+  if (createAdmin) {
+    while (!adminEmail) {
+      const input = await ask("Admin email");
+      if (!input) {
+        console.log(
+          c.red("    Required.") + c.dim(" Example: admin@example.com")
+        );
+        continue;
+      }
+      if (!input.includes("@") || !input.includes(".")) {
+        console.log(c.red("    Please enter a valid email address."));
+        continue;
+      }
+      adminEmail = input;
+    }
+
+    while (!adminPassword) {
+      const input = await ask("Admin password");
+      if (!input || input.length < 8) {
+        console.log(c.red("    Must be at least 8 characters."));
+        continue;
+      }
+      adminPassword = input;
+    }
+  }
+
+  // ─── Registration ───────────────────────────────────────────────
+  section("Registration");
+
+  const enableRegistration = await confirm(
+    "Allow public user registration?",
+    true
+  );
+
   // ─── Generate secrets ──────────────────────────────────────────────
   section("Security");
 
@@ -198,6 +243,17 @@ export async function runSetup(): Promise<void> {
     lines.push(`SMTP_PASS=${smtpPass}`);
   }
 
+  // Registration
+  lines.push("", "# Registration");
+  lines.push(`ENABLE_REGISTRATION=${enableRegistration}`);
+
+  // Admin bootstrap
+  if (adminEmail && adminPassword) {
+    lines.push("", "# Admin (auto-removed after first boot)");
+    lines.push(`ADMIN_EMAIL=${adminEmail}`);
+    lines.push(`ADMIN_PASSWORD=${adminPassword}`);
+  }
+
   lines.push(""); // trailing newline
 
   writeFileSync(envPath, lines.join("\n"), { mode: 0o600 });
@@ -208,9 +264,21 @@ export async function runSetup(): Promise<void> {
   console.log("");
 
   console.log(c.dim("  Configuration summary:"));
-  console.log(c.dim(`    Database: ${dbUrl.replace(/:[^@]*@/, ":***@")}`));
-  console.log(c.dim(`    Port:     ${port}`));
-  console.log(c.dim(`    Email:    ${enableEmail ? "enabled" : "disabled"}`));
+  console.log(c.dim(`    Database:     ${dbUrl.replace(/:[^@]*@/, ":***@")}`));
+  console.log(c.dim(`    Port:         ${port}`));
+  console.log(
+    c.dim(`    Email:        ${enableEmail ? "enabled" : "disabled"}`)
+  );
+  console.log(
+    c.dim(
+      `    Admin:        ${adminEmail ? adminEmail : "none (register via web)"}`
+    )
+  );
+  console.log(
+    c.dim(
+      `    Registration: ${enableRegistration ? "open" : "invitation-only"}`
+    )
+  );
   console.log("");
   console.log("  Next steps:");
   console.log(`    ${c.bold("Start Qarote:")}  ./qarote`);

--- a/apps/api/src/cli/setup.ts
+++ b/apps/api/src/cli/setup.ts
@@ -203,10 +203,20 @@ export async function runSetup(): Promise<void> {
   // ─── Registration ───────────────────────────────────────────────
   section("Registration");
 
-  const enableRegistration = await confirm(
+  let enableRegistration = await confirm(
     "Allow public user registration?",
     true
   );
+
+  if (!createAdmin && !enableRegistration) {
+    console.log(
+      c.red(
+        "    You must enable registration or create an admin account for first boot."
+      )
+    );
+    enableRegistration = true;
+    console.log(c.yellow("    Registration has been enabled automatically."));
+  }
 
   // ─── Generate secrets ──────────────────────────────────────────────
   section("Security");
@@ -250,8 +260,10 @@ export async function runSetup(): Promise<void> {
   // Admin bootstrap
   if (adminEmail && adminPassword) {
     lines.push("", "# Admin (auto-removed after first boot)");
-    lines.push(`ADMIN_EMAIL=${adminEmail}`);
-    lines.push(`ADMIN_PASSWORD=${adminPassword}`);
+    const escapeEnvValue = (v: string) =>
+      `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    lines.push(`ADMIN_EMAIL=${escapeEnvValue(adminEmail)}`);
+    lines.push(`ADMIN_PASSWORD=${escapeEnvValue(adminPassword)}`);
   }
 
   lines.push(""); // trailing newline

--- a/apps/api/src/cli/setup.ts
+++ b/apps/api/src/cli/setup.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
+import { Writable } from "node:stream";
 
 // Colors (disabled if not a terminal)
 const isTTY = process.stdout.isTTY;
@@ -34,7 +35,26 @@ function createPrompt() {
       });
     });
 
-  return { rl, ask, confirm };
+  /** Prompt for sensitive input without echoing to the terminal. */
+  const askSecret = (question: string): Promise<string> =>
+    new Promise((resolve) => {
+      rl.pause();
+      const mutedOutput = new Writable({ write: (_c, _e, cb) => cb() });
+      const secretRl = createInterface({
+        input: process.stdin,
+        output: mutedOutput,
+        terminal: true,
+      });
+      process.stdout.write(`  ${question}: `);
+      secretRl.question("", (answer) => {
+        secretRl.close();
+        process.stdout.write("\n");
+        rl.resume();
+        resolve(answer.trim());
+      });
+    });
+
+  return { rl, ask, confirm, askSecret };
 }
 
 async function testDatabaseConnection(
@@ -78,7 +98,7 @@ export async function runSetup(): Promise<void> {
     process.exit(1);
   }
 
-  const { rl, ask, confirm } = createPrompt();
+  const { rl, ask, confirm, askSecret } = createPrompt();
 
   console.log("");
   console.log(c.bold("  Qarote Setup"));
@@ -191,7 +211,7 @@ export async function runSetup(): Promise<void> {
     }
 
     while (!adminPassword) {
-      const input = await ask("Admin password");
+      const input = await askSecret("Admin password");
       if (!input || input.length < 8) {
         console.log(c.red("    Must be at least 8 characters."));
         continue;

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -124,6 +124,15 @@ export const emailConfig = {
   },
 } as const;
 
+export const registrationConfig = {
+  enabled: "ENABLE_REGISTRATION" in config ? config.ENABLE_REGISTRATION : true,
+} as const;
+
+export const adminBootstrapConfig = {
+  email: "ADMIN_EMAIL" in config ? config.ADMIN_EMAIL : undefined,
+  password: "ADMIN_PASSWORD" in config ? config.ADMIN_PASSWORD : undefined,
+} as const;
+
 export const stripeConfig = {
   secretKey: config.STRIPE_SECRET_KEY,
   webhookSecret: config.STRIPE_WEBHOOK_SECRET,

--- a/apps/api/src/config/schemas/selfhosted.ts
+++ b/apps/api/src/config/schemas/selfhosted.ts
@@ -11,6 +11,9 @@ export const selfhostedSchema = baseSchema.extend({
   // Deployment Mode
   DEPLOYMENT_MODE: z.literal("selfhosted"),
 
+  // Registration control
+  ENABLE_REGISTRATION: z.coerce.boolean().default(true),
+
   // Email Configuration - All optional with sensible defaults
   ENABLE_EMAIL: z.coerce.boolean().default(false),
   EMAIL_PROVIDER: z.literal("smtp").default("smtp"),
@@ -91,6 +94,10 @@ export const selfhostedSchema = baseSchema.extend({
   SSO_TENANT: z.string().optional().default("default"),
   SSO_PRODUCT: z.string().optional().default("qarote"),
   SSO_BUTTON_LABEL: z.string().optional().default("Sign in with SSO"),
+
+  // Admin bootstrap (used once on first boot, then removed from .env)
+  ADMIN_EMAIL: z.email().optional(),
+  ADMIN_PASSWORD: z.string().min(8).optional(),
 
   // Notion Configuration - Optional
   NOTION_API_KEY: z.string().optional(),

--- a/apps/api/src/config/schemas/selfhosted.ts
+++ b/apps/api/src/config/schemas/selfhosted.ts
@@ -12,7 +12,7 @@ export const selfhostedSchema = baseSchema.extend({
   DEPLOYMENT_MODE: z.literal("selfhosted"),
 
   // Registration control
-  ENABLE_REGISTRATION: z.coerce.boolean().default(true),
+  ENABLE_REGISTRATION: z.stringbool().optional().default(true),
 
   // Email Configuration - All optional with sensible defaults
   ENABLE_EMAIL: z.coerce.boolean().default(false),

--- a/apps/api/src/core/bootstrap-admin.ts
+++ b/apps/api/src/core/bootstrap-admin.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { hashPassword } from "@/core/auth";
+import { logger } from "@/core/logger";
+import { prisma } from "@/core/prisma";
+import { ensureWorkspaceMember } from "@/core/workspace-access";
+
+import { adminBootstrapConfig } from "@/config";
+
+import { UserRole } from "@/generated/prisma/client";
+
+/**
+ * Bootstrap the first admin user on first boot.
+ *
+ * Conditions:
+ * 1. ADMIN_EMAIL and ADMIN_PASSWORD env vars are set
+ * 2. No users exist in the database (first boot)
+ *
+ * After creation, removes ADMIN_EMAIL and ADMIN_PASSWORD from .env for security.
+ */
+export async function bootstrapAdmin(): Promise<void> {
+  const { email, password } = adminBootstrapConfig;
+
+  if (!email || !password) {
+    return;
+  }
+
+  // Check if any user exists (idempotency guard)
+  const userCount = await prisma.user.count({ take: 1 });
+  if (userCount > 0) {
+    logger.debug("Users already exist — skipping admin bootstrap");
+    removeAdminEnvVars();
+    return;
+  }
+
+  logger.info({ email }, "Bootstrapping admin account");
+
+  const hashedPassword = await hashPassword(password);
+
+  await prisma.$transaction(async (tx) => {
+    const workspace = await tx.workspace.create({
+      data: {
+        name: "Default Workspace",
+        contactEmail: email,
+      },
+    });
+
+    const user = await tx.user.create({
+      data: {
+        email,
+        passwordHash: hashedPassword,
+        firstName: "Admin",
+        lastName: "",
+        role: UserRole.ADMIN,
+        isActive: true,
+        emailVerified: true,
+        emailVerifiedAt: new Date(),
+        workspaceId: workspace.id,
+      },
+    });
+
+    await tx.workspace.update({
+      where: { id: workspace.id },
+      data: { ownerId: user.id },
+    });
+
+    await ensureWorkspaceMember(user.id, workspace.id, UserRole.ADMIN, tx);
+
+    logger.info(
+      { userId: user.id, workspaceId: workspace.id, email },
+      "Admin account bootstrapped successfully"
+    );
+  });
+
+  removeAdminEnvVars();
+}
+
+/**
+ * Remove ADMIN_EMAIL and ADMIN_PASSWORD lines from .env file.
+ */
+function removeAdminEnvVars(): void {
+  const envPath = path.join(process.cwd(), ".env");
+
+  if (!fs.existsSync(envPath)) {
+    return;
+  }
+
+  try {
+    const content = fs.readFileSync(envPath, "utf-8");
+    const filtered = content
+      .split("\n")
+      .filter((line) => {
+        const trimmed = line.trim();
+        return (
+          !trimmed.startsWith("ADMIN_EMAIL=") &&
+          !trimmed.startsWith("ADMIN_PASSWORD=") &&
+          trimmed !== "# Admin (auto-removed after first boot)"
+        );
+      })
+      .join("\n");
+
+    const cleaned = filtered.replace(/\n{3,}/g, "\n\n");
+    fs.writeFileSync(envPath, cleaned, { mode: 0o600 });
+    logger.info("Removed admin credentials from .env");
+  } catch (err) {
+    logger.warn(
+      { err },
+      "Failed to clean admin credentials from .env — please remove manually"
+    );
+  }
+}

--- a/apps/api/src/core/bootstrap-admin.ts
+++ b/apps/api/src/core/bootstrap-admin.ts
@@ -22,14 +22,13 @@ import { UserRole } from "@/generated/prisma/client";
 export async function bootstrapAdmin(): Promise<void> {
   const { email, password } = adminBootstrapConfig;
 
-  if (!email || !password) {
+  if (!email && !password) {
     return;
   }
 
-  // Check if any user exists (idempotency guard)
-  const userCount = await prisma.user.count({ take: 1 });
-  if (userCount > 0) {
-    logger.debug("Users already exist — skipping admin bootstrap");
+  // Clean up partial credentials (e.g. only email or only password set)
+  if (!email || !password) {
+    logger.warn("Incomplete admin bootstrap credentials — removing from .env");
     removeAdminEnvVars();
     return;
   }
@@ -39,6 +38,13 @@ export async function bootstrapAdmin(): Promise<void> {
   const hashedPassword = await hashPassword(password);
 
   await prisma.$transaction(async (tx) => {
+    // Idempotency guard inside transaction to prevent races
+    const existingUser = await tx.user.findFirst({ select: { id: true } });
+    if (existingUser) {
+      logger.debug("Users already exist — skipping admin bootstrap");
+      return;
+    }
+
     const workspace = await tx.workspace.create({
       data: {
         name: "Default Workspace",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,7 +27,6 @@ const { values: cliArgs } = parseArgs({
     "smtp-pass": { type: "string" },
     // Admin bootstrap
     "admin-email": { type: "string" },
-    "admin-password": { type: "string" },
     // Registration
     "enable-registration": { type: "string" },
     // Email OAuth2
@@ -52,7 +51,6 @@ const flagToEnv: Record<string, string> = {
   "smtp-user": "SMTP_USER",
   "smtp-pass": "SMTP_PASS",
   "admin-email": "ADMIN_EMAIL",
-  "admin-password": "ADMIN_PASSWORD",
   "enable-registration": "ENABLE_REGISTRATION",
   "smtp-service": "SMTP_SERVICE",
   "smtp-oauth-client-id": "SMTP_OAUTH_CLIENT_ID",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -25,6 +25,11 @@ const { values: cliArgs } = parseArgs({
     "smtp-port": { type: "string" },
     "smtp-user": { type: "string" },
     "smtp-pass": { type: "string" },
+    // Admin bootstrap
+    "admin-email": { type: "string" },
+    "admin-password": { type: "string" },
+    // Registration
+    "enable-registration": { type: "string" },
     // Email OAuth2
     "smtp-service": { type: "string" },
     "smtp-oauth-client-id": { type: "string" },
@@ -46,6 +51,9 @@ const flagToEnv: Record<string, string> = {
   "smtp-port": "SMTP_PORT",
   "smtp-user": "SMTP_USER",
   "smtp-pass": "SMTP_PASS",
+  "admin-email": "ADMIN_EMAIL",
+  "admin-password": "ADMIN_PASSWORD",
+  "enable-registration": "ENABLE_REGISTRATION",
   "smtp-service": "SMTP_SERVICE",
   "smtp-oauth-client-id": "SMTP_OAUTH_CLIENT_ID",
   "smtp-oauth-client-secret": "SMTP_OAUTH_CLIENT_SECRET",

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -9,6 +9,7 @@ import { logger as honoLogger } from "hono/logger";
 import { prettyJSON } from "hono/pretty-json";
 import { secureHeaders } from "hono/secure-headers";
 
+import { bootstrapAdmin } from "@/core/bootstrap-admin";
 import { logger } from "@/core/logger";
 import { runMigrations } from "@/core/migrate";
 import { prisma } from "@/core/prisma";
@@ -150,6 +151,9 @@ async function startServer() {
     await prisma.$connect();
     dbConnected = true;
     logger.info("Connected to database");
+
+    // Bootstrap admin account on first boot (if configured via setup CLI)
+    await bootstrapAdmin();
 
     // Initialize SSO service if enabled
     if (ssoConfig.enabled) {

--- a/apps/api/src/trpc/routers/auth/registration.ts
+++ b/apps/api/src/trpc/routers/auth/registration.ts
@@ -8,7 +8,7 @@ import { trackSignUpError } from "@/services/sentry";
 
 import { RegisterUserSchema } from "@/schemas/auth";
 
-import { emailConfig } from "@/config";
+import { emailConfig, registrationConfig } from "@/config";
 
 import { UserMapper } from "@/mappers/auth";
 
@@ -29,6 +29,14 @@ export const registrationRouter = router({
     .mutation(async ({ input, ctx }) => {
       const { email, password, firstName, lastName, acceptTerms, sourceApp } =
         input;
+
+      // Check if public registration is enabled
+      if (!registrationConfig.enabled) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: te(ctx.locale, "auth.registrationDisabled"),
+        });
+      }
 
       // Validate that terms were accepted
       if (!acceptTerms) {

--- a/apps/api/src/trpc/routers/public/index.ts
+++ b/apps/api/src/trpc/routers/public/index.ts
@@ -1,5 +1,11 @@
 import { areFeaturesEnabled } from "@/core/feature-flags";
 
+import {
+  emailConfig,
+  googleConfig,
+  registrationConfig,
+  ssoConfig,
+} from "@/config";
 import { getAllPremiumFeatures } from "@/config/features";
 
 import { publicProcedure, router } from "@/trpc/trpc";
@@ -12,6 +18,19 @@ import { publicInvitationRouter } from "./invitation";
  */
 export const publicRouter = router({
   invitation: publicInvitationRouter,
+
+  /**
+   * Get public app configuration (PUBLIC)
+   * Returns configuration flags needed by the frontend before authentication
+   */
+  getConfig: publicProcedure.query(async () => {
+    return {
+      registrationEnabled: registrationConfig.enabled,
+      emailEnabled: emailConfig.enabled,
+      oauthEnabled: googleConfig.enabled,
+      ssoEnabled: ssoConfig.enabled,
+    };
+  }),
 
   /**
    * Get feature flags (PUBLIC)

--- a/apps/api/src/trpc/routers/public/invitation.ts
+++ b/apps/api/src/trpc/routers/public/invitation.ts
@@ -15,7 +15,11 @@ import { googleConfig } from "@/config";
 
 import { rateLimitedPublicProcedure, router } from "@/trpc/trpc";
 
-import { InvitationStatus, UserRole } from "@/generated/prisma/client";
+import {
+  InvitationStatus,
+  UserPlan,
+  UserRole,
+} from "@/generated/prisma/client";
 import { te } from "@/i18n";
 
 /**
@@ -74,16 +78,16 @@ export const publicInvitationRouter = router({
         }
 
         // Get workspace owner's subscription to determine plan
-        const ownerSubscription = await ctx.prisma.subscription.findUnique({
-          where: { userId: invitation.workspace.ownerId! },
-          select: { plan: true },
-        });
-
-        if (!ownerSubscription) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: te(ctx.locale, "auth.workspaceOwnerNoSubscription"),
+        // Self-hosted deployments may not have a Subscription record — default to FREE
+        let ownerPlan: UserPlan = UserPlan.FREE;
+        if (invitation.workspace.ownerId) {
+          const ownerSubscription = await ctx.prisma.subscription.findUnique({
+            where: { userId: invitation.workspace.ownerId },
+            select: { plan: true },
           });
+          if (ownerSubscription) {
+            ownerPlan = ownerSubscription.plan;
+          }
         }
 
         return {
@@ -98,7 +102,7 @@ export const publicInvitationRouter = router({
               id: invitation.workspace.id,
               name: invitation.workspace.name,
               contactEmail: invitation.workspace.contactEmail,
-              plan: ownerSubscription.plan,
+              plan: ownerPlan,
             },
             invitedBy: formatInvitedBy(invitation.invitedBy),
           },

--- a/apps/api/src/trpc/routers/workspace/invitation.ts
+++ b/apps/api/src/trpc/routers/workspace/invitation.ts
@@ -13,6 +13,7 @@ import {
 import { inviteUserSchema } from "@/schemas/invitation";
 import { InvitationIdParamSchema } from "@/schemas/workspace";
 
+import { emailConfig } from "@/config";
 import { FEATURES } from "@/config/features";
 
 import {
@@ -206,7 +207,11 @@ export const invitationRouter = router({
           },
         });
 
+        // Build invite URL for sharing (useful when email is disabled)
+        const inviteUrl = `${emailConfig.frontendUrl}/invite/${token}`;
+
         // Send invitation email
+        let emailSent = false;
         try {
           const plan = await getUserPlan(user.id);
           await EmailService.sendInvitationEmail({
@@ -218,6 +223,7 @@ export const invitationRouter = router({
             plan,
             locale: ctx.locale,
           });
+          emailSent = true;
           ctx.logger.info(
             { invitationId: invitation.id, email },
             "Invitation email sent successfully"
@@ -238,6 +244,8 @@ export const invitationRouter = router({
             createdAt: invitation.createdAt.toISOString(),
             invitedBy: formatInvitedBy(invitation.invitedBy),
           },
+          inviteUrl,
+          emailSent,
         };
       } catch (error) {
         if (error instanceof TRPCError) {

--- a/apps/api/src/trpc/routers/workspace/invitation.ts
+++ b/apps/api/src/trpc/routers/workspace/invitation.ts
@@ -5,10 +5,7 @@ import { formatInvitedBy, getUserDisplayName } from "@/core/utils";
 
 import { EmailService } from "@/services/email/email.service";
 import { EncryptionService } from "@/services/encryption.service";
-import {
-  getUserPlan,
-  validateUserInvitation,
-} from "@/services/plan/plan.service";
+import { validateUserInvitation } from "@/services/plan/plan.service";
 
 import { inviteUserSchema } from "@/schemas/invitation";
 import { InvitationIdParamSchema } from "@/schemas/workspace";
@@ -214,14 +211,13 @@ export const invitationRouter = router({
         let emailSent = false;
         if (emailConfig.enabled) {
           try {
-            const plan = await getUserPlan(user.id);
             await EmailService.sendInvitationEmail({
               to: email,
               invitationToken: token,
               workspaceName: workspace.name,
               inviterName: getUserDisplayName(user),
               inviterEmail: user.email,
-              plan,
+              plan: ownerPlan,
               locale: ctx.locale,
             });
             emailSent = true;

--- a/apps/api/src/trpc/routers/workspace/invitation.ts
+++ b/apps/api/src/trpc/routers/workspace/invitation.ts
@@ -210,30 +210,32 @@ export const invitationRouter = router({
         // Build invite URL for sharing (useful when email is disabled)
         const inviteUrl = `${emailConfig.frontendUrl}/invite/${token}`;
 
-        // Send invitation email
+        // Send invitation email (only attempt if email is enabled)
         let emailSent = false;
-        try {
-          const plan = await getUserPlan(user.id);
-          await EmailService.sendInvitationEmail({
-            to: email,
-            invitationToken: token,
-            workspaceName: workspace.name,
-            inviterName: getUserDisplayName(user),
-            inviterEmail: user.email,
-            plan,
-            locale: ctx.locale,
-          });
-          emailSent = true;
-          ctx.logger.info(
-            { invitationId: invitation.id, email },
-            "Invitation email sent successfully"
-          );
-        } catch (emailError) {
-          ctx.logger.error(
-            { emailError, invitationId: invitation.id },
-            "Failed to send invitation email"
-          );
-          // Don't fail the request if email sending fails
+        if (emailConfig.enabled) {
+          try {
+            const plan = await getUserPlan(user.id);
+            await EmailService.sendInvitationEmail({
+              to: email,
+              invitationToken: token,
+              workspaceName: workspace.name,
+              inviterName: getUserDisplayName(user),
+              inviterEmail: user.email,
+              plan,
+              locale: ctx.locale,
+            });
+            emailSent = true;
+            ctx.logger.info(
+              { invitationId: invitation.id, email },
+              "Invitation email sent successfully"
+            );
+          } catch (emailError) {
+            ctx.logger.error(
+              { error: emailError, invitationId: invitation.id, email },
+              "Failed to send invitation email"
+            );
+            // Don't fail the request if email sending fails
+          }
         }
 
         return {

--- a/apps/app/public/locales/en/auth.json
+++ b/apps/app/public/locales/en/auth.json
@@ -124,5 +124,7 @@
   "pleaseConfirmPassword": "Please confirm your password",
   "passwordsDoNotMatch": "Passwords do not match",
   "continueWithGoogle": "Continue with Google",
-  "continueWithSSO": "Continue with SSO"
+  "continueWithSSO": "Continue with SSO",
+  "registrationDisabled": "Registration Disabled",
+  "registrationDisabledDescription": "Public registration is currently disabled on this server. Please contact your administrator for an invitation link."
 }

--- a/apps/app/public/locales/en/profile.json
+++ b/apps/app/public/locales/en/profile.json
@@ -7,5 +7,9 @@
     "team": "Team",
     "sendFeedback": "Send Feedback"
   },
-  "failedToLoad": "Failed to load profile information."
+  "failedToLoad": "Failed to load profile information.",
+  "toast": {
+    "copyInviteLink": "Email is disabled. Share this link with the invited user.",
+    "copyLink": "Copy Link"
+  }
 }

--- a/apps/app/public/locales/es/auth.json
+++ b/apps/app/public/locales/es/auth.json
@@ -124,5 +124,7 @@
   "pleaseConfirmPassword": "Por favor confirma tu contrase\u00f1a",
   "passwordsDoNotMatch": "Las contrase\u00f1as no coinciden",
   "continueWithGoogle": "Continuar con Google",
-  "continueWithSSO": "Continuar con SSO"
+  "continueWithSSO": "Continuar con SSO",
+  "registrationDisabled": "Registro deshabilitado",
+  "registrationDisabledDescription": "El registro público está actualmente deshabilitado en este servidor. Contacte con su administrador para obtener un enlace de invitación."
 }

--- a/apps/app/public/locales/es/profile.json
+++ b/apps/app/public/locales/es/profile.json
@@ -7,5 +7,9 @@
     "team": "Equipo",
     "sendFeedback": "Enviar comentarios"
   },
-  "failedToLoad": "No se pudo cargar la información del perfil."
+  "failedToLoad": "No se pudo cargar la información del perfil.",
+  "toast": {
+    "copyInviteLink": "El correo electrónico está deshabilitado. Comparta este enlace con el usuario invitado.",
+    "copyLink": "Copiar enlace"
+  }
 }

--- a/apps/app/public/locales/fr/auth.json
+++ b/apps/app/public/locales/fr/auth.json
@@ -124,5 +124,7 @@
   "pleaseConfirmPassword": "Veuillez confirmer votre mot de passe",
   "passwordsDoNotMatch": "Les mots de passe ne correspondent pas",
   "continueWithGoogle": "Continuer avec Google",
-  "continueWithSSO": "Continuer avec SSO"
+  "continueWithSSO": "Continuer avec SSO",
+  "registrationDisabled": "Inscription désactivée",
+  "registrationDisabledDescription": "L'inscription publique est actuellement désactivée sur ce serveur. Veuillez contacter votre administrateur pour obtenir un lien d'invitation."
 }

--- a/apps/app/public/locales/fr/profile.json
+++ b/apps/app/public/locales/fr/profile.json
@@ -7,7 +7,7 @@
     "team": "Equipe",
     "sendFeedback": "Envoyer un commentaire"
   },
-  "failedToLoad": "Echec du chargement des informations du profil.",
+  "failedToLoad": "Échec du chargement des informations du profil.",
   "toast": {
     "copyInviteLink": "L'e-mail est désactivé. Partagez ce lien avec l'utilisateur invité.",
     "copyLink": "Copier le lien"

--- a/apps/app/public/locales/fr/profile.json
+++ b/apps/app/public/locales/fr/profile.json
@@ -7,5 +7,9 @@
     "team": "Equipe",
     "sendFeedback": "Envoyer un commentaire"
   },
-  "failedToLoad": "Echec du chargement des informations du profil."
+  "failedToLoad": "Echec du chargement des informations du profil.",
+  "toast": {
+    "copyInviteLink": "L'e-mail est désactivé. Partagez ce lien avec l'utilisateur invité.",
+    "copyLink": "Copier le lien"
+  }
 }

--- a/apps/app/public/locales/zh/auth.json
+++ b/apps/app/public/locales/zh/auth.json
@@ -124,5 +124,7 @@
   "pleaseConfirmPassword": "请确认您的密码",
   "passwordsDoNotMatch": "两次输入的密码不一致",
   "continueWithGoogle": "使用 Google 继续",
-  "continueWithSSO": "使用 SSO 继续"
+  "continueWithSSO": "使用 SSO 继续",
+  "registrationDisabled": "注册已禁用",
+  "registrationDisabledDescription": "此服务器目前已禁用公开注册。请联系您的管理员获取邀请链接。"
 }

--- a/apps/app/public/locales/zh/profile.json
+++ b/apps/app/public/locales/zh/profile.json
@@ -7,5 +7,9 @@
     "team": "团队",
     "sendFeedback": "发送反馈"
   },
-  "failedToLoad": "加载个人资料信息失败。"
+  "failedToLoad": "加载个人资料信息失败。",
+  "toast": {
+    "copyInviteLink": "邮件已禁用。请将此链接分享给被邀请的用户。",
+    "copyLink": "复制链接"
+  }
 }

--- a/apps/app/src/components/TawkTo.tsx
+++ b/apps/app/src/components/TawkTo.tsx
@@ -2,10 +2,17 @@ import { useLocation } from "react-router";
 
 import TawkMessengerReact from "@tawk.to/tawk-messenger-react";
 
+import { isCloudMode } from "@/lib/featureFlags";
+
 const noop = () => {};
 
 export const TawkTo = () => {
   const location = useLocation();
+
+  // Only show Tawk.to in cloud mode, not in self-hosted deployments
+  if (!isCloudMode()) {
+    return null;
+  }
 
   // Don't show Tawk.to on sign-in or sign-up pages
   const excludedPaths = ["/auth/sign-in", "/auth/sign-up"];

--- a/apps/app/src/components/profile/EnhancedTeamTab.tsx
+++ b/apps/app/src/components/profile/EnhancedTeamTab.tsx
@@ -405,6 +405,7 @@ export const EnhancedTeamTab = ({
                             }}
                             className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
                             title="Copy invite link"
+                            aria-label="Copy invite link"
                           >
                             {copiedToken === invitation.id ? (
                               <Check className="h-4 w-4" />
@@ -423,6 +424,8 @@ export const EnhancedTeamTab = ({
                             }
                             disabled={isRevoking}
                             className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                            title="Revoke invitation"
+                            aria-label="Revoke invitation"
                           >
                             <X className="h-4 w-4" />
                           </Button>

--- a/apps/app/src/components/profile/EnhancedTeamTab.tsx
+++ b/apps/app/src/components/profile/EnhancedTeamTab.tsx
@@ -397,11 +397,15 @@ export const EnhancedTeamTab = ({
                           <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => {
-                              const inviteUrl = `${window.location.origin}/invite/${invitation.token}`;
-                              navigator.clipboard.writeText(inviteUrl);
-                              setCopiedToken(invitation.id);
-                              setTimeout(() => setCopiedToken(null), 2000);
+                            onClick={async () => {
+                              try {
+                                const inviteUrl = `${window.location.origin}/invite/${invitation.token}`;
+                                await navigator.clipboard.writeText(inviteUrl);
+                                setCopiedToken(invitation.id);
+                                setTimeout(() => setCopiedToken(null), 2000);
+                              } catch {
+                                // Clipboard write failed (e.g. permissions denied)
+                              }
                             }}
                             className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
                             title="Copy invite link"

--- a/apps/app/src/components/profile/EnhancedTeamTab.tsx
+++ b/apps/app/src/components/profile/EnhancedTeamTab.tsx
@@ -1,7 +1,16 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 
-import { Clock, Lock, Mail, UserPlus, Users, X } from "lucide-react";
+import {
+  Check,
+  Clock,
+  Copy,
+  Lock,
+  Mail,
+  UserPlus,
+  Users,
+  X,
+} from "lucide-react";
 
 import { User } from "@/lib/api/authTypes";
 import { InvitationWithInviter } from "@/lib/api/authTypes";
@@ -84,6 +93,9 @@ export const EnhancedTeamTab = ({
 
   // Check if current user is the workspace owner
   const isWorkspaceOwner = workspace?.ownerId === user?.id;
+
+  // State for copy feedback
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
 
   // State for confirmation dialog
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
@@ -381,17 +393,40 @@ export const EnhancedTeamTab = ({
                         {formatDate(invitation.expiresAt)}
                       </TableCell>
                       <TableCell>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() =>
-                            onRevokeInvitation(invitation.id, invitation.email)
-                          }
-                          disabled={isRevoking}
-                          className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
+                        <div className="flex items-center gap-1">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => {
+                              const inviteUrl = `${window.location.origin}/invite/${invitation.token}`;
+                              navigator.clipboard.writeText(inviteUrl);
+                              setCopiedToken(invitation.id);
+                              setTimeout(() => setCopiedToken(null), 2000);
+                            }}
+                            className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
+                            title="Copy invite link"
+                          >
+                            {copiedToken === invitation.id ? (
+                              <Check className="h-4 w-4" />
+                            ) : (
+                              <Copy className="h-4 w-4" />
+                            )}
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() =>
+                              onRevokeInvitation(
+                                invitation.id,
+                                invitation.email
+                              )
+                            }
+                            disabled={isRevoking}
+                            className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/apps/app/src/hooks/queries/usePublicConfig.ts
+++ b/apps/app/src/hooks/queries/usePublicConfig.ts
@@ -1,0 +1,8 @@
+import { trpc } from "@/lib/trpc/client";
+
+export const usePublicConfig = () => {
+  return trpc.public.getConfig.useQuery(undefined, {
+    staleTime: Infinity,
+    retry: false,
+  });
+};

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -257,13 +257,22 @@ const Profile = () => {
       setInviteDialogOpen(false);
       setInviteForm({ email: "", role: "MEMBER" });
 
-      toast.success(
-        `${t("toast.invitationSent", { email: inviteForm.email })} ${
-          result.invitation.monthlyCost > 0
-            ? t("toast.additionalCost", { cost: result.invitation.monthlyCost })
-            : ""
-        }`
-      );
+      if (result.emailSent) {
+        toast.success(t("toast.invitationSent", { email: inviteForm.email }));
+      } else {
+        // Email not sent (SMTP disabled) — show invite URL for manual sharing
+        const inviteUrl =
+          result.inviteUrl ||
+          `${window.location.origin}/invite/${result.invitation.token}`;
+        toast.success(t("toast.invitationSent", { email: inviteForm.email }), {
+          description: t("toast.copyInviteLink"),
+          action: {
+            label: t("toast.copyLink"),
+            onClick: () => navigator.clipboard.writeText(inviteUrl),
+          },
+          duration: 10000,
+        });
+      }
     } catch (error) {
       logger.error("Invitation error:", error);
       const errorMessage = extractErrorMessage(error);

--- a/apps/app/src/pages/SignIn.tsx
+++ b/apps/app/src/pages/SignIn.tsx
@@ -67,7 +67,7 @@ const SignIn: React.FC = () => {
           <h2 className="mt-6 text-3xl font-extrabold text-white">
             {t("signInToAccount")}
           </h2>
-          {publicConfig?.registrationEnabled !== false && (
+          {publicConfig?.registrationEnabled === true && (
             <p className="mt-2 text-sm text-orange-100">
               {t("or")}{" "}
               <Link

--- a/apps/app/src/pages/SignIn.tsx
+++ b/apps/app/src/pages/SignIn.tsx
@@ -29,6 +29,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 
+import { usePublicConfig } from "@/hooks/queries/usePublicConfig";
 import { useShowAlternativeAuth } from "@/hooks/queries/useSsoConfig";
 import { useLogin } from "@/hooks/ui/useAuth";
 
@@ -40,6 +41,7 @@ const SignIn: React.FC = () => {
   const [showPassword, setShowPassword] = useState(false);
   const loginMutation = useLogin();
   const { showAlternativeAuth } = useShowAlternativeAuth();
+  const { data: publicConfig } = usePublicConfig();
 
   // Initialize form with react-hook-form
   const form = useForm<SignInFormData>({
@@ -65,15 +67,17 @@ const SignIn: React.FC = () => {
           <h2 className="mt-6 text-3xl font-extrabold text-white">
             {t("signInToAccount")}
           </h2>
-          <p className="mt-2 text-sm text-orange-100">
-            {t("or")}{" "}
-            <Link
-              to="/auth/sign-up"
-              className="font-medium text-orange-300 hover:text-orange-200 transition-colors"
-            >
-              {t("createAccount")}
-            </Link>
-          </p>
+          {publicConfig?.registrationEnabled !== false && (
+            <p className="mt-2 text-sm text-orange-100">
+              {t("or")}{" "}
+              <Link
+                to="/auth/sign-up"
+                className="font-medium text-orange-300 hover:text-orange-200 transition-colors"
+              >
+                {t("createAccount")}
+              </Link>
+            </p>
+          )}
         </div>
 
         <Card className="bg-white/95 backdrop-blur-xs border-white/20 shadow-2xl">

--- a/apps/app/src/pages/SignUp.tsx
+++ b/apps/app/src/pages/SignUp.tsx
@@ -34,6 +34,7 @@ import { PasswordRequirements } from "@/components/ui/password-requirements";
 
 import { useAuth } from "@/contexts/AuthContextDefinition";
 
+import { usePublicConfig } from "@/hooks/queries/usePublicConfig";
 import { useShowAlternativeAuth } from "@/hooks/queries/useSsoConfig";
 import { useRegister } from "@/hooks/ui/useAuth";
 
@@ -48,6 +49,7 @@ const SignUp: React.FC = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const { showAlternativeAuth } = useShowAlternativeAuth();
+  const { data: publicConfig } = usePublicConfig();
 
   // Get the page the user was trying to access
   const from = location.state?.from?.pathname || "/";
@@ -118,7 +120,26 @@ const SignUp: React.FC = () => {
             <CardDescription>{t("createAccountDescription")}</CardDescription>
           </CardHeader>
           <CardContent>
-            {registerMutation.isSuccess ? (
+            {publicConfig?.registrationEnabled === false ? (
+              <Alert className="border-amber-200 bg-amber-50">
+                <AlertDescription className="text-amber-800">
+                  <div className="font-medium mb-2">
+                    {t("registrationDisabled")}
+                  </div>
+                  <p className="text-sm mb-3">
+                    {t("registrationDisabledDescription")}
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => navigate("/auth/sign-in")}
+                    className="bg-white border-amber-300 text-amber-700 hover:bg-amber-100"
+                  >
+                    {t("goToSignIn")}
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            ) : registerMutation.isSuccess ? (
               <Alert className="border-green-200 bg-green-50">
                 <AlertDescription className="text-green-800">
                   <div className="font-medium mb-2">

--- a/apps/e2e/helpers/trpc-mock.ts
+++ b/apps/e2e/helpers/trpc-mock.ts
@@ -1,0 +1,63 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Intercept a tRPC procedure in Playwright, correctly handling httpBatchLink.
+ *
+ * tRPC's httpBatchLink batches multiple procedures into a single HTTP request:
+ *   URL:  /trpc/proc1,proc2?batch=1&input=...
+ *   Body: [{result1}, {result2}]
+ *
+ * This helper intercepts any /trpc/* request that includes the target procedure,
+ * replaces only that procedure's response in the batch, and forwards the rest.
+ */
+export async function mockTrpcQuery(
+  page: Page,
+  procedure: string,
+  data: unknown
+): Promise<void> {
+  await page.route("**/trpc/**", async (route) => {
+    const url = new URL(route.request().url());
+    const segment = url.pathname.split("/trpc/")[1] || "";
+    const procedures = segment.split(",");
+    const index = procedures.indexOf(procedure);
+
+    if (index === -1) {
+      return route.continue();
+    }
+
+    const mockEntry = { result: { data } };
+
+    if (procedures.length === 1) {
+      // Only our target procedure in this batch
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([mockEntry]),
+      });
+    }
+
+    // Multi-procedure batch: fetch real responses, replace only our target
+    try {
+      const response = await route.fetch();
+      const body = await response.json();
+      body[index] = mockEntry;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+    } catch {
+      // If upstream fetch fails, build a minimal batch response
+      const batch = procedures.map((_, i) =>
+        i === index
+          ? mockEntry
+          : { error: { code: "INTERNAL_SERVER_ERROR", message: "mocked" } }
+      );
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(batch),
+      });
+    }
+  });
+}

--- a/apps/e2e/tests/auth/invitation.spec.ts
+++ b/apps/e2e/tests/auth/invitation.spec.ts
@@ -86,8 +86,9 @@ test.describe("Invitation Flow @p1", () => {
     expect(result.inviteUrl).toContain("/invite/");
     expect(typeof result.emailSent).toBe("boolean");
 
-    // In selfhosted E2E (ENABLE_EMAIL=false), email should NOT have been sent
-    expect(result.emailSent).toBe(false);
+    // Assert based on E2E email config
+    const emailEnabled = process.env.ENABLE_EMAIL === "true";
+    expect(result.emailSent).toBe(emailEnabled);
 
     // Clean up
     if (result.invitation?.id) {
@@ -121,6 +122,7 @@ test.describe("Invitation Flow @p1", () => {
     const subscription = await prisma.subscription.findUnique({
       where: { userId: admin!.id },
     });
+    expect(subscription, "Expected no subscription for self-hosted scenario").toBeNull();
 
     const inviteToken = `e2e-nosub-${Date.now()}`;
     const invitation = await prisma.invitation.create({

--- a/apps/e2e/tests/auth/invitation.spec.ts
+++ b/apps/e2e/tests/auth/invitation.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "../../fixtures/test-base.js";
 import { uniqueEmail } from "../../helpers/factories/user.factory.js";
 
+const apiUrl = process.env.API_URL || "http://localhost:3001";
+
 test.describe("Invitation Flow @p1", () => {
   test("should show invitation acceptance page with valid token", async ({
     page,
@@ -52,5 +54,100 @@ test.describe("Invitation Flow @p1", () => {
         page.getByRole("heading", { name: /sign in/i })
       )
     ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("should return inviteUrl and emailSent in sendInvitation API response @selfhosted", async ({
+    api,
+    db,
+  }) => {
+    test.skip(
+      process.env.DEPLOYMENT_MODE === "cloud",
+      "Selfhosted mode only — tests invite URL when SMTP disabled"
+    );
+
+    // Login as admin to get auth token
+    const { token } = await api.login(
+      "admin@e2e-test.local",
+      "TestPassword123!"
+    );
+    const authedApi = api.withAuth(token);
+
+    const inviteEmail = uniqueEmail("invite-api");
+
+    // Send invitation via API
+    const result = await authedApi.mutation(
+      "workspace.invitation.sendInvitation",
+      { email: inviteEmail, role: "MEMBER" }
+    );
+
+    // Verify response includes inviteUrl and emailSent
+    expect(result).toBeDefined();
+    expect(result.inviteUrl).toBeDefined();
+    expect(result.inviteUrl).toContain("/invite/");
+    expect(typeof result.emailSent).toBe("boolean");
+
+    // In selfhosted E2E (ENABLE_EMAIL=false), email should NOT have been sent
+    expect(result.emailSent).toBe(false);
+
+    // Clean up
+    if (result.invitation?.id) {
+      db.track("Invitation", result.invitation.id);
+    }
+  });
+
+  test("should show invitation details for self-hosted without subscription @selfhosted", async ({
+    page,
+    db,
+  }) => {
+    test.skip(
+      process.env.DEPLOYMENT_MODE === "cloud",
+      "Selfhosted mode only — tests getDetails without Stripe subscription"
+    );
+
+    const prisma = await db.getClient();
+    const inviteEmail = uniqueEmail("invite-nosubscription");
+
+    const admin = await prisma.user.findUnique({
+      where: { email: "admin@e2e-test.local" },
+    });
+    expect(admin, "Seeded admin user not found").toBeTruthy();
+
+    const workspace = await prisma.workspace.findFirst({
+      where: { ownerId: admin!.id },
+    });
+    expect(workspace, "Seeded workspace not found").toBeTruthy();
+
+    // Verify admin has no Subscription record (selfhosted scenario)
+    const subscription = await prisma.subscription.findUnique({
+      where: { userId: admin!.id },
+    });
+
+    const inviteToken = `e2e-nosub-${Date.now()}`;
+    const invitation = await prisma.invitation.create({
+      data: {
+        email: inviteEmail,
+        token: inviteToken,
+        invitedById: admin!.id,
+        workspaceId: workspace!.id,
+        role: "MEMBER",
+        status: "PENDING",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      },
+    });
+    db.track("Invitation", invitation.id);
+
+    // The getDetails endpoint should NOT throw even if admin has no Subscription
+    await page.goto(`/invite/${inviteToken}`);
+    await page.waitForLoadState("domcontentloaded");
+
+    // Should show invitation details (not an error page)
+    await expect(
+      page.getByText(/join qarote|invitation|accept/i).first()
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Should NOT show "workspaceOwnerNoSubscription" error
+    await expect(
+      page.getByText(/subscription/i)
+    ).not.toBeVisible({ timeout: 3_000 });
   });
 });

--- a/apps/e2e/tests/auth/sign-in.spec.ts
+++ b/apps/e2e/tests/auth/sign-in.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "../../fixtures/test-base.js";
 import { SignInPage } from "../../page-objects/auth/sign-in.page.js";
 
+const apiUrl = process.env.API_URL || "http://localhost:3001";
+
 test.describe("User Login @p0", () => {
   test("should login with valid credentials and redirect to dashboard", async ({
     page,
@@ -55,5 +57,47 @@ test.describe("User Login @p0", () => {
     await signInPage.goto();
     await signInPage.forgotPasswordLink.click();
     await page.waitForURL("**/forgot-password");
+  });
+
+  test("should hide create account link when registration is disabled", async ({
+    page,
+  }) => {
+    // Intercept public.getConfig to simulate registration disabled
+    await page.route(`${apiUrl}/trpc/public.getConfig*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          result: {
+            data: {
+              registrationEnabled: false,
+              emailEnabled: false,
+              oauthEnabled: false,
+              ssoEnabled: false,
+            },
+          },
+        }),
+      })
+    );
+
+    const signInPage = new SignInPage(page);
+    await signInPage.goto();
+    await page.waitForLoadState("domcontentloaded");
+
+    // "Create a new account" link should NOT be visible
+    await expect(signInPage.signUpLink).not.toBeVisible({ timeout: 5_000 });
+
+    // Sign-in form should still work
+    await expect(signInPage.signInButton).toBeVisible();
+  });
+
+  test("should show create account link when registration is enabled", async ({
+    page,
+  }) => {
+    const signInPage = new SignInPage(page);
+    await signInPage.goto();
+
+    // "Create a new account" link should be visible (default: registration enabled)
+    await expect(signInPage.signUpLink).toBeVisible({ timeout: 5_000 });
   });
 });

--- a/apps/e2e/tests/auth/sign-in.spec.ts
+++ b/apps/e2e/tests/auth/sign-in.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from "../../fixtures/test-base.js";
+import { mockTrpcQuery } from "../../helpers/trpc-mock.js";
 import { SignInPage } from "../../page-objects/auth/sign-in.page.js";
-
-const apiUrl = process.env.API_URL || "http://localhost:3001";
 
 test.describe("User Login @p0", () => {
   test("should login with valid credentials and redirect to dashboard", async ({
@@ -63,22 +62,13 @@ test.describe("User Login @p0", () => {
     page,
   }) => {
     // Intercept public.getConfig to simulate registration disabled
-    await page.route(`${apiUrl}/trpc/public.getConfig*`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          result: {
-            data: {
-              registrationEnabled: false,
-              emailEnabled: false,
-              oauthEnabled: false,
-              ssoEnabled: false,
-            },
-          },
-        }),
-      })
-    );
+    // Uses batch-aware helper because tRPC httpBatchLink may batch this with other queries
+    await mockTrpcQuery(page, "public.getConfig", {
+      registrationEnabled: false,
+      emailEnabled: false,
+      oauthEnabled: false,
+      ssoEnabled: false,
+    });
 
     const signInPage = new SignInPage(page);
     await signInPage.goto();

--- a/apps/e2e/tests/auth/sign-up.spec.ts
+++ b/apps/e2e/tests/auth/sign-up.spec.ts
@@ -3,6 +3,8 @@ import { SignInPage } from "../../page-objects/auth/sign-in.page.js";
 import { SignUpPage } from "../../page-objects/auth/sign-up.page.js";
 import { uniqueEmail } from "../../helpers/factories/user.factory.js";
 
+const apiUrl = process.env.API_URL || "http://localhost:3001";
+
 test.describe("User Registration @p0", () => {
   test("should register a new user successfully", async ({ page }) => {
     const signUpPage = new SignUpPage(page);
@@ -116,5 +118,76 @@ test.describe("User Registration @p0", () => {
     await signInPage.goto();
     await signInPage.login(email, password);
     await signInPage.expectErrorMessage(/verify your email|email not verified|not verified/i);
+  });
+
+  test("should show registration disabled message when registration is off", async ({
+    page,
+  }) => {
+    // Intercept public.getConfig to simulate registration disabled
+    await page.route(`${apiUrl}/trpc/public.getConfig*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          result: {
+            data: {
+              registrationEnabled: false,
+              emailEnabled: false,
+              oauthEnabled: false,
+              ssoEnabled: false,
+            },
+          },
+        }),
+      })
+    );
+
+    await page.goto("/auth/sign-up");
+    await page.waitForLoadState("domcontentloaded");
+
+    // Should show "Registration Disabled" message
+    await expect(
+      page.getByText(/registration disabled/i).first()
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Registration form should NOT be visible
+    await expect(
+      page.getByRole("button", { name: /create account/i })
+    ).not.toBeVisible();
+
+    // Should have a "Go to Sign In" button
+    await expect(
+      page.getByRole("button", { name: /go to sign in/i })
+    ).toBeVisible();
+  });
+
+  test("should reject registration at API level when disabled @selfhosted", async () => {
+    test.skip(
+      process.env.DEPLOYMENT_MODE === "cloud",
+      "Selfhosted mode only"
+    );
+
+    // In the default E2E config, registration IS enabled.
+    // This test verifies the API shape; the actual guard is tested via
+    // the route intercept test above for UI and integration tests
+    // with ENABLE_REGISTRATION=false for full end-to-end.
+    const response = await fetch(`${apiUrl}/trpc/auth.registration.register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "test-reg-check@e2e-test.local",
+        password: "SecurePass123!",
+        firstName: "Test",
+        lastName: "Check",
+        acceptTerms: true,
+      }),
+    });
+
+    // With registration enabled (default), this should succeed (200) or
+    // fail for other reasons (duplicate email, etc.) — NOT 403 FORBIDDEN
+    const body = await response.json();
+    if (body.error) {
+      // If there's an error, it should NOT be the registration disabled error
+      expect(body.error.message).not.toMatch(/registration.*disabled/i);
+    }
   });
 });

--- a/apps/e2e/tests/auth/sign-up.spec.ts
+++ b/apps/e2e/tests/auth/sign-up.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../../fixtures/test-base.js";
+import { mockTrpcQuery } from "../../helpers/trpc-mock.js";
 import { SignInPage } from "../../page-objects/auth/sign-in.page.js";
 import { SignUpPage } from "../../page-objects/auth/sign-up.page.js";
 import { uniqueEmail } from "../../helpers/factories/user.factory.js";
@@ -124,22 +125,13 @@ test.describe("User Registration @p0", () => {
     page,
   }) => {
     // Intercept public.getConfig to simulate registration disabled
-    await page.route(`${apiUrl}/trpc/public.getConfig*`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          result: {
-            data: {
-              registrationEnabled: false,
-              emailEnabled: false,
-              oauthEnabled: false,
-              ssoEnabled: false,
-            },
-          },
-        }),
-      })
-    );
+    // Uses batch-aware helper because tRPC httpBatchLink may batch this with other queries
+    await mockTrpcQuery(page, "public.getConfig", {
+      registrationEnabled: false,
+      emailEnabled: false,
+      oauthEnabled: false,
+      ssoEnabled: false,
+    });
 
     await page.goto("/auth/sign-up");
     await page.waitForLoadState("domcontentloaded");

--- a/apps/e2e/tests/auth/sign-up.spec.ts
+++ b/apps/e2e/tests/auth/sign-up.spec.ts
@@ -165,11 +165,11 @@ test.describe("User Registration @p0", () => {
       process.env.DEPLOYMENT_MODE === "cloud",
       "Selfhosted mode only"
     );
+    test.skip(
+      process.env.ENABLE_REGISTRATION !== "false",
+      "Requires ENABLE_REGISTRATION=false to validate the API guard"
+    );
 
-    // In the default E2E config, registration IS enabled.
-    // This test verifies the API shape; the actual guard is tested via
-    // the route intercept test above for UI and integration tests
-    // with ENABLE_REGISTRATION=false for full end-to-end.
     const response = await fetch(`${apiUrl}/trpc/auth.registration.register`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -182,12 +182,9 @@ test.describe("User Registration @p0", () => {
       }),
     });
 
-    // With registration enabled (default), this should succeed (200) or
-    // fail for other reasons (duplicate email, etc.) — NOT 403 FORBIDDEN
     const body = await response.json();
-    if (body.error) {
-      // If there's an error, it should NOT be the registration disabled error
-      expect(body.error.message).not.toMatch(/registration.*disabled/i);
-    }
+    // Registration should be rejected with FORBIDDEN
+    expect(body.error).toBeDefined();
+    expect(body.error.data?.code).toBe("FORBIDDEN");
   });
 });

--- a/apps/e2e/tests/smoke/public-config.spec.ts
+++ b/apps/e2e/tests/smoke/public-config.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+const apiUrl = process.env.API_URL || "http://localhost:3001";
+
+test.describe("Public Config Endpoint @p0 @smoke", () => {
+  test("should return app configuration flags", async () => {
+    const response = await fetch(`${apiUrl}/trpc/public.getConfig`);
+    expect(response.ok).toBeTruthy();
+
+    const body = await response.json();
+    const config = body.result?.data;
+
+    expect(config).toBeDefined();
+    expect(typeof config.registrationEnabled).toBe("boolean");
+    expect(typeof config.emailEnabled).toBe("boolean");
+    expect(typeof config.oauthEnabled).toBe("boolean");
+    expect(typeof config.ssoEnabled).toBe("boolean");
+  });
+
+  test("should reflect selfhosted defaults @selfhosted", async () => {
+    test.skip(
+      process.env.DEPLOYMENT_MODE === "cloud",
+      "Selfhosted mode only"
+    );
+
+    const response = await fetch(`${apiUrl}/trpc/public.getConfig`);
+    const body = await response.json();
+    const config = body.result?.data;
+
+    // Selfhosted E2E defaults: email disabled, registration enabled
+    expect(config.emailEnabled).toBe(false);
+    expect(config.registrationEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Admin bootstrap via setup CLI**: `./qarote setup` now prompts for admin email/password. On first boot, the server creates the admin user + workspace in a transaction, then auto-removes credentials from `.env`
- **Registration toggle**: New `ENABLE_REGISTRATION` config (default: true). When disabled, the sign-up page shows a "Registration Disabled" message and the sign-in page hides the "create account" link. Invitation-based signups still work
- **Invite links without SMTP**: Invitation API now returns `inviteUrl` and `emailSent`. When email is disabled, a toast with a "Copy Link" action appears. Pending invitations table has a copy-link button
- **Subscription bug fix**: `public/invitation.ts` getDetails no longer throws when workspace owner has no Stripe subscription (always the case in self-hosted). Defaults to `FREE` plan
- **Public config endpoint**: New `public.getConfig` tRPC endpoint exposes `registrationEnabled`, `emailEnabled`, `oauthEnabled`, `ssoEnabled` for frontend discovery
- **E2E tests**: Added tests for public config endpoint, registration disabled UI (route interception), invitation API response with inviteUrl/emailSent, and invitation details without subscription
- **i18n**: All keys added for en, fr, es, zh (both API errors and frontend auth/profile)

## Test plan

- [ ] Run `./qarote setup` and verify admin email/password prompts appear
- [ ] Start server, verify admin can login without email verification
- [ ] Restart server, verify no duplicate admin created and `.env` cleaned
- [ ] Set `ENABLE_REGISTRATION=false`, verify signup page shows disabled message
- [ ] Verify sign-in page hides "create account" link when registration disabled
- [ ] Verify invitation acceptance still works when registration disabled
- [ ] With `ENABLE_EMAIL=false`, send invitation and verify copy-link toast appears
- [ ] Verify copy-link button on pending invitations table
- [ ] Verify invitation page loads for self-hosted admin with no Stripe subscription
- [ ] Run `pnpm turbo run typecheck` — passes
- [ ] Run E2E tests — new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-controlled toggle for public sign-ups; admin bootstrap on first setup
  * Public config endpoint exposing registration and auth flags
  * Invite link copy-to-clipboard for easy sharing when email is unavailable

* **Improvements**
  * Sign-in/sign-up UI and toasts reflect registration setting
  * Localized "registration disabled" messages across languages
  * Invitations include invite URL and emailSent status; email sending respects config

* **Tests**
  * New e2e and smoke tests covering public config and disabled-registration scenarios, plus query-mocking helper
<!-- end of auto-generated comment: release notes by coderabbit.ai -->