### PR TITLE
fix: resolve self-hosted plan to license tier instead of always free

### DIFF
--- a/apps/api/src/core/feature-flags.ts
+++ b/apps/api/src/core/feature-flags.ts
@@ -38,7 +38,7 @@ export function invalidateLicenseCache(): void {
 /**
  * Get the current license payload from DB, with caching
  */
-async function getLicensePayload(): Promise<LicenseJwtPayload | null> {
+export async function getLicensePayload(): Promise<LicenseJwtPayload | null> {
   const now = Date.now();
 
   // Return cached value if still fresh and not expired

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -68,13 +68,15 @@ app.use("*", secureHeaders());
 app.use("*", requestIdMiddleware);
 app.use("*", performanceMonitoring);
 app.use("*", corsMiddleware);
-app.use("*", standardRateLimiter);
 
 // Mount webhook app BEFORE other routes to ensure it's processed first
 app.route("/webhooks", webhookApp);
 
 // Mount SSO routes (SAML ACS needs form-encoded body access)
 app.route("/sso", ssoApp);
+
+// Rate limit API routes only (not static assets/locales/SPA files)
+app.use("/trpc/*", standardRateLimiter);
 
 // Mount tRPC router
 app.use(

--- a/apps/api/src/trpc/routers/workspace/__tests__/plan.test.ts
+++ b/apps/api/src/trpc/routers/workspace/__tests__/plan.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LicenseJwtPayload } from "@/services/license/license.interfaces";
+
+import { UserPlan } from "@/generated/prisma/client";
+
+// --- Mocks ---
+
+const mockUserFindUnique = vi.fn();
+const mockSubscriptionFindUnique = vi.fn();
+const mockWorkspaceCount = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: { findUnique: (...args: unknown[]) => mockUserFindUnique(...args) },
+    subscription: {
+      findUnique: (...args: unknown[]) => mockSubscriptionFindUnique(...args),
+    },
+    workspace: {
+      count: (...args: unknown[]) => mockWorkspaceCount(...args),
+    },
+  },
+}));
+
+const mockGetLicensePayload = vi.fn();
+vi.mock("@/core/feature-flags", () => ({
+  getLicensePayload: (...args: unknown[]) => mockGetLicensePayload(...args),
+  invalidateLicenseCache: vi.fn(),
+}));
+
+let mockSelfHostedMode = false;
+vi.mock("@/config/deployment", () => ({
+  isSelfHostedMode: () => mockSelfHostedMode,
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock rate limiter to be a passthrough
+vi.mock("../../../middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+// Mock workspace middleware
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+// Import after mocks
+const { planRouter } = await import("../plan");
+
+// --- Helpers ---
+
+const validPayload: LicenseJwtPayload = {
+  sub: "lic-test-123",
+  tier: UserPlan.DEVELOPER,
+  features: ["alerting", "workspace_management", "data_export"],
+  iss: "qarote",
+  iat: Math.floor(Date.now() / 1000),
+  exp: Math.floor(Date.now() / 1000) + 3600,
+};
+
+function makeCtx() {
+  return {
+    prisma: {
+      user: { findUnique: mockUserFindUnique },
+      subscription: { findUnique: mockSubscriptionFindUnique },
+      workspace: { count: mockWorkspaceCount },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      role: "ADMIN",
+      isActive: true,
+      email: "admin@test.com",
+    },
+    workspaceId: "ws-1",
+    locale: "en",
+    req: {},
+  };
+}
+
+function mockUserWithWorkspace(overrides?: {
+  subscriptionPlan?: UserPlan;
+  ownerId?: string;
+  memberCount?: number;
+  serverCount?: number;
+}) {
+  const {
+    subscriptionPlan,
+    ownerId = "user-1",
+    memberCount = 1,
+    serverCount = 0,
+  } = overrides || {};
+
+  mockUserFindUnique.mockResolvedValue({
+    id: "user-1",
+    email: "admin@test.com",
+    subscription: subscriptionPlan
+      ? { plan: subscriptionPlan, status: "ACTIVE" }
+      : null,
+    workspace: {
+      id: "ws-1",
+      name: "Test Workspace",
+      ownerId,
+      _count: { members: memberCount, servers: serverCount },
+    },
+  });
+}
+
+// --- Tests ---
+
+describe("planRouter.getCurrentPlan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelfHostedMode = false;
+    mockWorkspaceCount.mockResolvedValue(1);
+    mockSubscriptionFindUnique.mockResolvedValue(null);
+  });
+
+  it("returns FREE plan when no subscription and not self-hosted", async () => {
+    mockUserWithWorkspace();
+
+    const caller = planRouter.createCaller(makeCtx() as never);
+    const result = await caller.getCurrentPlan();
+
+    expect(result.user.plan).toBe(UserPlan.FREE);
+    expect(result.planFeatures.displayName).toBe("Free");
+  });
+
+  it("returns subscription plan when Stripe subscription exists", async () => {
+    mockUserWithWorkspace({ subscriptionPlan: UserPlan.ENTERPRISE });
+    mockSubscriptionFindUnique.mockResolvedValue({
+      plan: UserPlan.ENTERPRISE,
+      status: "ACTIVE",
+    });
+
+    const caller = planRouter.createCaller(makeCtx() as never);
+    const result = await caller.getCurrentPlan();
+
+    expect(result.user.plan).toBe(UserPlan.ENTERPRISE);
+    expect(result.planFeatures.displayName).toBe("Enterprise");
+  });
+
+  describe("self-hosted license fallback", () => {
+    beforeEach(() => {
+      mockSelfHostedMode = true;
+    });
+
+    it("uses license JWT tier when no Stripe subscription exists", async () => {
+      mockUserWithWorkspace();
+      mockGetLicensePayload.mockResolvedValue(validPayload);
+
+      const caller = planRouter.createCaller(makeCtx() as never);
+      const result = await caller.getCurrentPlan();
+
+      expect(result.user.plan).toBe(UserPlan.DEVELOPER);
+      expect(result.planFeatures.displayName).toBe("Developer");
+      expect(result.planFeatures.maxServers).toBe(2);
+      expect(result.planFeatures.canInviteUsers).toBe(true);
+    });
+
+    it("uses ENTERPRISE tier from license JWT", async () => {
+      mockUserWithWorkspace();
+      mockGetLicensePayload.mockResolvedValue({
+        ...validPayload,
+        tier: UserPlan.ENTERPRISE,
+      });
+
+      const caller = planRouter.createCaller(makeCtx() as never);
+      const result = await caller.getCurrentPlan();
+
+      expect(result.user.plan).toBe(UserPlan.ENTERPRISE);
+      expect(result.planFeatures.displayName).toBe("Enterprise");
+      expect(result.planFeatures.maxServers).toBeNull(); // unlimited
+      expect(result.planFeatures.hasPrioritySupport).toBe(true);
+    });
+
+    it("stays FREE when no license JWT exists", async () => {
+      mockUserWithWorkspace();
+      mockGetLicensePayload.mockResolvedValue(null);
+
+      const caller = planRouter.createCaller(makeCtx() as never);
+      const result = await caller.getCurrentPlan();
+
+      expect(result.user.plan).toBe(UserPlan.FREE);
+      expect(result.planFeatures.displayName).toBe("Free");
+    });
+
+    it("prefers Stripe subscription over license JWT", async () => {
+      mockUserWithWorkspace({ subscriptionPlan: UserPlan.ENTERPRISE });
+      mockSubscriptionFindUnique.mockResolvedValue({
+        plan: UserPlan.ENTERPRISE,
+        status: "ACTIVE",
+      });
+      // License says DEVELOPER, but Stripe says ENTERPRISE
+      mockGetLicensePayload.mockResolvedValue(validPayload);
+
+      const caller = planRouter.createCaller(makeCtx() as never);
+      const result = await caller.getCurrentPlan();
+
+      // Should use Stripe subscription (ENTERPRISE), not license (DEVELOPER)
+      expect(result.user.plan).toBe(UserPlan.ENTERPRISE);
+      // getLicensePayload should not even be called since subscription exists
+      expect(mockGetLicensePayload).not.toHaveBeenCalled();
+    });
+
+    it("returns correct usage limits for DEVELOPER license", async () => {
+      mockUserWithWorkspace({ serverCount: 1 });
+      mockGetLicensePayload.mockResolvedValue(validPayload);
+
+      const caller = planRouter.createCaller(makeCtx() as never);
+      const result = await caller.getCurrentPlan();
+
+      expect(result.usage.servers.current).toBe(1);
+      expect(result.usage.servers.limit).toBe(2);
+      expect(result.usage.servers.canAdd).toBe(true);
+      expect(result.usage.users.limit).toBe(2);
+    });
+
+    it("does not use license fallback in cloud mode", async () => {
+      mockSelfHostedMode = false;
+      mockUserWithWorkspace();
+      mockGetLicensePayload.mockResolvedValue(validPayload);
+
+      const caller = planRouter.createCaller(makeCtx() as never);
+      const result = await caller.getCurrentPlan();
+
+      expect(result.user.plan).toBe(UserPlan.FREE);
+      expect(mockGetLicensePayload).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/workspace/plan.ts
+++ b/apps/api/src/trpc/routers/workspace/plan.ts
@@ -1,6 +1,10 @@
 import { TRPCError } from "@trpc/server";
 
+import { getLicensePayload } from "@/core/feature-flags";
+
 import { getPlanFeatures, PLAN_FEATURES } from "@/services/plan/plan.service";
+
+import { isSelfHostedMode } from "@/config/deployment";
 
 import { rateLimitedProcedure, router } from "@/trpc/trpc";
 
@@ -87,6 +91,14 @@ export const planRouter = router({
 
         if (ownerSubscription) {
           workspacePlan = ownerSubscription.plan;
+        }
+      }
+
+      // Self-hosted fallback: if no Stripe subscription exists, use the license JWT tier
+      if (workspacePlan === UserPlan.FREE && isSelfHostedMode()) {
+        const licensePayload = await getLicensePayload();
+        if (licensePayload) {
+          workspacePlan = licensePayload.tier;
         }
       }
 

--- a/apps/e2e/tests/license/license-plan-resolution.spec.ts
+++ b/apps/e2e/tests/license/license-plan-resolution.spec.ts
@@ -93,9 +93,8 @@ test.describe("License Plan Resolution @p1", () => {
 
     // Click the Plans tab
     const plansTab = adminPage.getByRole("tab", { name: /plans/i });
-    if (await plansTab.isVisible()) {
-      await plansTab.click();
-    }
+    await expect(plansTab).toBeVisible();
+    await plansTab.click();
 
     // Should NOT show "Unlock premium features" prompt
     await expect(

--- a/apps/e2e/tests/license/license-plan-resolution.spec.ts
+++ b/apps/e2e/tests/license/license-plan-resolution.spec.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { test, expect } from "../../fixtures/test-base.js";
+import {
+  generateTestLicenseJwt,
+  ALL_PREMIUM_FEATURES,
+} from "../../helpers/license.js";
+
+const AUTH_TOKENS_FILE = path.resolve(
+  import.meta.dirname,
+  "../../.auth-tokens.json"
+);
+
+function getAdminToken(): string {
+  const raw = fs.readFileSync(AUTH_TOKENS_FILE, "utf-8");
+  const tokens = JSON.parse(raw);
+  return tokens["admin@e2e-test.local"].token;
+}
+
+test.describe("License Plan Resolution @p1", () => {
+  // Ensure no license is active before each test
+  test.beforeEach(async ({ db }) => {
+    await db.clearSystemSetting("license_jwt");
+  });
+
+  // Clean up after each test
+  test.afterEach(async ({ db }) => {
+    await db.clearSystemSetting("license_jwt");
+  });
+
+  test("should show Free plan badge when no license is active", async ({
+    adminPage,
+  }) => {
+    await adminPage.goto("/");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    // PlanBadge should display "Free"
+    await expect(adminPage.getByText("Free")).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("should show Developer plan badge after DEVELOPER license activation", async ({
+    adminPage,
+    api,
+  }) => {
+    // Activate a DEVELOPER license via API
+    const jwt = await generateTestLicenseJwt({
+      tier: "DEVELOPER",
+      features: ALL_PREMIUM_FEATURES,
+    });
+    const token = getAdminToken();
+    await api
+      .withAuth(token)
+      .mutation("selfhostedLicense.activate", { licenseKey: jwt });
+
+    // Navigate to dashboard
+    await adminPage.goto("/");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    // PlanBadge should display "Developer" instead of "Free"
+    await expect(adminPage.getByText("Developer")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("should not show 'Unlock premium features' after license activation", async ({
+    adminPage,
+    api,
+  }) => {
+    // Activate a DEVELOPER license via API
+    const jwt = await generateTestLicenseJwt({
+      tier: "DEVELOPER",
+      features: ALL_PREMIUM_FEATURES,
+    });
+    const token = getAdminToken();
+    await api
+      .withAuth(token)
+      .mutation("selfhostedLicense.activate", { licenseKey: jwt });
+
+    // Navigate to profile plans tab
+    await adminPage.goto("/settings/profile");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    // Click the Plans tab
+    const plansTab = adminPage.getByRole("tab", { name: /plans/i });
+    if (await plansTab.isVisible()) {
+      await plansTab.click();
+    }
+
+    // Should NOT show "Unlock premium features" prompt
+    await expect(
+      adminPage.getByText(/unlock premium features/i)
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("should show correct plan features for DEVELOPER license", async ({
+    api,
+  }) => {
+    // Activate a DEVELOPER license via API
+    const jwt = await generateTestLicenseJwt({
+      tier: "DEVELOPER",
+      features: ALL_PREMIUM_FEATURES,
+    });
+    const token = getAdminToken();
+    await api
+      .withAuth(token)
+      .mutation("selfhostedLicense.activate", { licenseKey: jwt });
+
+    // Query getCurrentPlan directly to verify API returns DEVELOPER
+    const planData = await api
+      .withAuth(token)
+      .query("workspace.plan.getCurrentPlan");
+
+    expect(planData.user.plan).toBe("DEVELOPER");
+    expect(planData.planFeatures.displayName).toBe("Developer");
+    expect(planData.planFeatures.maxServers).toBe(2);
+    expect(planData.planFeatures.canInviteUsers).toBe(true);
+  });
+
+  test("should revert to Free plan after license deactivation", async ({
+    api,
+  }) => {
+    const token = getAdminToken();
+
+    // Activate a DEVELOPER license
+    const jwt = await generateTestLicenseJwt({
+      tier: "DEVELOPER",
+      features: ALL_PREMIUM_FEATURES,
+    });
+    await api
+      .withAuth(token)
+      .mutation("selfhostedLicense.activate", { licenseKey: jwt });
+
+    // Verify plan is DEVELOPER
+    let planData = await api
+      .withAuth(token)
+      .query("workspace.plan.getCurrentPlan");
+    expect(planData.user.plan).toBe("DEVELOPER");
+
+    // Deactivate
+    await api
+      .withAuth(token)
+      .mutation("selfhostedLicense.deactivate", {});
+
+    // Verify plan reverts to FREE
+    planData = await api
+      .withAuth(token)
+      .query("workspace.plan.getCurrentPlan");
+    expect(planData.user.plan).toBe("FREE");
+    expect(planData.planFeatures.displayName).toBe("Free");
+  });
+
+  test("should show Enterprise plan for ENTERPRISE license", async ({
+    api,
+  }) => {
+    const jwt = await generateTestLicenseJwt({
+      tier: "ENTERPRISE",
+      features: ALL_PREMIUM_FEATURES,
+    });
+    const token = getAdminToken();
+    await api
+      .withAuth(token)
+      .mutation("selfhostedLicense.activate", { licenseKey: jwt });
+
+    const planData = await api
+      .withAuth(token)
+      .query("workspace.plan.getCurrentPlan");
+
+    expect(planData.user.plan).toBe("ENTERPRISE");
+    expect(planData.planFeatures.displayName).toBe("Enterprise");
+    expect(planData.planFeatures.maxServers).toBeNull(); // unlimited
+    expect(planData.planFeatures.hasPrioritySupport).toBe(true);
+  });
+});

--- a/apps/e2e/tests/license/license-plan-resolution.spec.ts
+++ b/apps/e2e/tests/license/license-plan-resolution.spec.ts
@@ -19,13 +19,23 @@ function getAdminToken(): string {
 }
 
 test.describe("License Plan Resolution @p1", () => {
-  // Ensure no license is active before each test
-  test.beforeEach(async ({ db }) => {
+  // Deactivate via API to invalidate the in-memory license cache (60s TTL),
+  // then clear DB as a safety net.
+  test.beforeEach(async ({ api, db }) => {
+    const token = getAdminToken();
+    await api
+      .withAuth(token)
+      .mutation("selfhostedLicense.deactivate", {})
+      .catch(() => {});
     await db.clearSystemSetting("license_jwt");
   });
 
-  // Clean up after each test
-  test.afterEach(async ({ db }) => {
+  test.afterEach(async ({ api, db }) => {
+    const token = getAdminToken();
+    await api
+      .withAuth(token)
+      .mutation("selfhostedLicense.deactivate", {})
+      .catch(() => {});
     await db.clearSystemSetting("license_jwt");
   });
 


### PR DESCRIPTION
## Summary
- **Root cause**: The plan system (`getCurrentPlan`) and license system (`feature-flags`) were independent — activating a license enabled premium features via feature flags, but the plan always returned `FREE` because it only checked the Stripe `Subscription` table (which is never populated in self-hosted mode).
- **Fix**: `getCurrentPlan` now falls back to the license JWT's `tier` field when no Stripe subscription exists and the app is in self-hosted mode.
- **Bonus**: Scoped the rate limiter from global `app.use("*")` to `app.use("/trpc/*")` only — it was previously 429-blocking static assets and SPA files.

## Changes
- `apps/api/src/core/feature-flags.ts` — Export `getLicensePayload()` so plan router can access it
- `apps/api/src/trpc/routers/workspace/plan.ts` — Add self-hosted license fallback in `getCurrentPlan`
- `apps/api/src/server.ts` — Scope rate limiter to `/trpc/*` routes only
- `apps/api/src/trpc/routers/workspace/__tests__/plan.test.ts` — 8 unit tests for plan resolution logic
- `apps/e2e/tests/license/license-plan-resolution.spec.ts` — 6 E2E tests for plan display after license activation/deactivation

## Test plan
- [x] Unit tests: 8 new tests covering FREE default, Stripe subscription, self-hosted DEVELOPER/ENTERPRISE fallback, no-license fallback, Stripe-over-license priority, cloud mode no-fallback
- [x] E2E tests: 6 new tests covering Free badge without license, Developer badge after activation, upgrade prompt hidden, API plan response, revert on deactivation, Enterprise license
- [x] All 116 related unit tests pass
- [x] Type check passes
- [x] Lint + knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-hosted deployments can use license JWTs as a fallback to determine workspace plans, enabling automatic plan upgrades to Developer/Enterprise without a Stripe subscription.
* **Infrastructure**
  * Rate limiting scope narrowed to API/trpc routes, excluding static assets, locales, and SPA files.
* **Tests**
  * Added comprehensive unit and end-to-end tests validating license plan resolution, UI badges, activation/deactivation flows, and backend consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->