### PR TITLE
feat: allow free trial without credit card and add payment method ui

### DIFF
--- a/apps/api/locales/en/emails.json
+++ b/apps/api/locales/en/emails.json
@@ -118,7 +118,7 @@
   "trialEnding": {
     "title": "Your trial is ending soon",
     "body": "Your <strong>{{plan}}</strong> trial for <strong>{{workspaceName}}</strong> will end soon. {{usageText}}",
-    "upgradeCta": "Upgrade Now",
+    "upgradeCta": "Add Payment Method",
     "keepAccess": "Upgrade now to keep access to all features."
   },
   "upgradeConfirmation": {

--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -113,6 +113,8 @@
     "failedToCreatePortalSession": "Failed to create portal session",
     "cannotCheckoutFreePlan": "Cannot create checkout for FREE plan",
     "failedToCreateCheckoutSession": "Failed to create checkout session",
+    "alreadyHasSubscription": "You already have an active subscription",
+    "failedToStartTrial": "Failed to start free trial",
     "noActiveSubscription": "No active subscription found",
     "failedToCancelSubscription": "Failed to cancel subscription",
     "planRequired": "Plan is required",

--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -118,7 +118,8 @@
     "noActiveSubscription": "No active subscription found",
     "failedToCancelSubscription": "Failed to cancel subscription",
     "planRequired": "Plan is required",
-    "failedToRenewSubscription": "Failed to renew subscription"
+    "failedToRenewSubscription": "Failed to renew subscription",
+    "allWorkspaces": "your workspaces"
   },
   "license": {
     "validationFailed": "License validation failed",

--- a/apps/api/locales/es/emails.json
+++ b/apps/api/locales/es/emails.json
@@ -118,7 +118,7 @@
   "trialEnding": {
     "title": "Tu período de prueba termina pronto",
     "body": "Tu período de prueba de <strong>{{plan}}</strong> para <strong>{{workspaceName}}</strong> terminará pronto. {{usageText}}",
-    "upgradeCta": "Actualizar ahora",
+    "upgradeCta": "Agregar método de pago",
     "keepAccess": "Actualiza ahora para mantener el acceso a todas las funcionalidades."
   },
   "upgradeConfirmation": {

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -119,7 +119,8 @@
     "noActiveSubscription": "No se encontró una suscripción activa",
     "failedToCancelSubscription": "Error al cancelar la suscripción",
     "planRequired": "El plan es obligatorio",
-    "failedToRenewSubscription": "Error al renovar la suscripción"
+    "failedToRenewSubscription": "Error al renovar la suscripción",
+    "allWorkspaces": "todos tus espacios de trabajo"
   },
   "license": {
     "validationFailed": "Error en la validación de la licencia",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -114,6 +114,8 @@
     "failedToCreatePortalSession": "Error al crear la sesión del portal",
     "cannotCheckoutFreePlan": "No se puede crear un pago para el plan GRATUITO",
     "failedToCreateCheckoutSession": "Error al crear la sesión de pago",
+    "alreadyHasSubscription": "Ya tienes una suscripción activa",
+    "failedToStartTrial": "Error al iniciar la prueba gratuita",
     "noActiveSubscription": "No se encontró una suscripción activa",
     "failedToCancelSubscription": "Error al cancelar la suscripción",
     "planRequired": "El plan es obligatorio",

--- a/apps/api/locales/fr/emails.json
+++ b/apps/api/locales/fr/emails.json
@@ -118,7 +118,7 @@
   "trialEnding": {
     "title": "Votre essai se termine bientôt",
     "body": "Votre essai <strong>{{plan}}</strong> pour <strong>{{workspaceName}}</strong> se termine bientôt. {{usageText}}",
-    "upgradeCta": "Passer à la version supérieure",
+    "upgradeCta": "Ajouter un moyen de paiement",
     "keepAccess": "Passez à la version supérieure dès maintenant pour conserver l'accès à toutes les fonctionnalités."
   },
   "upgradeConfirmation": {

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -119,7 +119,8 @@
     "noActiveSubscription": "Aucun abonnement actif trouvé",
     "failedToCancelSubscription": "Échec de l'annulation de l'abonnement",
     "planRequired": "Le plan est requis",
-    "failedToRenewSubscription": "Échec du renouvellement de l'abonnement"
+    "failedToRenewSubscription": "Échec du renouvellement de l'abonnement",
+    "allWorkspaces": "tous vos espaces de travail"
   },
   "license": {
     "validationFailed": "Échec de la validation de la licence",

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -114,6 +114,8 @@
     "failedToCreatePortalSession": "Échec de la création de la session du portail",
     "cannotCheckoutFreePlan": "Impossible de créer un paiement pour le plan GRATUIT",
     "failedToCreateCheckoutSession": "Échec de la création de la session de paiement",
+    "alreadyHasSubscription": "Vous avez déjà un abonnement actif",
+    "failedToStartTrial": "Échec du démarrage de l'essai gratuit",
     "noActiveSubscription": "Aucun abonnement actif trouvé",
     "failedToCancelSubscription": "Échec de l'annulation de l'abonnement",
     "planRequired": "Le plan est requis",

--- a/apps/api/locales/zh/emails.json
+++ b/apps/api/locales/zh/emails.json
@@ -118,7 +118,7 @@
   "trialEnding": {
     "title": "您的试用即将结束",
     "body": "您的 <strong>{{workspaceName}}</strong> 的 <strong>{{plan}}</strong> 试用即将结束。{{usageText}}",
-    "upgradeCta": "立即升级",
+    "upgradeCta": "添加支付方式",
     "keepAccess": "立即升级以保留对所有功能的访问权限。"
   },
   "upgradeConfirmation": {

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -114,6 +114,8 @@
     "failedToCreatePortalSession": "创建门户会话失败",
     "cannotCheckoutFreePlan": "无法为免费套餐创建结账",
     "failedToCreateCheckoutSession": "创建结账会话失败",
+    "alreadyHasSubscription": "您已有活跃的订阅",
+    "failedToStartTrial": "启动免费试用失败",
     "noActiveSubscription": "未找到活动的订阅",
     "failedToCancelSubscription": "取消订阅失败",
     "planRequired": "套餐为必填项",

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -119,7 +119,8 @@
     "noActiveSubscription": "未找到活动的订阅",
     "failedToCancelSubscription": "取消订阅失败",
     "planRequired": "套餐为必填项",
-    "failedToRenewSubscription": "续订失败"
+    "failedToRenewSubscription": "续订失败",
+    "allWorkspaces": "您的所有工作区"
   },
   "license": {
     "validationFailed": "许可证验证失败",

--- a/apps/api/src/services/email/templates/trial-ending-email.tsx
+++ b/apps/api/src/services/email/templates/trial-ending-email.tsx
@@ -79,8 +79,8 @@ export default function TrialEndingEmail({
 
             <Text style={contentStyles.paragraph}>
               To continue enjoying all the premium features and keep your
-              RabbitMQ monitoring uninterrupted, please upgrade your
-              subscription before your trial expires.
+              RabbitMQ monitoring uninterrupted, please add a payment method
+              before your trial expires.
             </Text>
 
             {/* Warning Section */}
@@ -125,9 +125,9 @@ export default function TrialEndingEmail({
             <Section style={buttonStyles.buttonSection}>
               <Button
                 style={buttonStyles.primaryButton}
-                href={`${frontendUrl}/profile?tab=plans`}
+                href={`${frontendUrl}/billing`}
               >
-                Upgrade Now
+                Add Payment Method
               </Button>
             </Section>
 

--- a/apps/api/src/services/stripe/customer.service.ts
+++ b/apps/api/src/services/stripe/customer.service.ts
@@ -102,6 +102,99 @@ export class StripeCustomerService {
   }
 
   /**
+   * Create a trial subscription directly without Stripe Checkout.
+   * No payment method is required — the subscription starts in "trialing" status.
+   * If no card is added before trial ends, Stripe auto-cancels the subscription.
+   */
+  static async createTrialSubscription({
+    customerId,
+    plan,
+    billingInterval,
+    trialDays,
+    userId,
+  }: {
+    customerId: string;
+    plan: UserPlan;
+    billingInterval: string;
+    trialDays: number;
+    userId: string;
+  }) {
+    try {
+      if (plan === UserPlan.FREE) {
+        throw new Error("Cannot create trial subscription for FREE plan");
+      }
+
+      if (!STRIPE_PRICE_IDS) {
+        throw new Error(
+          "Stripe is not configured. STRIPE_PRICE_IDS are required."
+        );
+      }
+
+      const priceId =
+        STRIPE_PRICE_IDS[plan][billingInterval as "monthly" | "yearly"];
+
+      logger.info(
+        { customerId, plan, billingInterval, trialDays, userId },
+        "Creating Stripe trial subscription directly"
+      );
+
+      const subscription = await retryWithBackoff(
+        () =>
+          stripe.subscriptions.create({
+            customer: customerId,
+            items: [{ price: priceId }],
+            trial_period_days: trialDays,
+            trial_settings: {
+              end_behavior: {
+                missing_payment_method: "cancel",
+              },
+            },
+            payment_behavior: "default_incomplete",
+            metadata: {
+              userId,
+              plan,
+              billingInterval,
+              trialDays: trialDays.toString(),
+            },
+          }),
+        {
+          maxRetries: 3,
+          retryDelayMs: 1_000,
+          timeoutMs: 10_000,
+        },
+        "stripe"
+      );
+
+      CoreStripeService.setSentryContext("stripe_trial_subscription", {
+        subscriptionId: subscription.id,
+        customerId,
+        userId,
+        plan,
+      });
+
+      logger.info(
+        {
+          subscriptionId: subscription.id,
+          customerId,
+          userId,
+          plan,
+          trialEnd: subscription.trial_end,
+        },
+        "Stripe trial subscription created successfully"
+      );
+
+      return subscription;
+    } catch (error) {
+      CoreStripeService.logStripeError(error, "create_trial_subscription", {
+        customerId,
+        userId,
+        plan,
+      });
+      throw error;
+    }
+  }
+
+  /**
    * Create a checkout session
    */
   static async createCheckoutSession({
@@ -161,9 +254,20 @@ export class StripeCustomerService {
             ...(trialDays && { trialDays: trialDays.toString() }),
           },
           // Add trial period for early access users
-          ...(trialDays && { trial_period_days: trialDays }),
+          ...(trialDays && {
+            trial_period_days: trialDays,
+            trial_settings: {
+              end_behavior: {
+                missing_payment_method: "cancel",
+              },
+            },
+          }),
         },
         allow_promotion_codes: true,
+        // Allow users to start trial without entering a card
+        ...(trialDays && {
+          payment_method_collection: "if_required" as const,
+        }),
       };
 
       // Add customer email if provided

--- a/apps/api/src/services/stripe/customer.service.ts
+++ b/apps/api/src/services/stripe/customer.service.ts
@@ -11,7 +11,11 @@ import {
   STRIPE_PRICE_IDS,
 } from "./core.service";
 
-import { UserPlan } from "@/generated/prisma/client";
+import {
+  PrismaClient,
+  SubscriptionStatus,
+  UserPlan,
+} from "@/generated/prisma/client";
 
 export class StripeCustomerService {
   /**
@@ -317,5 +321,109 @@ export class StripeCustomerService {
       });
       throw error;
     }
+  }
+
+  /**
+   * Provision a full trial for a newly registered user.
+   * Creates Stripe customer + trial subscription + DB records.
+   * Returns null if Stripe is not configured (self-hosted mode).
+   * Does NOT send emails — caller decides.
+   */
+  static async provisionTrialForNewUser({
+    userId,
+    email,
+    name,
+    prisma,
+  }: {
+    userId: string;
+    email: string;
+    name: string;
+    prisma: PrismaClient;
+  }) {
+    // Skip if Stripe is not configured (self-hosted deployments)
+    if (!STRIPE_PRICE_IDS) {
+      return null;
+    }
+
+    const plan = UserPlan.ENTERPRISE;
+    const billingInterval = "monthly" as const;
+    const trialDays = 14;
+
+    logger.info({ userId, plan, trialDays }, "Provisioning trial for new user");
+
+    // Create Stripe customer
+    const customer = await StripeCustomerService.createCustomer({
+      email,
+      name,
+      userId,
+    });
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { stripeCustomerId: customer.id },
+    });
+
+    // Create trial subscription via Stripe API
+    const idempotencyKey = `auto_trial_${userId}`;
+    const subscription = await StripeCustomerService.createTrialSubscription({
+      customerId: customer.id,
+      plan,
+      billingInterval,
+      trialDays,
+      userId,
+      idempotencyKey,
+    });
+
+    // Update user with subscription ID
+    await prisma.user.update({
+      where: { id: userId },
+      data: { stripeSubscriptionId: subscription.id },
+    });
+
+    // Create subscription record in DB
+    const firstItem = subscription.items?.data?.[0];
+    const currentPeriodStart = firstItem?.current_period_start
+      ? new Date(firstItem.current_period_start * 1000)
+      : new Date();
+    const currentPeriodEnd = firstItem?.current_period_end
+      ? new Date(firstItem.current_period_end * 1000)
+      : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000);
+
+    const dbSubscription = await prisma.subscription.create({
+      data: {
+        userId,
+        stripeSubscriptionId: subscription.id,
+        stripePriceId: firstItem?.price?.id || "",
+        stripeCustomerId: customer.id,
+        plan,
+        status: SubscriptionStatus.TRIALING,
+        billingInterval:
+          CoreStripeService.mapStripeBillingIntervalToBillingInterval(
+            billingInterval
+          ),
+        pricePerMonth: firstItem?.price?.unit_amount || 0,
+        currentPeriodStart,
+        currentPeriodEnd,
+        trialStart: subscription.trial_start
+          ? new Date(subscription.trial_start * 1000)
+          : new Date(),
+        trialEnd: subscription.trial_end
+          ? new Date(subscription.trial_end * 1000)
+          : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000),
+        cancelAtPeriodEnd: false,
+      },
+    });
+
+    logger.info(
+      {
+        userId,
+        subscriptionId: dbSubscription.stripeSubscriptionId,
+        plan,
+        trialEnd: dbSubscription.trialEnd,
+      },
+      "Trial provisioned for new user"
+    );
+
+    return dbSubscription;
   }
 }

--- a/apps/api/src/services/stripe/customer.service.ts
+++ b/apps/api/src/services/stripe/customer.service.ts
@@ -112,12 +112,14 @@ export class StripeCustomerService {
     billingInterval,
     trialDays,
     userId,
+    idempotencyKey,
   }: {
     customerId: string;
     plan: UserPlan;
-    billingInterval: string;
+    billingInterval: "monthly" | "yearly";
     trialDays: number;
     userId: string;
+    idempotencyKey?: string;
   }) {
     try {
       if (plan === UserPlan.FREE) {
@@ -130,8 +132,7 @@ export class StripeCustomerService {
         );
       }
 
-      const priceId =
-        STRIPE_PRICE_IDS[plan][billingInterval as "monthly" | "yearly"];
+      const priceId = STRIPE_PRICE_IDS[plan][billingInterval];
 
       logger.info(
         { customerId, plan, billingInterval, trialDays, userId },
@@ -140,23 +141,26 @@ export class StripeCustomerService {
 
       const subscription = await retryWithBackoff(
         () =>
-          stripe.subscriptions.create({
-            customer: customerId,
-            items: [{ price: priceId }],
-            trial_period_days: trialDays,
-            trial_settings: {
-              end_behavior: {
-                missing_payment_method: "cancel",
+          stripe.subscriptions.create(
+            {
+              customer: customerId,
+              items: [{ price: priceId }],
+              trial_period_days: trialDays,
+              trial_settings: {
+                end_behavior: {
+                  missing_payment_method: "cancel",
+                },
+              },
+              payment_behavior: "default_incomplete",
+              metadata: {
+                userId,
+                plan,
+                billingInterval,
+                trialDays: trialDays.toString(),
               },
             },
-            payment_behavior: "default_incomplete",
-            metadata: {
-              userId,
-              plan,
-              billingInterval,
-              trialDays: trialDays.toString(),
-            },
-          }),
+            idempotencyKey ? { idempotencyKey } : undefined
+          ),
         {
           maxRetries: 3,
           retryDelayMs: 1_000,

--- a/apps/api/src/services/stripe/customer.service.ts
+++ b/apps/api/src/services/stripe/customer.service.ts
@@ -68,6 +68,27 @@ export class StripeCustomerService {
   }
 
   /**
+   * Retrieve a Stripe customer
+   */
+  static async getCustomer(customerId: string) {
+    try {
+      const customer = await retryWithBackoff(
+        () => stripe.customers.retrieve(customerId),
+        {
+          maxRetries: 3,
+          retryDelayMs: 1_000,
+          timeoutMs: 10_000,
+        },
+        "stripe"
+      );
+      return customer;
+    } catch (error) {
+      CoreStripeService.logStripeError(error, "get_customer", { customerId });
+      throw error;
+    }
+  }
+
+  /**
    * Create a billing portal session
    */
   static async createPortalSession(customerId: string, returnUrl: string) {

--- a/apps/api/src/services/stripe/customer.service.ts
+++ b/apps/api/src/services/stripe/customer.service.ts
@@ -351,22 +351,32 @@ export class StripeCustomerService {
 
     logger.info({ userId, plan, trialDays }, "Provisioning trial for new user");
 
-    // Create Stripe customer
-    const customer = await StripeCustomerService.createCustomer({
-      email,
-      name,
-      userId,
+    // Reuse existing Stripe customer if one was already created (race condition guard)
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { stripeCustomerId: true },
     });
 
-    await prisma.user.update({
-      where: { id: userId },
-      data: { stripeCustomerId: customer.id },
-    });
+    let customerId = user.stripeCustomerId;
+    if (!customerId) {
+      const customer = await StripeCustomerService.createCustomer({
+        email,
+        name,
+        userId,
+      });
+      customerId = customer.id;
+
+      // Conditional write: only set if still null (avoids overwriting concurrent request)
+      await prisma.user.updateMany({
+        where: { id: userId, stripeCustomerId: null },
+        data: { stripeCustomerId: customerId },
+      });
+    }
 
     // Create trial subscription via Stripe API
     const idempotencyKey = `auto_trial_${userId}`;
     const subscription = await StripeCustomerService.createTrialSubscription({
-      customerId: customer.id,
+      customerId,
       plan,
       billingInterval,
       trialDays,
@@ -380,7 +390,7 @@ export class StripeCustomerService {
       data: { stripeSubscriptionId: subscription.id },
     });
 
-    // Create subscription record in DB
+    // Upsert subscription record (idempotent against duplicate events/retries)
     const firstItem = subscription.items?.data?.[0];
     const currentPeriodStart = firstItem?.current_period_start
       ? new Date(firstItem.current_period_start * 1000)
@@ -389,28 +399,41 @@ export class StripeCustomerService {
       ? new Date(firstItem.current_period_end * 1000)
       : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000);
 
-    const dbSubscription = await prisma.subscription.create({
-      data: {
-        userId,
-        stripeSubscriptionId: subscription.id,
-        stripePriceId: firstItem?.price?.id || "",
-        stripeCustomerId: customer.id,
-        plan,
-        status: SubscriptionStatus.TRIALING,
-        billingInterval:
-          CoreStripeService.mapStripeBillingIntervalToBillingInterval(
-            billingInterval
-          ),
-        pricePerMonth: firstItem?.price?.unit_amount || 0,
-        currentPeriodStart,
-        currentPeriodEnd,
-        trialStart: subscription.trial_start
-          ? new Date(subscription.trial_start * 1000)
-          : new Date(),
-        trialEnd: subscription.trial_end
-          ? new Date(subscription.trial_end * 1000)
-          : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000),
-        cancelAtPeriodEnd: false,
+    const subscriptionData = {
+      userId,
+      stripeSubscriptionId: subscription.id,
+      stripePriceId: firstItem?.price?.id || "",
+      stripeCustomerId: customerId,
+      plan,
+      status: SubscriptionStatus.TRIALING,
+      billingInterval:
+        CoreStripeService.mapStripeBillingIntervalToBillingInterval(
+          billingInterval
+        ),
+      pricePerMonth: firstItem?.price?.unit_amount || 0,
+      currentPeriodStart,
+      currentPeriodEnd,
+      trialStart: subscription.trial_start
+        ? new Date(subscription.trial_start * 1000)
+        : new Date(),
+      trialEnd: subscription.trial_end
+        ? new Date(subscription.trial_end * 1000)
+        : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000),
+      cancelAtPeriodEnd: false,
+    };
+
+    const dbSubscription = await prisma.subscription.upsert({
+      where: { userId },
+      create: subscriptionData,
+      update: {
+        stripeSubscriptionId: subscriptionData.stripeSubscriptionId,
+        stripePriceId: subscriptionData.stripePriceId,
+        stripeCustomerId: subscriptionData.stripeCustomerId,
+        status: subscriptionData.status,
+        trialStart: subscriptionData.trialStart,
+        trialEnd: subscriptionData.trialEnd,
+        currentPeriodStart: subscriptionData.currentPeriodStart,
+        currentPeriodEnd: subscriptionData.currentPeriodEnd,
       },
     });
 

--- a/apps/api/src/services/stripe/stripe.service.ts
+++ b/apps/api/src/services/stripe/stripe.service.ts
@@ -39,6 +39,8 @@ export class StripeService {
   static createCheckoutSession = StripeCustomerService.createCheckoutSession;
   static createTrialSubscription =
     StripeCustomerService.createTrialSubscription;
+  static provisionTrialForNewUser =
+    StripeCustomerService.provisionTrialForNewUser;
 
   // Subscription operations
   static getSubscription = StripeSubscriptionService.getSubscription;

--- a/apps/api/src/services/stripe/stripe.service.ts
+++ b/apps/api/src/services/stripe/stripe.service.ts
@@ -34,6 +34,7 @@ export class StripeService {
     CoreStripeService.generatePaymentDescription;
 
   // Customer operations
+  static getCustomer = StripeCustomerService.getCustomer;
   static createCustomer = StripeCustomerService.createCustomer;
   static createPortalSession = StripeCustomerService.createPortalSession;
   static createCheckoutSession = StripeCustomerService.createCheckoutSession;

--- a/apps/api/src/services/stripe/stripe.service.ts
+++ b/apps/api/src/services/stripe/stripe.service.ts
@@ -37,6 +37,8 @@ export class StripeService {
   static createCustomer = StripeCustomerService.createCustomer;
   static createPortalSession = StripeCustomerService.createPortalSession;
   static createCheckoutSession = StripeCustomerService.createCheckoutSession;
+  static createTrialSubscription =
+    StripeCustomerService.createTrialSubscription;
 
   // Subscription operations
   static getSubscription = StripeSubscriptionService.getSubscription;

--- a/apps/api/src/trpc/routers/auth/google.ts
+++ b/apps/api/src/trpc/routers/auth/google.ts
@@ -5,6 +5,7 @@ import { generateToken } from "@/core/auth";
 
 import { notionService } from "@/services/integrations/notion.service";
 import { setSentryUser, trackSignUpError } from "@/services/sentry";
+import { StripeCustomerService } from "@/services/stripe/customer.service";
 
 import { GoogleAuthSchema } from "@/schemas/auth";
 
@@ -212,6 +213,21 @@ export const googleRouter = router({
                 },
               },
             });
+
+            // Auto-start Enterprise trial for cloud users (fire-and-forget)
+            if (isCloudMode()) {
+              StripeCustomerService.provisionTrialForNewUser({
+                userId: user.id,
+                email,
+                name: `${given_name || ""} ${family_name || ""}`.trim(),
+                prisma: ctx.prisma,
+              }).catch((error) => {
+                ctx.logger.warn(
+                  { error, userId: user?.id },
+                  "Failed to auto-start trial at Google OAuth registration"
+                );
+              });
+            }
 
             // Update user in Notion (non-blocking)
             // Fire and forget - don't await to avoid blocking the response

--- a/apps/api/src/trpc/routers/auth/registration.ts
+++ b/apps/api/src/trpc/routers/auth/registration.ts
@@ -5,10 +5,12 @@ import { hashPassword } from "@/core/auth";
 import { EmailVerificationService } from "@/services/email/email-verification.service";
 import { notionService } from "@/services/integrations/notion.service";
 import { trackSignUpError } from "@/services/sentry";
+import { StripeCustomerService } from "@/services/stripe/customer.service";
 
 import { RegisterUserSchema } from "@/schemas/auth";
 
 import { emailConfig, registrationConfig } from "@/config";
+import { isCloudMode } from "@/config/deployment";
 
 import { UserMapper } from "@/mappers/auth";
 
@@ -93,6 +95,21 @@ export const registrationRouter = router({
             updatedAt: true,
           },
         });
+
+        // Auto-start Enterprise trial for cloud users (fire-and-forget)
+        if (isCloudMode()) {
+          StripeCustomerService.provisionTrialForNewUser({
+            userId: user.id,
+            email,
+            name: `${firstName} ${lastName}`.trim(),
+            prisma: ctx.prisma,
+          }).catch((error) => {
+            ctx.logger.warn(
+              { error, userId: user.id },
+              "Failed to auto-start trial at registration"
+            );
+          });
+        }
 
         // Generate verification token and send email (skip if email is disabled)
         if (!autoVerify) {

--- a/apps/api/src/trpc/routers/payment/billing.ts
+++ b/apps/api/src/trpc/routers/payment/billing.ts
@@ -187,6 +187,12 @@ export const billingRouter = router({
                 .previousCancelDate
                 ? userWithSubscription.subscription.previousCancelDate.toISOString()
                 : null,
+              trialStart: userWithSubscription.subscription.trialStart
+                ? userWithSubscription.subscription.trialStart.toISOString()
+                : null,
+              trialEnd: userWithSubscription.subscription.trialEnd
+                ? userWithSubscription.subscription.trialEnd.toISOString()
+                : null,
               createdAt:
                 userWithSubscription.subscription.createdAt.toISOString(),
               updatedAt:

--- a/apps/api/src/trpc/routers/payment/billing.ts
+++ b/apps/api/src/trpc/routers/payment/billing.ts
@@ -80,29 +80,38 @@ export const billingRouter = router({
             );
           }
 
-          // Get payment method from subscription's default_payment_method
-          if (stripeSubscription?.default_payment_method) {
-            ctx.logger.info(
-              {
-                paymentMethodId: stripeSubscription.default_payment_method,
-              },
-              "Attempting to fetch payment method"
-            );
+          // Get payment method: check subscription first, then fall back to customer default
+          // During trials, Stripe often sets the payment method on the customer, not the subscription
+          let paymentMethodId = stripeSubscription?.default_payment_method as
+            | string
+            | null;
 
+          if (!paymentMethodId && userWithSubscription.stripeCustomerId) {
             try {
-              const fullPaymentMethod = await StripeService.getPaymentMethod(
-                stripeSubscription.default_payment_method as string
+              const customer = await StripeService.getCustomer(
+                userWithSubscription.stripeCustomerId
               );
-
-              ctx.logger.info(
-                {
-                  id: fullPaymentMethod.id,
-                  type: fullPaymentMethod.type,
-                },
-                "Payment method fetched successfully"
+              if (
+                customer &&
+                !customer.deleted &&
+                customer.invoice_settings?.default_payment_method
+              ) {
+                paymentMethodId = customer.invoice_settings
+                  .default_payment_method as string;
+              }
+            } catch (customerError) {
+              ctx.logger.warn(
+                { customerError },
+                "Failed to fetch customer for payment method fallback"
               );
+            }
+          }
 
-              // Return only essential payment method data
+          if (paymentMethodId) {
+            try {
+              const fullPaymentMethod =
+                await StripeService.getPaymentMethod(paymentMethodId);
+
               paymentMethod = {
                 id: fullPaymentMethod.id,
                 type: fullPaymentMethod.type,
@@ -123,23 +132,10 @@ export const billingRouter = router({
               };
             } catch (paymentMethodError) {
               ctx.logger.error(
-                {
-                  error: paymentMethodError,
-                  paymentMethodId: stripeSubscription.default_payment_method,
-                },
+                { error: paymentMethodError, paymentMethodId },
                 "Failed to fetch payment method"
               );
-              // Continue without payment method data
             }
-          } else {
-            ctx.logger.warn(
-              {
-                subscriptionId: stripeSubscription?.id,
-                hasDefaultPaymentMethod:
-                  !!stripeSubscription?.default_payment_method,
-              },
-              "No default_payment_method found in subscription"
-            );
           }
         } catch (stripeError) {
           ctx.logger.warn({ stripeError }, "Failed to fetch Stripe data");

--- a/apps/api/src/trpc/routers/payment/checkout.ts
+++ b/apps/api/src/trpc/routers/payment/checkout.ts
@@ -95,110 +95,47 @@ export const checkoutRouter = router({
    */
   startTrial: strictRateLimitedProcedure.mutation(async ({ ctx }) => {
     const { user, prisma } = ctx;
-    const plan = UserPlan.ENTERPRISE;
-    const billingInterval = "monthly" as const;
-    const trialDays = 14;
 
     try {
-      ctx.logger.info(
-        { userId: user.id, plan, trialDays },
-        "Starting free trial"
-      );
-
-      // Create Stripe customer if not exists
-      let customerId = user.stripeCustomerId;
-      if (!customerId) {
-        const customer = await StripeService.createCustomer({
-          email: user.email,
-          name: getUserDisplayName(user),
+      // Check for existing subscription before provisioning
+      const existingSubscription = await prisma.subscription.findFirst({
+        where: {
           userId: user.id,
-        });
-        customerId = customer.id;
+          status: {
+            in: [SubscriptionStatus.ACTIVE, SubscriptionStatus.TRIALING],
+          },
+        },
+      });
 
-        await prisma.user.update({
-          where: { id: user.id },
-          data: { stripeCustomerId: customerId },
+      if (existingSubscription) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: te(ctx.locale, "billing.alreadyHasSubscription"),
         });
       }
 
-      // Use a transaction to prevent race conditions:
-      // Re-check subscription inside the transaction before creating
-      const dbSubscription = await prisma.$transaction(async (tx) => {
-        const existingSubscription = await tx.subscription.findFirst({
-          where: {
-            userId: user.id,
-            status: {
-              in: [SubscriptionStatus.ACTIVE, SubscriptionStatus.TRIALING],
-            },
-          },
-        });
+      ctx.logger.info({ userId: user.id }, "Starting free trial");
 
-        if (existingSubscription) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: te(ctx.locale, "billing.alreadyHasSubscription"),
-          });
-        }
-
-        // Create subscription via Stripe API with idempotency key
-        const idempotencyKey = `start_trial_${user.id}`;
-        const subscription = await StripeService.createTrialSubscription({
-          customerId: customerId!,
-          plan,
-          billingInterval,
-          trialDays,
-          userId: user.id,
-          idempotencyKey,
-        });
-
-        // Update user with subscription ID
-        await tx.user.update({
-          where: { id: user.id },
-          data: { stripeSubscriptionId: subscription.id },
-        });
-
-        // Get period dates from subscription items
-        const firstItem = subscription.items?.data?.[0];
-        const currentPeriodStart = firstItem?.current_period_start
-          ? new Date(firstItem.current_period_start * 1000)
-          : new Date();
-        const currentPeriodEnd = firstItem?.current_period_end
-          ? new Date(firstItem.current_period_end * 1000)
-          : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000);
-
-        // Create subscription record in DB
-        return tx.subscription.create({
-          data: {
-            userId: user.id,
-            stripeSubscriptionId: subscription.id,
-            stripePriceId: firstItem?.price?.id || "",
-            stripeCustomerId: customerId!,
-            plan,
-            status: SubscriptionStatus.TRIALING,
-            billingInterval:
-              CoreStripeService.mapStripeBillingIntervalToBillingInterval(
-                billingInterval
-              ),
-            pricePerMonth: firstItem?.price?.unit_amount || 0,
-            currentPeriodStart,
-            currentPeriodEnd,
-            trialStart: subscription.trial_start
-              ? new Date(subscription.trial_start * 1000)
-              : new Date(),
-            trialEnd: subscription.trial_end
-              ? new Date(subscription.trial_end * 1000)
-              : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000),
-            cancelAtPeriodEnd: false,
-          },
-        });
+      const dbSubscription = await StripeService.provisionTrialForNewUser({
+        userId: user.id,
+        email: user.email,
+        name: getUserDisplayName(user),
+        prisma,
       });
 
-      // Send welcome email (outside transaction — non-critical)
+      if (!dbSubscription) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: te(ctx.locale, "billing.failedToStartTrial"),
+        });
+      }
+
+      // Send welcome email (non-critical)
       const emailResult = await EmailService.sendUpgradeConfirmationEmail({
         to: user.email,
         userName: getUserDisplayName(user),
         workspaceName: te(ctx.locale, "billing.allWorkspaces"),
-        plan,
+        plan: UserPlan.ENTERPRISE,
         billingInterval: CoreStripeService.mapBillingIntervalToString(
           BillingInterval.MONTH
         ),
@@ -219,7 +156,6 @@ export const checkoutRouter = router({
         {
           userId: user.id,
           subscriptionId: dbSubscription.stripeSubscriptionId,
-          plan,
           trialEnd: dbSubscription.trialEnd,
         },
         "Free trial started successfully"

--- a/apps/api/src/trpc/routers/payment/checkout.ts
+++ b/apps/api/src/trpc/routers/payment/checkout.ts
@@ -96,25 +96,8 @@ export const checkoutRouter = router({
   startTrial: strictRateLimitedProcedure.mutation(async ({ ctx }) => {
     const { user, prisma } = ctx;
     const plan = UserPlan.ENTERPRISE;
-    const billingInterval = "monthly";
+    const billingInterval = "monthly" as const;
     const trialDays = 14;
-
-    // Check if user already has an active subscription
-    const existingSubscription = await prisma.subscription.findFirst({
-      where: {
-        userId: user.id,
-        status: {
-          in: [SubscriptionStatus.ACTIVE, SubscriptionStatus.TRIALING],
-        },
-      },
-    });
-
-    if (existingSubscription) {
-      throw new TRPCError({
-        code: "BAD_REQUEST",
-        message: te(ctx.locale, "billing.alreadyHasSubscription"),
-      });
-    }
 
     try {
       ctx.logger.info(
@@ -138,81 +121,114 @@ export const checkoutRouter = router({
         });
       }
 
-      // Create subscription directly via Stripe API (no checkout page)
-      const subscription = await StripeService.createTrialSubscription({
-        customerId,
-        plan,
-        billingInterval,
-        trialDays,
-        userId: user.id,
-      });
+      // Use a transaction to prevent race conditions:
+      // Re-check subscription inside the transaction before creating
+      const dbSubscription = await prisma.$transaction(async (tx) => {
+        const existingSubscription = await tx.subscription.findFirst({
+          where: {
+            userId: user.id,
+            status: {
+              in: [SubscriptionStatus.ACTIVE, SubscriptionStatus.TRIALING],
+            },
+          },
+        });
 
-      // Update user with subscription ID
-      await prisma.user.update({
-        where: { id: user.id },
-        data: {
-          stripeSubscriptionId: subscription.id,
-        },
-      });
+        if (existingSubscription) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: te(ctx.locale, "billing.alreadyHasSubscription"),
+          });
+        }
 
-      // Get period dates from subscription items
-      const firstItem = subscription.items?.data?.[0];
-      const currentPeriodStart = firstItem?.current_period_start
-        ? new Date(firstItem.current_period_start * 1000)
-        : new Date();
-      const currentPeriodEnd = firstItem?.current_period_end
-        ? new Date(firstItem.current_period_end * 1000)
-        : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
-
-      // Create subscription record in DB
-      await prisma.subscription.create({
-        data: {
-          userId: user.id,
-          stripeSubscriptionId: subscription.id,
-          stripePriceId: firstItem?.price?.id || "",
-          stripeCustomerId: customerId,
+        // Create subscription via Stripe API with idempotency key
+        const idempotencyKey = `start_trial_${user.id}`;
+        const subscription = await StripeService.createTrialSubscription({
+          customerId: customerId!,
           plan,
-          status: SubscriptionStatus.TRIALING,
-          billingInterval:
-            CoreStripeService.mapStripeBillingIntervalToBillingInterval(
-              billingInterval
-            ),
-          pricePerMonth: firstItem?.price?.unit_amount || 0,
-          currentPeriodStart,
-          currentPeriodEnd,
-          trialStart: subscription.trial_start
-            ? new Date(subscription.trial_start * 1000)
-            : new Date(),
-          trialEnd: subscription.trial_end
-            ? new Date(subscription.trial_end * 1000)
-            : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000),
-          cancelAtPeriodEnd: false,
-        },
+          billingInterval,
+          trialDays,
+          userId: user.id,
+          idempotencyKey,
+        });
+
+        // Update user with subscription ID
+        await tx.user.update({
+          where: { id: user.id },
+          data: { stripeSubscriptionId: subscription.id },
+        });
+
+        // Get period dates from subscription items
+        const firstItem = subscription.items?.data?.[0];
+        const currentPeriodStart = firstItem?.current_period_start
+          ? new Date(firstItem.current_period_start * 1000)
+          : new Date();
+        const currentPeriodEnd = firstItem?.current_period_end
+          ? new Date(firstItem.current_period_end * 1000)
+          : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000);
+
+        // Create subscription record in DB
+        return tx.subscription.create({
+          data: {
+            userId: user.id,
+            stripeSubscriptionId: subscription.id,
+            stripePriceId: firstItem?.price?.id || "",
+            stripeCustomerId: customerId!,
+            plan,
+            status: SubscriptionStatus.TRIALING,
+            billingInterval:
+              CoreStripeService.mapStripeBillingIntervalToBillingInterval(
+                billingInterval
+              ),
+            pricePerMonth: firstItem?.price?.unit_amount || 0,
+            currentPeriodStart,
+            currentPeriodEnd,
+            trialStart: subscription.trial_start
+              ? new Date(subscription.trial_start * 1000)
+              : new Date(),
+            trialEnd: subscription.trial_end
+              ? new Date(subscription.trial_end * 1000)
+              : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000),
+            cancelAtPeriodEnd: false,
+          },
+        });
       });
 
-      // Send welcome email
-      await EmailService.sendUpgradeConfirmationEmail({
+      // Send welcome email (outside transaction — non-critical)
+      const emailResult = await EmailService.sendUpgradeConfirmationEmail({
         to: user.email,
         userName: getUserDisplayName(user),
-        workspaceName: "your workspaces",
+        workspaceName: te(ctx.locale, "billing.allWorkspaces"),
         plan,
         billingInterval: CoreStripeService.mapBillingIntervalToString(
           BillingInterval.MONTH
         ),
       });
 
+      if (!emailResult.success) {
+        ctx.logger.warn(
+          {
+            email: user.email,
+            error: emailResult.error,
+            method: "EmailService.sendUpgradeConfirmationEmail",
+          },
+          "Failed to send trial welcome email"
+        );
+      }
+
       ctx.logger.info(
         {
           userId: user.id,
-          subscriptionId: subscription.id,
+          subscriptionId: dbSubscription.stripeSubscriptionId,
           plan,
-          trialEnd: subscription.trial_end,
+          trialEnd: dbSubscription.trialEnd,
         },
         "Free trial started successfully"
       );
 
       return { success: true };
     } catch (error) {
+      // Re-throw TRPCErrors (e.g. alreadyHasSubscription) as-is
+      if (error instanceof TRPCError) throw error;
       ctx.logger.error({ error }, "Error starting free trial");
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",

--- a/apps/api/src/trpc/routers/payment/checkout.ts
+++ b/apps/api/src/trpc/routers/payment/checkout.ts
@@ -41,7 +41,7 @@ export const checkoutRouter = router({
             plan,
             billingInterval,
           },
-          "Creating checkout session with 30-day trial"
+          "Creating checkout session with 14-day trial"
         );
 
         // Create Stripe customer if not exists
@@ -61,7 +61,7 @@ export const checkoutRouter = router({
           });
         }
 
-        // Create checkout session with 30-day trial
+        // Create checkout session with 14-day trial
         const session = await StripeService.createCheckoutSession({
           userId: user.id,
           plan,
@@ -69,8 +69,8 @@ export const checkoutRouter = router({
           successUrl: `${emailConfig.frontendUrl}/payment/success?session_id={CHECKOUT_SESSION_ID}`,
           cancelUrl: `${emailConfig.frontendUrl}/payment/cancelled`,
           customerEmail: user.email,
-          // Automatically give 30-day trial to all users during early access period
-          trialDays: 30,
+          // Automatically give 14-day trial to all users during early access period
+          trialDays: 14,
         });
 
         return { url: session.url };

--- a/apps/api/src/trpc/routers/payment/checkout.ts
+++ b/apps/api/src/trpc/routers/payment/checkout.ts
@@ -2,6 +2,8 @@ import { TRPCError } from "@trpc/server";
 
 import { getUserDisplayName } from "@/core/utils";
 
+import { EmailService } from "@/services/email/email.service";
+import { CoreStripeService } from "@/services/stripe/core.service";
 import { StripeService } from "@/services/stripe/stripe.service";
 
 import { createCheckoutSessionSchema } from "@/schemas/payment";
@@ -10,12 +12,16 @@ import { emailConfig } from "@/config";
 
 import { router, strictRateLimitedProcedure } from "@/trpc/trpc";
 
-import { UserPlan } from "@/generated/prisma/client";
+import {
+  BillingInterval,
+  SubscriptionStatus,
+  UserPlan,
+} from "@/generated/prisma/client";
 import { te } from "@/i18n";
 
 /**
  * Checkout router
- * Handles Stripe checkout session creation
+ * Handles Stripe checkout session creation and direct trial starts
  */
 export const checkoutRouter = router({
   /**
@@ -82,4 +88,136 @@ export const checkoutRouter = router({
         });
       }
     }),
+
+  /**
+   * Start a free trial directly — no Stripe Checkout page, no card required.
+   * Creates a Stripe customer + subscription with trial, and saves to DB.
+   */
+  startTrial: strictRateLimitedProcedure.mutation(async ({ ctx }) => {
+    const { user, prisma } = ctx;
+    const plan = UserPlan.ENTERPRISE;
+    const billingInterval = "monthly";
+    const trialDays = 14;
+
+    // Check if user already has an active subscription
+    const existingSubscription = await prisma.subscription.findFirst({
+      where: {
+        userId: user.id,
+        status: {
+          in: [SubscriptionStatus.ACTIVE, SubscriptionStatus.TRIALING],
+        },
+      },
+    });
+
+    if (existingSubscription) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: te(ctx.locale, "billing.alreadyHasSubscription"),
+      });
+    }
+
+    try {
+      ctx.logger.info(
+        { userId: user.id, plan, trialDays },
+        "Starting free trial"
+      );
+
+      // Create Stripe customer if not exists
+      let customerId = user.stripeCustomerId;
+      if (!customerId) {
+        const customer = await StripeService.createCustomer({
+          email: user.email,
+          name: getUserDisplayName(user),
+          userId: user.id,
+        });
+        customerId = customer.id;
+
+        await prisma.user.update({
+          where: { id: user.id },
+          data: { stripeCustomerId: customerId },
+        });
+      }
+
+      // Create subscription directly via Stripe API (no checkout page)
+      const subscription = await StripeService.createTrialSubscription({
+        customerId,
+        plan,
+        billingInterval,
+        trialDays,
+        userId: user.id,
+      });
+
+      // Update user with subscription ID
+      await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          stripeSubscriptionId: subscription.id,
+        },
+      });
+
+      // Get period dates from subscription items
+      const firstItem = subscription.items?.data?.[0];
+      const currentPeriodStart = firstItem?.current_period_start
+        ? new Date(firstItem.current_period_start * 1000)
+        : new Date();
+      const currentPeriodEnd = firstItem?.current_period_end
+        ? new Date(firstItem.current_period_end * 1000)
+        : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+      // Create subscription record in DB
+      await prisma.subscription.create({
+        data: {
+          userId: user.id,
+          stripeSubscriptionId: subscription.id,
+          stripePriceId: firstItem?.price?.id || "",
+          stripeCustomerId: customerId,
+          plan,
+          status: SubscriptionStatus.TRIALING,
+          billingInterval:
+            CoreStripeService.mapStripeBillingIntervalToBillingInterval(
+              billingInterval
+            ),
+          pricePerMonth: firstItem?.price?.unit_amount || 0,
+          currentPeriodStart,
+          currentPeriodEnd,
+          trialStart: subscription.trial_start
+            ? new Date(subscription.trial_start * 1000)
+            : new Date(),
+          trialEnd: subscription.trial_end
+            ? new Date(subscription.trial_end * 1000)
+            : new Date(Date.now() + trialDays * 24 * 60 * 60 * 1000),
+          cancelAtPeriodEnd: false,
+        },
+      });
+
+      // Send welcome email
+      await EmailService.sendUpgradeConfirmationEmail({
+        to: user.email,
+        userName: getUserDisplayName(user),
+        workspaceName: "your workspaces",
+        plan,
+        billingInterval: CoreStripeService.mapBillingIntervalToString(
+          BillingInterval.MONTH
+        ),
+      });
+
+      ctx.logger.info(
+        {
+          userId: user.id,
+          subscriptionId: subscription.id,
+          plan,
+          trialEnd: subscription.trial_end,
+        },
+        "Free trial started successfully"
+      );
+
+      return { success: true };
+    } catch (error) {
+      ctx.logger.error({ error }, "Error starting free trial");
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: te(ctx.locale, "billing.failedToStartTrial"),
+      });
+    }
+  }),
 });

--- a/apps/api/src/trpc/routers/workspace/plan.ts
+++ b/apps/api/src/trpc/routers/workspace/plan.ts
@@ -54,6 +54,7 @@ export const planRouter = router({
             select: {
               plan: true,
               status: true,
+              trialEnd: true,
             },
           },
           workspace: {
@@ -163,6 +164,9 @@ export const planRouter = router({
           email: userWithSubscription.email,
           plan: workspacePlan, // Always return workspace plan
           subscriptionStatus: userWithSubscription.subscription?.status || null,
+          trialEnd: userWithSubscription.subscription?.trialEnd
+            ? userWithSubscription.subscription.trialEnd.toISOString()
+            : null,
         },
         workspace: currentWorkspace
           ? {

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -117,6 +117,14 @@
     "processing": "Processing...",
     "upgradeTo": "Upgrade to {{plan}}"
   },
+  "trial": {
+    "badge": "Trial",
+    "endsOn": "Trial ends",
+    "noPaymentMethod": "No payment method",
+    "addPaymentMethod": "Add payment method",
+    "trialActive": "Your trial is active",
+    "addPaymentToKeep": "Add a payment method before {{date}} to keep your plan when the trial ends."
+  },
   "error": {
     "workspaceIdRequired": "Workspace ID is required"
   }

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -123,7 +123,8 @@
     "noPaymentMethod": "No payment method",
     "addPaymentMethod": "Add payment method",
     "trialActive": "Your trial is active",
-    "addPaymentToKeep": "Add a payment method before {{date}} to keep your plan when the trial ends."
+    "addPaymentToKeep": "Add a payment method before {{date}} to keep your plan when the trial ends.",
+    "trialActiveWithPayment": "Your trial is active until {{date}}. Your subscription will start automatically when the trial ends."
   },
   "error": {
     "workspaceIdRequired": "Workspace ID is required"

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -124,7 +124,10 @@
     "addPaymentMethod": "Add payment method",
     "trialActive": "Your trial is active",
     "addPaymentToKeep": "Add a payment method before {{date}} to keep your plan when the trial ends.",
-    "trialActiveWithPayment": "Your trial is active until {{date}}. Your subscription will start automatically when the trial ends."
+    "trialActiveWithPayment": "Your trial is active until {{date}}. Your subscription will start automatically when the trial ends.",
+    "cancelTrial": "Cancel Trial",
+    "trialCanceled": "Trial canceled",
+    "trialEndsOnDate": "Your trial will end on {{date}}. You will be downgraded to the Free plan."
   },
   "currentPlan": {
     "noSubscription": "No subscription required",
@@ -134,10 +137,15 @@
     "nextBilling": "Next Billing",
     "paymentMethod": "Payment Method",
     "planName": "{{plan}} Plan",
-    "activeSubscription": "Your active subscription"
+    "activeSubscription": "Your active subscription",
+    "changePaymentMethod": "Change payment method"
   },
   "status": {
     "active": "Active"
+  },
+  "subscriptionManagement": {
+    "title": "Subscription Management",
+    "description": "Manage your plan, billing cycle, and subscription settings for all your workspaces"
   },
   "error": {
     "workspaceIdRequired": "Workspace ID is required"

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -126,6 +126,17 @@
     "addPaymentToKeep": "Add a payment method before {{date}} to keep your plan when the trial ends.",
     "trialActiveWithPayment": "Your trial is active until {{date}}. Your subscription will start automatically when the trial ends."
   },
+  "currentPlan": {
+    "noSubscription": "No subscription required",
+    "billingInterval": "{{interval}} billing",
+    "perInterval": "per {{interval}}",
+    "currentPeriod": "Current Period",
+    "nextBilling": "Next Billing",
+    "paymentMethod": "Payment Method"
+  },
+  "status": {
+    "active": "Active"
+  },
   "error": {
     "workspaceIdRequired": "Workspace ID is required"
   }

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -132,7 +132,9 @@
     "perInterval": "per {{interval}}",
     "currentPeriod": "Current Period",
     "nextBilling": "Next Billing",
-    "paymentMethod": "Payment Method"
+    "paymentMethod": "Payment Method",
+    "planName": "{{plan}} Plan",
+    "activeSubscription": "Your active subscription"
   },
   "status": {
     "active": "Active"

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -123,7 +123,8 @@
     "noPaymentMethod": "Sin método de pago",
     "addPaymentMethod": "Agregar método de pago",
     "trialActive": "Tu prueba está activa",
-    "addPaymentToKeep": "Agrega un método de pago antes del {{date}} para mantener tu plan cuando termine la prueba."
+    "addPaymentToKeep": "Agrega un método de pago antes del {{date}} para mantener tu plan cuando termine la prueba.",
+    "trialActiveWithPayment": "Tu prueba está activa hasta el {{date}}. Tu suscripción comenzará automáticamente cuando termine la prueba."
   },
   "error": {
     "workspaceIdRequired": "Se requiere el ID del espacio de trabajo"

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -126,6 +126,17 @@
     "addPaymentToKeep": "Agrega un método de pago antes del {{date}} para mantener tu plan cuando termine la prueba.",
     "trialActiveWithPayment": "Tu prueba está activa hasta el {{date}}. Tu suscripción comenzará automáticamente cuando termine la prueba."
   },
+  "currentPlan": {
+    "noSubscription": "No se requiere suscripción",
+    "billingInterval": "Facturación {{interval}}",
+    "perInterval": "por {{interval}}",
+    "currentPeriod": "Período actual",
+    "nextBilling": "Próxima facturación",
+    "paymentMethod": "Método de pago"
+  },
+  "status": {
+    "active": "Activo"
+  },
   "error": {
     "workspaceIdRequired": "Se requiere el ID del espacio de trabajo"
   }

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -117,6 +117,14 @@
     "processing": "Procesando...",
     "upgradeTo": "Mejorar a {{plan}}"
   },
+  "trial": {
+    "badge": "Prueba",
+    "endsOn": "La prueba termina",
+    "noPaymentMethod": "Sin método de pago",
+    "addPaymentMethod": "Agregar método de pago",
+    "trialActive": "Tu prueba está activa",
+    "addPaymentToKeep": "Agrega un método de pago antes del {{date}} para mantener tu plan cuando termine la prueba."
+  },
   "error": {
     "workspaceIdRequired": "Se requiere el ID del espacio de trabajo"
   }

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -124,7 +124,10 @@
     "addPaymentMethod": "Agregar método de pago",
     "trialActive": "Tu prueba está activa",
     "addPaymentToKeep": "Agrega un método de pago antes del {{date}} para mantener tu plan cuando termine la prueba.",
-    "trialActiveWithPayment": "Tu prueba está activa hasta el {{date}}. Tu suscripción comenzará automáticamente cuando termine la prueba."
+    "trialActiveWithPayment": "Tu prueba está activa hasta el {{date}}. Tu suscripción comenzará automáticamente cuando termine la prueba.",
+    "cancelTrial": "Cancelar prueba",
+    "trialCanceled": "Prueba cancelada",
+    "trialEndsOnDate": "Tu prueba terminará el {{date}}. Serás degradado al plan Gratuito."
   },
   "currentPlan": {
     "noSubscription": "No se requiere suscripción",
@@ -134,10 +137,15 @@
     "nextBilling": "Próxima facturación",
     "paymentMethod": "Método de pago",
     "planName": "Plan {{plan}}",
-    "activeSubscription": "Tu suscripción activa"
+    "activeSubscription": "Tu suscripción activa",
+    "changePaymentMethod": "Cambiar método de pago"
   },
   "status": {
     "active": "Activo"
+  },
+  "subscriptionManagement": {
+    "title": "Gestión de suscripción",
+    "description": "Gestiona tu plan, ciclo de facturación y configuración de suscripción para todos tus espacios de trabajo"
   },
   "error": {
     "workspaceIdRequired": "Se requiere el ID del espacio de trabajo"

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -132,7 +132,9 @@
     "perInterval": "por {{interval}}",
     "currentPeriod": "Período actual",
     "nextBilling": "Próxima facturación",
-    "paymentMethod": "Método de pago"
+    "paymentMethod": "Método de pago",
+    "planName": "Plan {{plan}}",
+    "activeSubscription": "Tu suscripción activa"
   },
   "status": {
     "active": "Activo"

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -132,7 +132,9 @@
     "perInterval": "par {{interval}}",
     "currentPeriod": "Période en cours",
     "nextBilling": "Prochaine facturation",
-    "paymentMethod": "Moyen de paiement"
+    "paymentMethod": "Moyen de paiement",
+    "planName": "Forfait {{plan}}",
+    "activeSubscription": "Votre abonnement actif"
   },
   "status": {
     "active": "Actif"

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -124,7 +124,10 @@
     "addPaymentMethod": "Ajouter un moyen de paiement",
     "trialActive": "Votre essai est actif",
     "addPaymentToKeep": "Ajoutez un moyen de paiement avant le {{date}} pour conserver votre forfait à la fin de l'essai.",
-    "trialActiveWithPayment": "Votre essai est actif jusqu'au {{date}}. Votre abonnement commencera automatiquement à la fin de l'essai."
+    "trialActiveWithPayment": "Votre essai est actif jusqu'au {{date}}. Votre abonnement commencera automatiquement à la fin de l'essai.",
+    "cancelTrial": "Annuler l'essai",
+    "trialCanceled": "Essai annulé",
+    "trialEndsOnDate": "Votre essai se terminera le {{date}}. Vous serez rétrogradé au forfait Gratuit."
   },
   "currentPlan": {
     "noSubscription": "Aucun abonnement requis",
@@ -134,10 +137,15 @@
     "nextBilling": "Prochaine facturation",
     "paymentMethod": "Moyen de paiement",
     "planName": "Forfait {{plan}}",
-    "activeSubscription": "Votre abonnement actif"
+    "activeSubscription": "Votre abonnement actif",
+    "changePaymentMethod": "Modifier le moyen de paiement"
   },
   "status": {
     "active": "Actif"
+  },
+  "subscriptionManagement": {
+    "title": "Gestion de l'abonnement",
+    "description": "Gérez votre forfait, cycle de facturation et paramètres d'abonnement pour tous vos espaces de travail"
   },
   "error": {
     "workspaceIdRequired": "L'identifiant de l'espace de travail est requis"

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -117,6 +117,14 @@
     "processing": "Traitement en cours...",
     "upgradeTo": "Mettre à niveau vers {{plan}}"
   },
+  "trial": {
+    "badge": "Essai",
+    "endsOn": "Fin de l'essai",
+    "noPaymentMethod": "Aucun moyen de paiement",
+    "addPaymentMethod": "Ajouter un moyen de paiement",
+    "trialActive": "Votre essai est actif",
+    "addPaymentToKeep": "Ajoutez un moyen de paiement avant le {{date}} pour conserver votre forfait à la fin de l'essai."
+  },
   "error": {
     "workspaceIdRequired": "L'identifiant de l'espace de travail est requis"
   }

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -126,6 +126,17 @@
     "addPaymentToKeep": "Ajoutez un moyen de paiement avant le {{date}} pour conserver votre forfait à la fin de l'essai.",
     "trialActiveWithPayment": "Votre essai est actif jusqu'au {{date}}. Votre abonnement commencera automatiquement à la fin de l'essai."
   },
+  "currentPlan": {
+    "noSubscription": "Aucun abonnement requis",
+    "billingInterval": "Facturation {{interval}}",
+    "perInterval": "par {{interval}}",
+    "currentPeriod": "Période en cours",
+    "nextBilling": "Prochaine facturation",
+    "paymentMethod": "Moyen de paiement"
+  },
+  "status": {
+    "active": "Actif"
+  },
   "error": {
     "workspaceIdRequired": "L'identifiant de l'espace de travail est requis"
   }

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -123,7 +123,8 @@
     "noPaymentMethod": "Aucun moyen de paiement",
     "addPaymentMethod": "Ajouter un moyen de paiement",
     "trialActive": "Votre essai est actif",
-    "addPaymentToKeep": "Ajoutez un moyen de paiement avant le {{date}} pour conserver votre forfait à la fin de l'essai."
+    "addPaymentToKeep": "Ajoutez un moyen de paiement avant le {{date}} pour conserver votre forfait à la fin de l'essai.",
+    "trialActiveWithPayment": "Votre essai est actif jusqu'au {{date}}. Votre abonnement commencera automatiquement à la fin de l'essai."
   },
   "error": {
     "workspaceIdRequired": "L'identifiant de l'espace de travail est requis"

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -117,6 +117,14 @@
     "processing": "处理中...",
     "upgradeTo": "升级到{{plan}}"
   },
+  "trial": {
+    "badge": "试用",
+    "endsOn": "试用结束",
+    "noPaymentMethod": "无支付方式",
+    "addPaymentMethod": "添加支付方式",
+    "trialActive": "您的试用期正在进行中",
+    "addPaymentToKeep": "请在 {{date}} 之前添加支付方式，以便在试用结束后保留您的方案。"
+  },
   "error": {
     "workspaceIdRequired": "需要工作区 ID"
   }

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -123,7 +123,8 @@
     "noPaymentMethod": "无支付方式",
     "addPaymentMethod": "添加支付方式",
     "trialActive": "您的试用期正在进行中",
-    "addPaymentToKeep": "请在 {{date}} 之前添加支付方式，以便在试用结束后保留您的方案。"
+    "addPaymentToKeep": "请在 {{date}} 之前添加支付方式，以便在试用结束后保留您的方案。",
+    "trialActiveWithPayment": "您的试用期有效至 {{date}}。试用结束后，您的订阅将自动开始。"
   },
   "error": {
     "workspaceIdRequired": "需要工作区 ID"

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -132,7 +132,9 @@
     "perInterval": "每{{interval}}",
     "currentPeriod": "当前期间",
     "nextBilling": "下次计费",
-    "paymentMethod": "支付方式"
+    "paymentMethod": "支付方式",
+    "planName": "{{plan}}方案",
+    "activeSubscription": "您的活跃订阅"
   },
   "status": {
     "active": "活跃"

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -124,7 +124,10 @@
     "addPaymentMethod": "添加支付方式",
     "trialActive": "您的试用期正在进行中",
     "addPaymentToKeep": "请在 {{date}} 之前添加支付方式，以便在试用结束后保留您的方案。",
-    "trialActiveWithPayment": "您的试用期有效至 {{date}}。试用结束后，您的订阅将自动开始。"
+    "trialActiveWithPayment": "您的试用期有效至 {{date}}。试用结束后，您的订阅将自动开始。",
+    "cancelTrial": "取消试用",
+    "trialCanceled": "试用已取消",
+    "trialEndsOnDate": "您的试用将于 {{date}} 结束。届时将降级为免费方案。"
   },
   "currentPlan": {
     "noSubscription": "无需订阅",
@@ -134,10 +137,15 @@
     "nextBilling": "下次计费",
     "paymentMethod": "支付方式",
     "planName": "{{plan}}方案",
-    "activeSubscription": "您的活跃订阅"
+    "activeSubscription": "您的活跃订阅",
+    "changePaymentMethod": "更改支付方式"
   },
   "status": {
     "active": "活跃"
+  },
+  "subscriptionManagement": {
+    "title": "订阅管理",
+    "description": "管理您所有工作区的方案、计费周期和订阅设置"
   },
   "error": {
     "workspaceIdRequired": "需要工作区 ID"

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -126,6 +126,17 @@
     "addPaymentToKeep": "请在 {{date}} 之前添加支付方式，以便在试用结束后保留您的方案。",
     "trialActiveWithPayment": "您的试用期有效至 {{date}}。试用结束后，您的订阅将自动开始。"
   },
+  "currentPlan": {
+    "noSubscription": "无需订阅",
+    "billingInterval": "{{interval}}计费",
+    "perInterval": "每{{interval}}",
+    "currentPeriod": "当前期间",
+    "nextBilling": "下次计费",
+    "paymentMethod": "支付方式"
+  },
+  "status": {
+    "active": "活跃"
+  },
   "error": {
     "workspaceIdRequired": "需要工作区 ID"
   }

--- a/apps/app/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/app/src/components/auth/GoogleLoginButton.tsx
@@ -11,6 +11,8 @@ import { trpc } from "@/lib/trpc/client";
 
 import { useAuth } from "@/contexts/AuthContextDefinition";
 
+const TRIAL_PROVISION_DELAY_MS = 3000;
+
 interface GoogleLoginButtonProps {
   onSuccess?: () => void;
   onError?: (error: string) => void;
@@ -26,6 +28,7 @@ export const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({
 }) => {
   const { login } = useAuth();
   const navigate = useNavigate();
+  const utils = trpc.useUtils();
 
   // OAuth is only enabled for cloud deployments
   const enableOAuth = isCloudMode();
@@ -43,6 +46,13 @@ export const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({
           method: "google",
           user_id: data.user.id,
         });
+      }
+
+      // For new users, refetch plan data after trial provisioning completes
+      if (data.isNewUser) {
+        setTimeout(() => {
+          utils.workspace.plan.getCurrentPlan.invalidate();
+        }, TRIAL_PROVISION_DELAY_MS);
       }
 
       onSuccess?.();

--- a/apps/app/src/components/billing/CurrentPlanCard.tsx
+++ b/apps/app/src/components/billing/CurrentPlanCard.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import { CreditCard } from "lucide-react";
 
 import { formatCurrency, formatDate } from "@/lib/utils";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { getPlanDisplayName, UserPlan } from "@/types/plans";
@@ -13,6 +15,7 @@ interface CurrentPlanCardProps {
   subscription?: {
     status: string;
     plan: UserPlan;
+    trialEnd?: string | null;
   };
   stripeSubscription?: {
     items: {
@@ -33,14 +36,21 @@ interface CurrentPlanCardProps {
       last4: string;
     };
   };
+  onAddPaymentMethod?: () => void;
 }
 
 export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
   subscription,
   stripeSubscription,
   paymentMethod,
+  onAddPaymentMethod,
 }) => {
+  const { t } = useTranslation("billing");
   const plan = subscription?.plan ?? UserPlan.FREE;
+  const isTrialing = subscription?.status === "TRIALING";
+  const trialEndDate = subscription?.trialEnd
+    ? new Date(subscription.trialEnd)
+    : null;
 
   return (
     <Card className="border-l-4 border-l-primary">
@@ -54,9 +64,17 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
               <CardTitle className="flex items-center gap-2">
                 {getPlanDisplayName(plan)} Plan
                 <Badge
-                  variant={plan === UserPlan.FREE ? "secondary" : "default"}
+                  variant={
+                    isTrialing
+                      ? "outline"
+                      : plan === UserPlan.FREE
+                        ? "secondary"
+                        : "default"
+                  }
                 >
-                  {subscription?.status || "Active"}
+                  {isTrialing
+                    ? t("trial.badge")
+                    : subscription?.status || "Active"}
                 </Badge>
               </CardTitle>
               <p className="text-sm text-muted-foreground mt-1">
@@ -99,11 +117,17 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
               </div>
             </div>
             <div>
-              <div className="text-sm text-muted-foreground">Next Billing</div>
+              <div className="text-sm text-muted-foreground">
+                {isTrialing && trialEndDate
+                  ? t("trial.endsOn")
+                  : "Next Billing"}
+              </div>
               <div className="font-medium">
-                {formatDate(
-                  new Date(stripeSubscription.current_period_end * 1000)
-                )}
+                {isTrialing && trialEndDate
+                  ? formatDate(trialEndDate)
+                  : formatDate(
+                      new Date(stripeSubscription.current_period_end * 1000)
+                    )}
               </div>
             </div>
             <div>
@@ -116,8 +140,17 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
                     <CreditCard className="w-4 h-4" />
                     •••• {paymentMethod.card?.last4}
                   </>
+                ) : isTrialing && onAddPaymentMethod ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={onAddPaymentMethod}
+                  >
+                    <CreditCard className="w-4 h-4 mr-2" />
+                    {t("trial.addPaymentMethod")}
+                  </Button>
                 ) : (
-                  "No payment method"
+                  t("trial.noPaymentMethod")
                 )}
               </div>
             </div>

--- a/apps/app/src/components/billing/CurrentPlanCard.tsx
+++ b/apps/app/src/components/billing/CurrentPlanCard.tsx
@@ -62,7 +62,7 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
             </div>
             <div>
               <CardTitle className="flex items-center gap-2">
-                {getPlanDisplayName(plan)} Plan
+                {t("currentPlan.planName", { plan: getPlanDisplayName(plan) })}
                 <Badge
                   variant={
                     isTrialing

--- a/apps/app/src/components/billing/CurrentPlanCard.tsx
+++ b/apps/app/src/components/billing/CurrentPlanCard.tsx
@@ -130,7 +130,7 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
                     )}
               </div>
             </div>
-            <div>
+            <div data-testid="current-plan-payment-section">
               <div className="text-sm text-muted-foreground">
                 Payment Method
               </div>

--- a/apps/app/src/components/billing/CurrentPlanCard.tsx
+++ b/apps/app/src/components/billing/CurrentPlanCard.tsx
@@ -18,7 +18,7 @@ interface CurrentPlanCardProps {
     trialEnd?: string | null;
   };
   stripeSubscription?: {
-    items: {
+    items?: {
       data: Array<{
         price?: {
           unit_amount?: number;
@@ -27,7 +27,7 @@ interface CurrentPlanCardProps {
           };
         };
       }>;
-    };
+    } | null;
     current_period_start: number;
     current_period_end: number;
   };
@@ -88,12 +88,12 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
             <div className="text-right">
               <div className="text-2xl font-bold">
                 {formatCurrency(
-                  stripeSubscription.items.data[0]?.price?.unit_amount || 0
+                  stripeSubscription.items?.data[0]?.price?.unit_amount || 0
                 )}
               </div>
               <div className="text-sm text-muted-foreground">
                 per{" "}
-                {stripeSubscription.items.data[0]?.price?.recurring?.interval}
+                {stripeSubscription.items?.data[0]?.price?.recurring?.interval}
               </div>
             </div>
           )}

--- a/apps/app/src/components/billing/CurrentPlanCard.tsx
+++ b/apps/app/src/components/billing/CurrentPlanCard.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { CreditCard } from "lucide-react";
+import { Clock, CreditCard, X } from "lucide-react";
 
 import { formatCurrency, formatDate } from "@/lib/utils";
 
@@ -10,6 +10,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { getPlanDisplayName, UserPlan } from "@/types/plans";
+
+import { CancelSubscriptionModal } from "./CancelSubscriptionModal";
 
 interface CurrentPlanCardProps {
   subscription?: {
@@ -36,132 +38,261 @@ interface CurrentPlanCardProps {
       last4: string;
     };
   };
-  onAddPaymentMethod?: () => void;
+  onManagePaymentMethod?: () => void;
+  onCancelSubscription?: (data: {
+    cancelImmediately: boolean;
+    reason: string;
+    feedback: string;
+  }) => Promise<unknown>;
+  isLoading?: boolean;
+  cancelAtPeriodEnd?: boolean;
 }
 
 export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
   subscription,
   stripeSubscription,
   paymentMethod,
-  onAddPaymentMethod,
+  onManagePaymentMethod,
+  onCancelSubscription,
+  isLoading,
+  cancelAtPeriodEnd,
 }) => {
-  const { t } = useTranslation("billing");
+  const { t, i18n } = useTranslation("billing");
+  const [showCancelModal, setShowCancelModal] = useState(false);
   const plan = subscription?.plan ?? UserPlan.FREE;
   const isTrialing = subscription?.status === "TRIALING";
   const trialEndDate = subscription?.trialEnd
     ? new Date(subscription.trialEnd)
     : null;
 
+  const handleCancelConfirm = async (data: {
+    cancelImmediately: boolean;
+    reason: string;
+    feedback: string;
+  }) => {
+    await onCancelSubscription?.(data);
+    setShowCancelModal(false);
+  };
+
   return (
-    <Card className="border-l-4 border-l-primary">
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-primary/10 rounded-lg">
-              <CreditCard className="w-6 h-6 text-primary" />
-            </div>
-            <div>
-              <CardTitle className="flex items-center gap-2">
-                {t("currentPlan.planName", { plan: getPlanDisplayName(plan) })}
-                <Badge
-                  variant={
-                    isTrialing
-                      ? "outline"
-                      : plan === UserPlan.FREE
-                        ? "secondary"
-                        : "default"
-                  }
-                >
-                  {isTrialing ? t("trial.badge") : t("status.active", "Active")}
-                </Badge>
-              </CardTitle>
-              <p className="text-sm text-muted-foreground mt-1">
-                {plan === UserPlan.FREE
-                  ? t("currentPlan.noSubscription")
-                  : t("currentPlan.billingInterval", {
-                      interval:
-                        stripeSubscription?.items?.data[0]?.price?.recurring
-                          ?.interval || "",
-                    })}
-              </p>
-            </div>
-          </div>
-          {stripeSubscription && (
-            <div className="text-right">
-              <div className="text-2xl font-bold">
-                {formatCurrency(
-                  stripeSubscription.items?.data[0]?.price?.unit_amount || 0
-                )}
+    <>
+      <Card className="border-l-4 border-l-primary">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-primary/10 rounded-lg">
+                <CreditCard className="w-6 h-6 text-primary" />
               </div>
-              <div className="text-sm text-muted-foreground">
-                {t("currentPlan.perInterval", {
-                  interval:
-                    stripeSubscription.items?.data[0]?.price?.recurring
-                      ?.interval,
-                })}
-              </div>
-            </div>
-          )}
-        </div>
-      </CardHeader>
-      {stripeSubscription && (
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div>
-              <div className="text-sm text-muted-foreground">
-                {t("currentPlan.currentPeriod")}
-              </div>
-              <div className="font-medium">
-                {formatDate(
-                  new Date(stripeSubscription.current_period_start * 1000)
-                )}{" "}
-                -{" "}
-                {formatDate(
-                  new Date(stripeSubscription.current_period_end * 1000)
-                )}
-              </div>
-            </div>
-            <div>
-              <div className="text-sm text-muted-foreground">
-                {isTrialing && trialEndDate
-                  ? t("trial.endsOn")
-                  : t("currentPlan.nextBilling")}
-              </div>
-              <div className="font-medium">
-                {isTrialing && trialEndDate
-                  ? formatDate(trialEndDate)
-                  : formatDate(
-                      new Date(stripeSubscription.current_period_end * 1000)
-                    )}
-              </div>
-            </div>
-            <div data-testid="current-plan-payment-section">
-              <div className="text-sm text-muted-foreground">
-                {t("currentPlan.paymentMethod")}
-              </div>
-              <div className="font-medium flex items-center gap-2">
-                {paymentMethod ? (
-                  <>
-                    <CreditCard className="w-4 h-4" />
-                    •••• {paymentMethod.card?.last4}
-                  </>
-                ) : isTrialing && onAddPaymentMethod ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={onAddPaymentMethod}
+              <div>
+                <CardTitle className="flex items-center gap-2">
+                  {t("currentPlan.planName", {
+                    plan: getPlanDisplayName(plan),
+                  })}
+                  <Badge
+                    variant={
+                      isTrialing
+                        ? "outline"
+                        : plan === UserPlan.FREE
+                          ? "secondary"
+                          : "default"
+                    }
                   >
-                    <CreditCard className="w-4 h-4 mr-2" />
-                    {t("trial.addPaymentMethod")}
-                  </Button>
-                ) : (
-                  t("trial.noPaymentMethod")
-                )}
+                    {isTrialing
+                      ? t("trial.badge")
+                      : t("status.active", "Active")}
+                  </Badge>
+                </CardTitle>
+                <p className="text-sm text-muted-foreground mt-1">
+                  {plan === UserPlan.FREE
+                    ? t("currentPlan.noSubscription")
+                    : t("currentPlan.billingInterval", {
+                        interval:
+                          stripeSubscription?.items?.data[0]?.price?.recurring
+                            ?.interval || "",
+                      })}
+                </p>
               </div>
             </div>
+            <div className="flex items-center gap-3">
+              {isTrialing && onCancelSubscription && (
+                <Button
+                  onClick={() => setShowCancelModal(true)}
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive border-destructive/20 hover:bg-destructive/10"
+                  disabled={isLoading}
+                >
+                  <X className="w-4 h-4 mr-2" />
+                  {t("trial.cancelTrial")}
+                </Button>
+              )}
+              {stripeSubscription && (
+                <div className="text-right">
+                  <div className="text-2xl font-bold">
+                    {formatCurrency(
+                      stripeSubscription.items?.data[0]?.price?.unit_amount || 0
+                    )}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {t("currentPlan.perInterval", {
+                      interval:
+                        stripeSubscription.items?.data[0]?.price?.recurring
+                          ?.interval,
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
-        </CardContent>
+        </CardHeader>
+        {stripeSubscription && (
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <div className="text-sm text-muted-foreground">
+                  {t("currentPlan.currentPeriod")}
+                </div>
+                <div className="font-medium">
+                  {formatDate(
+                    new Date(stripeSubscription.current_period_start * 1000)
+                  )}{" "}
+                  -{" "}
+                  {formatDate(
+                    new Date(stripeSubscription.current_period_end * 1000)
+                  )}
+                </div>
+              </div>
+              <div>
+                <div className="text-sm text-muted-foreground">
+                  {isTrialing && trialEndDate
+                    ? t("trial.endsOn")
+                    : t("currentPlan.nextBilling")}
+                </div>
+                <div className="font-medium">
+                  {isTrialing && trialEndDate
+                    ? formatDate(trialEndDate)
+                    : formatDate(
+                        new Date(stripeSubscription.current_period_end * 1000)
+                      )}
+                </div>
+              </div>
+              <div data-testid="current-plan-payment-section">
+                <div className="text-sm text-muted-foreground">
+                  {t("currentPlan.paymentMethod")}
+                </div>
+                <div className="font-medium flex items-center gap-2">
+                  {paymentMethod ? (
+                    <button
+                      onClick={onManagePaymentMethod}
+                      className="flex items-center gap-2 hover:text-primary transition-colors cursor-pointer"
+                      title={t("currentPlan.changePaymentMethod")}
+                    >
+                      <CreditCard className="w-4 h-4" />
+                      •••• {paymentMethod.card?.last4}
+                    </button>
+                  ) : (
+                    t("trial.noPaymentMethod")
+                  )}
+                </div>
+              </div>
+            </div>
+            {isTrialing && (
+              <div
+                className={`rounded-lg p-4 border ${
+                  cancelAtPeriodEnd
+                    ? "bg-destructive/10 border-destructive/20"
+                    : "bg-primary/10 border-primary/20"
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <div className="shrink-0">
+                    <Clock
+                      className={`w-5 h-5 mt-0.5 ${cancelAtPeriodEnd ? "text-destructive" : "text-primary"}`}
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <h4
+                      className={`font-medium mb-1 ${cancelAtPeriodEnd ? "text-destructive" : "text-primary"}`}
+                    >
+                      {cancelAtPeriodEnd
+                        ? t("trial.trialCanceled")
+                        : t("trial.trialActive")}
+                    </h4>
+                    <p
+                      className={`text-sm ${cancelAtPeriodEnd ? "text-destructive/80" : "text-primary/80"}`}
+                    >
+                      {cancelAtPeriodEnd
+                        ? t("trial.trialEndsOnDate", {
+                            date: trialEndDate
+                              ? trialEndDate.toLocaleDateString(i18n.language, {
+                                  year: "numeric",
+                                  month: "long",
+                                  day: "numeric",
+                                })
+                              : "",
+                          })
+                        : paymentMethod
+                          ? t("trial.trialActiveWithPayment", {
+                              date: trialEndDate
+                                ? trialEndDate.toLocaleDateString(
+                                    i18n.language,
+                                    {
+                                      year: "numeric",
+                                      month: "long",
+                                      day: "numeric",
+                                    }
+                                  )
+                                : "",
+                            })
+                          : t("trial.addPaymentToKeep", {
+                              date: trialEndDate
+                                ? trialEndDate.toLocaleDateString(
+                                    i18n.language,
+                                    {
+                                      year: "numeric",
+                                      month: "long",
+                                      day: "numeric",
+                                    }
+                                  )
+                                : "",
+                            })}
+                    </p>
+                    {!cancelAtPeriodEnd &&
+                      !paymentMethod &&
+                      onManagePaymentMethod && (
+                        <Button
+                          onClick={onManagePaymentMethod}
+                          size="sm"
+                          className="mt-3"
+                        >
+                          <CreditCard className="w-4 h-4 mr-2" />
+                          {t("trial.addPaymentMethod")}
+                        </Button>
+                      )}
+                  </div>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        )}
+      </Card>
+
+      {onCancelSubscription && (
+        <CancelSubscriptionModal
+          isOpen={showCancelModal}
+          onClose={() => setShowCancelModal(false)}
+          onConfirm={handleCancelConfirm}
+          currentPlan={plan}
+          periodEnd={
+            stripeSubscription
+              ? new Date(
+                  stripeSubscription.current_period_end * 1000
+                ).toISOString()
+              : undefined
+          }
+          isLoading={isLoading}
+        />
       )}
-    </Card>
+    </>
   );
 };

--- a/apps/app/src/components/billing/CurrentPlanCard.tsx
+++ b/apps/app/src/components/billing/CurrentPlanCard.tsx
@@ -72,15 +72,17 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
                         : "default"
                   }
                 >
-                  {isTrialing
-                    ? t("trial.badge")
-                    : subscription?.status || "Active"}
+                  {isTrialing ? t("trial.badge") : t("status.active", "Active")}
                 </Badge>
               </CardTitle>
               <p className="text-sm text-muted-foreground mt-1">
                 {plan === UserPlan.FREE
-                  ? "No subscription required"
-                  : `${stripeSubscription?.items?.data[0]?.price?.recurring?.interval || ""} billing`}
+                  ? t("currentPlan.noSubscription")
+                  : t("currentPlan.billingInterval", {
+                      interval:
+                        stripeSubscription?.items?.data[0]?.price?.recurring
+                          ?.interval || "",
+                    })}
               </p>
             </div>
           </div>
@@ -92,8 +94,11 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
                 )}
               </div>
               <div className="text-sm text-muted-foreground">
-                per{" "}
-                {stripeSubscription.items?.data[0]?.price?.recurring?.interval}
+                {t("currentPlan.perInterval", {
+                  interval:
+                    stripeSubscription.items?.data[0]?.price?.recurring
+                      ?.interval,
+                })}
               </div>
             </div>
           )}
@@ -104,7 +109,7 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
               <div className="text-sm text-muted-foreground">
-                Current Period
+                {t("currentPlan.currentPeriod")}
               </div>
               <div className="font-medium">
                 {formatDate(
@@ -120,7 +125,7 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
               <div className="text-sm text-muted-foreground">
                 {isTrialing && trialEndDate
                   ? t("trial.endsOn")
-                  : "Next Billing"}
+                  : t("currentPlan.nextBilling")}
               </div>
               <div className="font-medium">
                 {isTrialing && trialEndDate
@@ -132,7 +137,7 @@ export const CurrentPlanCard: React.FC<CurrentPlanCardProps> = ({
             </div>
             <div data-testid="current-plan-payment-section">
               <div className="text-sm text-muted-foreground">
-                Payment Method
+                {t("currentPlan.paymentMethod")}
               </div>
               <div className="font-medium flex items-center gap-2">
                 {paymentMethod ? (

--- a/apps/app/src/components/billing/SubscriptionManagement.tsx
+++ b/apps/app/src/components/billing/SubscriptionManagement.tsx
@@ -25,7 +25,7 @@ interface CancelSubscriptionResponse {
 interface SubscriptionManagementProps {
   currentPlan: UserPlan;
   onOpenBillingPortal: () => void;
-  onUpgrade: (plan: UserPlan, interval: "monthly" | "yearly") => void;
+  onUpgrade: (plan: UserPlan) => void;
   onRenewSubscription?: () => void;
   onCancelSubscription: (data: {
     cancelImmediately: boolean;

--- a/apps/app/src/components/billing/SubscriptionManagement.tsx
+++ b/apps/app/src/components/billing/SubscriptionManagement.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { Clock, CreditCard, RefreshCw, X } from "lucide-react";
+import { Clock, RefreshCw, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -35,16 +35,12 @@ interface SubscriptionManagementProps {
   periodEnd?: string;
   isLoading?: boolean;
   cancelAtPeriodEnd?: boolean;
-  subscriptionCanceled?: boolean; // True if user had a subscription but canceled it
-  lastPlan?: UserPlan; // The plan they had before canceling
-  isTrialing?: boolean;
-  trialEnd?: string | null;
-  hasPaymentMethod?: boolean;
+  subscriptionCanceled?: boolean;
+  lastPlan?: UserPlan;
 }
 
 export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
   currentPlan,
-  onOpenBillingPortal,
   onRenewSubscription,
   onCancelSubscription,
   periodEnd,
@@ -52,11 +48,8 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
   cancelAtPeriodEnd,
   subscriptionCanceled = false,
   lastPlan,
-  isTrialing = false,
-  trialEnd,
-  hasPaymentMethod = false,
 }) => {
-  const { t, i18n } = useTranslation("billing");
+  const { t } = useTranslation("billing");
   const [showCancelModal, setShowCancelModal] = useState(false);
 
   const handleCancelClick = () => {
@@ -78,10 +71,9 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
         <CardHeader>
           <div className="flex justify-between items-start">
             <div>
-              <CardTitle>Subscription Management</CardTitle>
+              <CardTitle>{t("subscriptionManagement.title")}</CardTitle>
               <p className="text-sm text-muted-foreground">
-                Manage your plan, billing cycle, and subscription settings for
-                all your workspaces
+                {t("subscriptionManagement.description")}
               </p>
             </div>
             {/* Subscription Actions */}
@@ -89,7 +81,6 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
             subscriptionCanceled &&
             lastPlan &&
             onRenewSubscription ? (
-              // Show renew button for canceled subscriptions
               <Button
                 onClick={onRenewSubscription}
                 className="bg-primary hover:bg-primary/90 text-primary-foreground"
@@ -99,11 +90,9 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
                 Renew {lastPlan} Plan
               </Button>
             ) : currentPlan !== UserPlan.FREE ? (
-              // Show cancel/pending cancellation for active paid plans
               <>
                 {cancelAtPeriodEnd ? (
                   <div className="flex items-center gap-3">
-                    {/* Show renewal option alongside cancellation notice */}
                     {onRenewSubscription && (
                       <Button
                         onClick={onRenewSubscription}
@@ -146,57 +135,8 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
             ) : null}
           </div>
         </CardHeader>
-        <CardContent>
-          {/* Subscription Status Information */}
-          {isTrialing ? (
-            <div className="bg-primary/10 border border-primary/20 rounded-lg p-4">
-              <div className="flex items-start gap-3">
-                <div className="shrink-0">
-                  <Clock className="w-5 h-5 text-primary mt-0.5" />
-                </div>
-                <div className="flex-1">
-                  <h4 className="font-medium text-primary mb-1">
-                    {t("trial.trialActive")}
-                  </h4>
-                  <p className="text-sm text-primary/80 mb-3">
-                    {hasPaymentMethod
-                      ? t("trial.trialActiveWithPayment", {
-                          date: trialEnd
-                            ? new Date(trialEnd).toLocaleDateString(
-                                i18n.language,
-                                {
-                                  year: "numeric",
-                                  month: "long",
-                                  day: "numeric",
-                                }
-                              )
-                            : "",
-                        })
-                      : t("trial.addPaymentToKeep", {
-                          date: trialEnd
-                            ? new Date(trialEnd).toLocaleDateString(
-                                i18n.language,
-                                {
-                                  year: "numeric",
-                                  month: "long",
-                                  day: "numeric",
-                                }
-                              )
-                            : "",
-                        })}
-                  </p>
-                  {!hasPaymentMethod && (
-                    <Button onClick={onOpenBillingPortal} size="sm">
-                      <CreditCard className="w-4 h-4 mr-2" />
-                      {t("trial.addPaymentMethod")}
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </div>
-          ) : currentPlan === UserPlan.FREE &&
-            subscriptionCanceled &&
-            lastPlan ? (
+        {currentPlan === UserPlan.FREE && subscriptionCanceled && lastPlan && (
+          <CardContent>
             <div className="bg-primary/10 border border-primary/20 rounded-lg p-4">
               <div className="flex items-start gap-3">
                 <div className="shrink-0">
@@ -214,8 +154,8 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
                 </div>
               </div>
             </div>
-          ) : null}
-        </CardContent>
+          </CardContent>
+        )}
       </Card>
 
       <CancelSubscriptionModal

--- a/apps/app/src/components/billing/SubscriptionManagement.tsx
+++ b/apps/app/src/components/billing/SubscriptionManagement.tsx
@@ -54,7 +54,7 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
   isTrialing = false,
   trialEnd,
 }) => {
-  const { t } = useTranslation("billing");
+  const { t, i18n } = useTranslation("billing");
   const [showCancelModal, setShowCancelModal] = useState(false);
 
   const handleCancelClick = () => {
@@ -159,7 +159,7 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
                   <p className="text-sm text-primary/80 mb-3">
                     {t("trial.addPaymentToKeep", {
                       date: trialEnd
-                        ? new Date(trialEnd).toLocaleDateString("en-US", {
+                        ? new Date(trialEnd).toLocaleDateString(i18n.language, {
                             year: "numeric",
                             month: "long",
                             day: "numeric",

--- a/apps/app/src/components/billing/SubscriptionManagement.tsx
+++ b/apps/app/src/components/billing/SubscriptionManagement.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
 
-import { Clock, RefreshCw, X } from "lucide-react";
+import { Clock, CreditCard, RefreshCw, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -36,10 +37,13 @@ interface SubscriptionManagementProps {
   cancelAtPeriodEnd?: boolean;
   subscriptionCanceled?: boolean; // True if user had a subscription but canceled it
   lastPlan?: UserPlan; // The plan they had before canceling
+  isTrialing?: boolean;
+  trialEnd?: string | null;
 }
 
 export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
   currentPlan,
+  onOpenBillingPortal,
   onRenewSubscription,
   onCancelSubscription,
   periodEnd,
@@ -47,7 +51,10 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
   cancelAtPeriodEnd,
   subscriptionCanceled = false,
   lastPlan,
+  isTrialing = false,
+  trialEnd,
 }) => {
+  const { t } = useTranslation("billing");
   const [showCancelModal, setShowCancelModal] = useState(false);
 
   const handleCancelClick = () => {
@@ -139,7 +146,37 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
         </CardHeader>
         <CardContent>
           {/* Subscription Status Information */}
-          {currentPlan === UserPlan.FREE && subscriptionCanceled && lastPlan ? (
+          {isTrialing ? (
+            <div className="bg-primary/10 border border-primary/20 rounded-lg p-4">
+              <div className="flex items-start gap-3">
+                <div className="shrink-0">
+                  <Clock className="w-5 h-5 text-primary mt-0.5" />
+                </div>
+                <div className="flex-1">
+                  <h4 className="font-medium text-primary mb-1">
+                    {t("trial.trialActive")}
+                  </h4>
+                  <p className="text-sm text-primary/80 mb-3">
+                    {t("trial.addPaymentToKeep", {
+                      date: trialEnd
+                        ? new Date(trialEnd).toLocaleDateString("en-US", {
+                            year: "numeric",
+                            month: "long",
+                            day: "numeric",
+                          })
+                        : "",
+                    })}
+                  </p>
+                  <Button onClick={onOpenBillingPortal} size="sm">
+                    <CreditCard className="w-4 h-4 mr-2" />
+                    {t("trial.addPaymentMethod")}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : currentPlan === UserPlan.FREE &&
+            subscriptionCanceled &&
+            lastPlan ? (
             <div className="bg-primary/10 border border-primary/20 rounded-lg p-4">
               <div className="flex items-start gap-3">
                 <div className="shrink-0">

--- a/apps/app/src/components/billing/SubscriptionManagement.tsx
+++ b/apps/app/src/components/billing/SubscriptionManagement.tsx
@@ -39,6 +39,7 @@ interface SubscriptionManagementProps {
   lastPlan?: UserPlan; // The plan they had before canceling
   isTrialing?: boolean;
   trialEnd?: string | null;
+  hasPaymentMethod?: boolean;
 }
 
 export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
@@ -53,6 +54,7 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
   lastPlan,
   isTrialing = false,
   trialEnd,
+  hasPaymentMethod = false,
 }) => {
   const { t, i18n } = useTranslation("billing");
   const [showCancelModal, setShowCancelModal] = useState(false);
@@ -157,20 +159,38 @@ export const SubscriptionManagement: React.FC<SubscriptionManagementProps> = ({
                     {t("trial.trialActive")}
                   </h4>
                   <p className="text-sm text-primary/80 mb-3">
-                    {t("trial.addPaymentToKeep", {
-                      date: trialEnd
-                        ? new Date(trialEnd).toLocaleDateString(i18n.language, {
-                            year: "numeric",
-                            month: "long",
-                            day: "numeric",
-                          })
-                        : "",
-                    })}
+                    {hasPaymentMethod
+                      ? t("trial.trialActiveWithPayment", {
+                          date: trialEnd
+                            ? new Date(trialEnd).toLocaleDateString(
+                                i18n.language,
+                                {
+                                  year: "numeric",
+                                  month: "long",
+                                  day: "numeric",
+                                }
+                              )
+                            : "",
+                        })
+                      : t("trial.addPaymentToKeep", {
+                          date: trialEnd
+                            ? new Date(trialEnd).toLocaleDateString(
+                                i18n.language,
+                                {
+                                  year: "numeric",
+                                  month: "long",
+                                  day: "numeric",
+                                }
+                              )
+                            : "",
+                        })}
                   </p>
-                  <Button onClick={onOpenBillingPortal} size="sm">
-                    <CreditCard className="w-4 h-4 mr-2" />
-                    {t("trial.addPaymentMethod")}
-                  </Button>
+                  {!hasPaymentMethod && (
+                    <Button onClick={onOpenBillingPortal} size="sm">
+                      <CreditCard className="w-4 h-4 mr-2" />
+                      {t("trial.addPaymentMethod")}
+                    </Button>
+                  )}
                 </div>
               </div>
             </div>

--- a/apps/app/src/components/plans/PlanUpgradeModal.tsx
+++ b/apps/app/src/components/plans/PlanUpgradeModal.tsx
@@ -10,7 +10,6 @@ import { trpc } from "@/lib/trpc/client";
 
 import { useAllPlans } from "@/hooks/queries/usePlans";
 import { useUser } from "@/hooks/ui/useUser";
-import { useWorkspace } from "@/hooks/ui/useWorkspace";
 
 import { UserPlan } from "@/types/plans";
 
@@ -27,7 +26,6 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
 }) => {
   const { t } = useTranslation("billing");
   const { planData, userPlan } = useUser();
-  const { workspace } = useWorkspace();
   const navigate = useNavigate();
   const [isUpgrading, setIsUpgrading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -46,21 +44,17 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
     },
   });
 
-  const handleUpgrade = async (targetPlan: UserPlan) => {
+  const handleUpgrade = async () => {
     try {
       setError(null);
-      setIsUpgrading(targetPlan);
+      setIsUpgrading("ENTERPRISE");
 
-      logger.info(`Starting upgrade to ${targetPlan}`);
-
-      if (!workspace?.id) {
-        throw new Error(t("error.workspaceIdRequired"));
-      }
+      logger.info("Starting free trial");
 
       // Start free trial directly (no Stripe Checkout page)
       startTrialMutation.mutate();
     } catch (error) {
-      logger.error("Failed to create checkout session:", error);
+      logger.error("Failed to start trial:", error);
       setError(t("upgradeModal.upgradeFailed"));
       setIsUpgrading(null);
     }
@@ -265,7 +259,7 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
                         ? "bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-400"
                         : "bg-gray-100 hover:bg-gray-200 text-gray-900 disabled:bg-gray-50 disabled:text-gray-400"
                     }`}
-                    onClick={() => handleUpgrade(planData.plan)}
+                    onClick={() => handleUpgrade()}
                     disabled={isUpgrading !== null}
                   >
                     {isUpgrading === planData.plan ? (

--- a/apps/app/src/components/plans/PlanUpgradeModal.tsx
+++ b/apps/app/src/components/plans/PlanUpgradeModal.tsx
@@ -35,18 +35,16 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
   // Fetch all plans data
   const { data: allPlansData } = useAllPlans();
 
-  const createCheckoutMutation =
-    trpc.payment.checkout.createCheckoutSession.useMutation({
-      onSuccess: (data) => {
-        // Redirect to Stripe checkout
-        window.location.href = data.url;
-      },
-      onError: (error) => {
-        logger.error("Failed to create checkout session:", error);
-        setError(t("upgradeModal.upgradeFailed"));
-        setIsUpgrading(null);
-      },
-    });
+  const startTrialMutation = trpc.payment.checkout.startTrial.useMutation({
+    onSuccess: () => {
+      navigate("/billing");
+    },
+    onError: (error) => {
+      logger.error("Failed to start trial:", error);
+      setError(t("upgradeModal.upgradeFailed"));
+      setIsUpgrading(null);
+    },
+  });
 
   const handleUpgrade = async (targetPlan: UserPlan) => {
     try {
@@ -59,11 +57,8 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
         throw new Error(t("error.workspaceIdRequired"));
       }
 
-      // Create Stripe checkout session
-      createCheckoutMutation.mutate({
-        plan: targetPlan,
-        billingInterval: "monthly", // Default to monthly, could be made configurable
-      });
+      // Start free trial directly (no Stripe Checkout page)
+      startTrialMutation.mutate();
     } catch (error) {
       logger.error("Failed to create checkout session:", error);
       setError(t("upgradeModal.upgradeFailed"));

--- a/apps/app/src/components/profile/PlansSummaryTab.tsx
+++ b/apps/app/src/components/profile/PlansSummaryTab.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router";
 
 import {
@@ -12,6 +13,7 @@ import {
 } from "lucide-react";
 
 import { isSelfHostedMode } from "@/lib/featureFlags";
+import { formatDate } from "@/lib/utils";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -31,9 +33,14 @@ export const PlansSummaryTab: React.FC<PlansSummaryTabProps> = ({
   currentPlan,
   className = "",
 }) => {
+  const { t } = useTranslation("billing");
   const { handleUpgrade, isUpgrading } = usePlanUpgrade();
   const { planData } = useUser();
   const currentFeatures = planData?.planFeatures;
+  const isTrialing = planData?.user?.subscriptionStatus === "TRIALING";
+  const trialEndDate = planData?.user?.trialEnd
+    ? new Date(planData.user.trialEnd)
+    : null;
 
   // Helper function to get next plan
   const getNextPlan = (plan: UserPlan): UserPlan | null => {
@@ -99,12 +106,17 @@ export const PlansSummaryTab: React.FC<PlansSummaryTabProps> = ({
               <div>
                 <CardTitle className="flex items-center gap-2">
                   {getPlanDisplayName(currentPlan)} Plan
-                  <Badge variant="outline" className="text-xs">
-                    Current
+                  <Badge
+                    variant={isTrialing ? "outline" : "outline"}
+                    className="text-xs"
+                  >
+                    {isTrialing ? t("trial.badge") : "Current"}
                   </Badge>
                 </CardTitle>
                 <p className="text-sm text-muted-foreground mt-1">
-                  Your active subscription
+                  {isTrialing && trialEndDate
+                    ? `${t("trial.endsOn")}: ${formatDate(trialEndDate)}`
+                    : "Your active subscription"}
                 </p>
               </div>
             </div>

--- a/apps/app/src/components/profile/PlansSummaryTab.tsx
+++ b/apps/app/src/components/profile/PlansSummaryTab.tsx
@@ -264,7 +264,7 @@ export const PlansSummaryTab: React.FC<PlansSummaryTabProps> = ({
 
               <div className="ml-4">
                 <Button
-                  onClick={() => handleUpgrade(nextPlan, "monthly")}
+                  onClick={() => handleUpgrade(nextPlan)}
                   className="btn-primary"
                   disabled={isUpgrading}
                 >

--- a/apps/app/src/components/profile/PlansSummaryTab.tsx
+++ b/apps/app/src/components/profile/PlansSummaryTab.tsx
@@ -105,18 +105,19 @@ export const PlansSummaryTab: React.FC<PlansSummaryTabProps> = ({
               </div>
               <div>
                 <CardTitle className="flex items-center gap-2">
-                  {getPlanDisplayName(currentPlan)} Plan
-                  <Badge
-                    variant={isTrialing ? "outline" : "outline"}
-                    className="text-xs"
-                  >
-                    {isTrialing ? t("trial.badge") : "Current"}
+                  {t("currentPlan.planName", {
+                    plan: getPlanDisplayName(currentPlan),
+                  })}
+                  <Badge variant="outline" className="text-xs">
+                    {isTrialing
+                      ? t("trial.badge")
+                      : t("status.active", "Active")}
                   </Badge>
                 </CardTitle>
                 <p className="text-sm text-muted-foreground mt-1">
                   {isTrialing && trialEndDate
                     ? `${t("trial.endsOn")}: ${formatDate(trialEndDate)}`
-                    : "Your active subscription"}
+                    : t("currentPlan.activeSubscription")}
                 </p>
               </div>
             </div>

--- a/apps/app/src/hooks/ui/usePlanUpgrade.ts
+++ b/apps/app/src/hooks/ui/usePlanUpgrade.ts
@@ -16,17 +16,17 @@ export const usePlanUpgrade = () => {
   const { workspace } = useWorkspace();
   const { user } = useAuth();
 
-  const createCheckoutMutation =
-    trpc.payment.checkout.createCheckoutSession.useMutation({
-      onSuccess: (data) => {
-        window.location.href = data.url;
-      },
-      onError: (error) => {
-        logger.error("Error upgrading plan:", error);
-        alert("There was an error upgrading your plan. Please try again.");
-        setIsUpgrading(false);
-      },
-    });
+  const startTrialMutation = trpc.payment.checkout.startTrial.useMutation({
+    onSuccess: () => {
+      setIsUpgrading(false);
+      navigate("/billing");
+    },
+    onError: (error) => {
+      logger.error("Error starting trial:", error);
+      alert("There was an error starting your trial. Please try again.");
+      setIsUpgrading(false);
+    },
+  });
 
   const createPortalMutation =
     trpc.payment.billing.createPortalSession.useMutation({
@@ -45,7 +45,7 @@ export const usePlanUpgrade = () => {
 
   const handleUpgrade = async (
     targetPlan: UserPlan,
-    billingInterval: "monthly" | "yearly" = "monthly"
+    _billingInterval: "monthly" | "yearly" = "monthly"
   ) => {
     if (!workspace || !user) {
       navigate("/auth/signin");
@@ -64,11 +64,8 @@ export const usePlanUpgrade = () => {
         return;
       }
 
-      // Create Stripe checkout session for paid plans
-      createCheckoutMutation.mutate({
-        plan: targetPlan,
-        billingInterval,
-      });
+      // Start free trial directly (no Stripe Checkout page)
+      startTrialMutation.mutate();
     } catch (error) {
       logger.error("Error upgrading plan:", error);
       alert("There was an error upgrading your plan. Please try again.");

--- a/apps/app/src/hooks/ui/usePlanUpgrade.ts
+++ b/apps/app/src/hooks/ui/usePlanUpgrade.ts
@@ -43,10 +43,7 @@ export const usePlanUpgrade = () => {
       },
     });
 
-  const handleUpgrade = async (
-    targetPlan: UserPlan,
-    _billingInterval: "monthly" | "yearly" = "monthly"
-  ) => {
+  const handleUpgrade = async (targetPlan: UserPlan) => {
     if (!workspace || !user) {
       navigate("/auth/signin");
       return;

--- a/apps/app/src/lib/api/planClient.ts
+++ b/apps/app/src/lib/api/planClient.ts
@@ -10,6 +10,8 @@ export interface CurrentPlanResponse {
     id: string;
     email: string;
     plan: UserPlan;
+    subscriptionStatus: string | null;
+    trialEnd: string | null;
   };
   workspace: {
     id: string;

--- a/apps/app/src/pages/Billing.tsx
+++ b/apps/app/src/pages/Billing.tsx
@@ -169,6 +169,7 @@ const Billing: React.FC = () => {
             subscription={billingData.subscription}
             stripeSubscription={billingData.stripeSubscription}
             paymentMethod={billingData.paymentMethod}
+            onAddPaymentMethod={handleOpenBillingPortal}
           />
 
           <SubscriptionManagement
@@ -194,6 +195,8 @@ const Billing: React.FC = () => {
             }
             subscriptionCanceled={subscriptionCanceled}
             lastPlan={lastPlan}
+            isTrialing={billingData.subscription?.status === "TRIALING"}
+            trialEnd={billingData.subscription?.trialEnd}
           />
 
           <RecentPayments recentPayments={billingData.recentPayments} />

--- a/apps/app/src/pages/Billing.tsx
+++ b/apps/app/src/pages/Billing.tsx
@@ -44,7 +44,7 @@ const Billing: React.FC = () => {
   } = trpc.payment.billing.getBillingOverview.useQuery(undefined, {
     enabled: !!user.id,
     staleTime: 2 * 60 * 1000, // 2 minutes - billing data doesn't change frequently
-    refetchOnWindowFocus: false, // Don't refetch when window gains focus
+    refetchOnWindowFocus: true, // Refetch when returning from Stripe billing portal
     retry: (failureCount: number, error: unknown) => {
       // Don't retry on 429 (rate limit) errors
       if (
@@ -159,6 +159,13 @@ const Billing: React.FC = () => {
   // For now, we'll use a default since we don't have historical plan data
   const lastPlan = subscriptionCanceled ? UserPlan.DEVELOPER : undefined;
 
+  const isTrialing = billingData?.subscription?.status === "TRIALING";
+  const cancelAtPeriodEnd =
+    (billingData?.stripeSubscription as ExtendedStripeSubscription)
+      ?.cancel_at_period_end ||
+    (billingData?.subscription as ExtendedSubscription)?.cancelAtPeriodEnd ||
+    false;
+
   return (
     <BillingLayout isLoading={isLoading} error={!!error || !billingData}>
       {billingData && (
@@ -169,36 +176,36 @@ const Billing: React.FC = () => {
             subscription={billingData.subscription}
             stripeSubscription={billingData.stripeSubscription}
             paymentMethod={billingData.paymentMethod}
-            onAddPaymentMethod={handleOpenBillingPortal}
-          />
-
-          <SubscriptionManagement
-            currentPlan={billingData.subscription?.plan || UserPlan.FREE}
-            onOpenBillingPortal={handleOpenBillingPortal}
-            onUpgrade={handleUpgrade}
-            onRenewSubscription={handleRenewSubscription}
-            onCancelSubscription={handleCancelSubscription}
-            periodEnd={
-              billingData.stripeSubscription?.current_period_end
-                ? new Date(
-                    billingData.stripeSubscription.current_period_end * 1000
-                  ).toISOString()
+            onManagePaymentMethod={handleOpenBillingPortal}
+            onCancelSubscription={
+              isTrialing && !cancelAtPeriodEnd
+                ? handleCancelSubscription
                 : undefined
             }
             isLoading={isLoading}
-            cancelAtPeriodEnd={
-              (billingData.stripeSubscription as ExtendedStripeSubscription)
-                ?.cancel_at_period_end ||
-              (billingData.subscription as ExtendedSubscription)
-                ?.cancelAtPeriodEnd ||
-              false
-            }
-            subscriptionCanceled={subscriptionCanceled}
-            lastPlan={lastPlan}
-            isTrialing={billingData.subscription?.status === "TRIALING"}
-            trialEnd={billingData.subscription?.trialEnd}
-            hasPaymentMethod={!!billingData.paymentMethod}
+            cancelAtPeriodEnd={cancelAtPeriodEnd}
           />
+
+          {!isTrialing && (
+            <SubscriptionManagement
+              currentPlan={billingData.subscription?.plan || UserPlan.FREE}
+              onOpenBillingPortal={handleOpenBillingPortal}
+              onUpgrade={handleUpgrade}
+              onRenewSubscription={handleRenewSubscription}
+              onCancelSubscription={handleCancelSubscription}
+              periodEnd={
+                billingData.stripeSubscription?.current_period_end
+                  ? new Date(
+                      billingData.stripeSubscription.current_period_end * 1000
+                    ).toISOString()
+                  : undefined
+              }
+              isLoading={isLoading}
+              cancelAtPeriodEnd={cancelAtPeriodEnd}
+              subscriptionCanceled={subscriptionCanceled}
+              lastPlan={lastPlan}
+            />
+          )}
 
           <RecentPayments recentPayments={billingData.recentPayments} />
         </>

--- a/apps/app/src/pages/Billing.tsx
+++ b/apps/app/src/pages/Billing.tsx
@@ -197,6 +197,7 @@ const Billing: React.FC = () => {
             lastPlan={lastPlan}
             isTrialing={billingData.subscription?.status === "TRIALING"}
             trialEnd={billingData.subscription?.trialEnd}
+            hasPaymentMethod={!!billingData.paymentMethod}
           />
 
           <RecentPayments recentPayments={billingData.recentPayments} />

--- a/apps/app/src/pages/PaymentCancelled.tsx
+++ b/apps/app/src/pages/PaymentCancelled.tsx
@@ -31,7 +31,7 @@ const PaymentCancelled: React.FC = () => {
 
   const handleTryAgain = () => {
     if (nextPlan) {
-      handleUpgrade(nextPlan, "monthly");
+      handleUpgrade(nextPlan);
     } else {
       // Fallback to plans page if no next plan available
       navigate("/plans");

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -49,17 +49,15 @@ interface PlanCardProps {
   };
   price: string;
   period: "month" | "year";
-  billingPeriod: "monthly" | "yearly";
   originalPrice?: string;
   isCurrentPlan?: boolean;
-  onUpgrade: (plan: UserPlan, billingInterval: "monthly" | "yearly") => void;
+  onUpgrade: (plan: UserPlan) => void;
 }
 
 const PlanCard: React.FC<PlanCardProps> = ({
   plan,
   price,
   period,
-  billingPeriod,
   originalPrice,
   isCurrentPlan,
   onUpgrade,
@@ -345,7 +343,7 @@ const PlanCard: React.FC<PlanCardProps> = ({
         </div>
 
         <Button
-          onClick={() => onUpgrade(plan.id as UserPlan, billingPeriod)}
+          onClick={() => onUpgrade(plan.id as UserPlan)}
           className={`w-full ${isCurrentPlan ? "bg-gray-100 text-gray-600 cursor-not-allowed" : "text-white"}`}
           style={
             !isCurrentPlan
@@ -602,7 +600,6 @@ export const PlansPage: React.FC<PlansPageProps> = ({ onUpgrade }) => {
                         price={currentPricing.price}
                         originalPrice={currentPricing.originalPrice}
                         period={billingPeriod === "monthly" ? "month" : "year"}
-                        billingPeriod={billingPeriod}
                         isCurrentPlan={isCurrentPlan}
                         onUpgrade={onUpgrade || (() => {})}
                       />

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -344,15 +344,7 @@ const PlanCard: React.FC<PlanCardProps> = ({
 
         <Button
           onClick={() => onUpgrade(plan.id as UserPlan)}
-          className={`w-full ${isCurrentPlan ? "bg-gray-100 text-gray-600 cursor-not-allowed" : "text-white"}`}
-          style={
-            !isCurrentPlan
-              ? {
-                  backgroundImage:
-                    "linear-gradient(to right, rgb(234 88 12), rgb(220 38 38))",
-                }
-              : undefined
-          }
+          className={`w-full ${isCurrentPlan ? "bg-gray-100 text-gray-600 cursor-not-allowed" : "bg-gradient-button hover:bg-gradient-button-hover text-white"}`}
           disabled={isCurrentPlan}
         >
           {isCurrentPlan ? t("plans.currentPlan") : t("plans.startFree")}
@@ -363,7 +355,7 @@ const PlanCard: React.FC<PlanCardProps> = ({
 };
 
 interface PlansPageProps {
-  onUpgrade?: (plan: UserPlan, billingInterval: "monthly" | "yearly") => void;
+  onUpgrade?: (plan: UserPlan) => void;
 }
 
 export const PlansPage: React.FC<PlansPageProps> = ({ onUpgrade }) => {

--- a/apps/e2e/tests/billing/trial.spec.ts
+++ b/apps/e2e/tests/billing/trial.spec.ts
@@ -94,7 +94,7 @@ test.describe("Trial Billing UI @p1", () => {
     await adminPage.waitForLoadState("domcontentloaded");
 
     // Verify trial badge is visible
-    await expect(adminPage.getByText("Trial")).toBeVisible({ timeout: 15_000 });
+    await expect(adminPage.getByText(/^Trial$/)).toBeVisible({ timeout: 15_000 });
 
     // Verify "Add payment method" buttons are visible (one in plan card, one in management banner)
     const addPaymentButtons = adminPage.getByRole("button", {
@@ -129,7 +129,7 @@ test.describe("Trial Billing UI @p1", () => {
     await adminPage.waitForLoadState("domcontentloaded");
 
     // Trial badge should still be visible
-    await expect(adminPage.getByText("Trial")).toBeVisible({ timeout: 15_000 });
+    await expect(adminPage.getByText(/^Trial$/)).toBeVisible({ timeout: 15_000 });
 
     // Card last4 should be shown
     await expect(adminPage.getByText("4242")).toBeVisible();
@@ -162,7 +162,7 @@ test.describe("Active Subscription Billing UI @p2", () => {
     await expect(adminPage.getByText("4242")).toBeVisible({ timeout: 15_000 });
 
     // No trial badge
-    await expect(adminPage.getByText("Trial")).not.toBeVisible();
+    await expect(adminPage.getByText(/^Trial$/)).not.toBeVisible();
 
     // No trial banner
     await expect(

--- a/apps/e2e/tests/billing/trial.spec.ts
+++ b/apps/e2e/tests/billing/trial.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from "../../fixtures/test-base.js";
+import { mockTrpcQuery } from "../../helpers/trpc-mock.js";
+
+const now = Math.floor(Date.now() / 1000);
+const thirtyDaysFromNow = now + 30 * 24 * 60 * 60;
+
+function makeBillingOverview(
+  overrides: {
+    status?: string;
+    trialEnd?: string | null;
+    paymentMethod?: unknown;
+  } = {}
+) {
+  const status = overrides.status ?? "TRIALING";
+  const trialEnd =
+    overrides.trialEnd !== undefined
+      ? overrides.trialEnd
+      : new Date(thirtyDaysFromNow * 1000).toISOString();
+
+  return {
+    workspace: { id: "ws-1", name: "Test Workspace" },
+    subscription: {
+      id: "sub-db-1",
+      status,
+      plan: "DEVELOPER",
+      stripeCustomerId: "cus_test123",
+      stripeSubscriptionId: "sub_test123",
+      canceledAt: null,
+      isRenewalAfterCancel: false,
+      previousCancelDate: null,
+      trialStart:
+        status === "TRIALING" ? new Date(now * 1000).toISOString() : null,
+      trialEnd: status === "TRIALING" ? trialEnd : null,
+      createdAt: new Date(now * 1000).toISOString(),
+      updatedAt: new Date(now * 1000).toISOString(),
+    },
+    stripeSubscription: {
+      id: "sub_test123",
+      status: status === "TRIALING" ? "trialing" : "active",
+      current_period_start: now,
+      current_period_end: thirtyDaysFromNow,
+      cancel_at_period_end: false,
+      canceled_at: null,
+      default_payment_method: null,
+      currency: "usd",
+      items: {
+        data: [
+          {
+            price: {
+              id: "price_test123",
+              unit_amount: 1900,
+              currency: "usd",
+              recurring: { interval: "month" },
+            },
+          },
+        ],
+      },
+    },
+    upcomingInvoice: null,
+    paymentMethod: overrides.paymentMethod ?? null,
+    currentUsage: {
+      servers: 1,
+      users: 1,
+      queues: 0,
+      messagesThisMonth: 0,
+    },
+    recentPayments: [],
+  };
+}
+
+const mockPaymentMethod = {
+  id: "pm_test123",
+  type: "card",
+  card: {
+    brand: "visa",
+    last4: "4242",
+    exp_month: 12,
+    exp_year: 2027,
+  },
+  billing_details: null,
+};
+
+test.describe("Trial Billing UI @p1", () => {
+  test("should show trial badge and add payment method button when trialing without card @cloud", async ({
+    adminPage,
+  }) => {
+    await mockTrpcQuery(
+      adminPage,
+      "payment.billing.getBillingOverview",
+      makeBillingOverview({ status: "TRIALING", paymentMethod: null })
+    );
+
+    await adminPage.goto("/billing");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    // Verify trial badge is visible
+    await expect(adminPage.getByText("Trial")).toBeVisible({ timeout: 15_000 });
+
+    // Verify "Add payment method" buttons are visible (one in plan card, one in management banner)
+    const addPaymentButtons = adminPage.getByRole("button", {
+      name: /add payment method/i,
+    });
+    await expect(addPaymentButtons.first()).toBeVisible();
+
+    // Verify trial end date section is shown
+    await expect(adminPage.getByText(/trial ends/i)).toBeVisible();
+
+    // Verify trial active banner is shown
+    await expect(
+      adminPage.getByText(/your trial is active/i)
+    ).toBeVisible();
+  });
+
+  test("should NOT show add payment button when trialing WITH a card @cloud", async ({
+    adminPage,
+  }) => {
+    await mockTrpcQuery(
+      adminPage,
+      "payment.billing.getBillingOverview",
+      makeBillingOverview({
+        status: "TRIALING",
+        paymentMethod: mockPaymentMethod,
+      })
+    );
+
+    await adminPage.goto("/billing");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    // Trial badge should still be visible
+    await expect(adminPage.getByText("Trial")).toBeVisible({ timeout: 15_000 });
+
+    // Card last4 should be shown
+    await expect(adminPage.getByText("4242")).toBeVisible();
+
+    // The add payment button in CurrentPlanCard should NOT be visible
+    // (but the one in SubscriptionManagement banner may still be visible)
+    const planCardPaymentSection = adminPage
+      .locator("[class*='grid']")
+      .getByRole("button", { name: /add payment method/i });
+    await expect(planCardPaymentSection).not.toBeVisible();
+  });
+});
+
+test.describe("Active Subscription Billing UI @p2", () => {
+  test("should NOT show trial badge or trial banner for active subscription @cloud", async ({
+    adminPage,
+  }) => {
+    await mockTrpcQuery(
+      adminPage,
+      "payment.billing.getBillingOverview",
+      makeBillingOverview({
+        status: "ACTIVE",
+        paymentMethod: mockPaymentMethod,
+      })
+    );
+
+    await adminPage.goto("/billing");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    // Wait for page to load
+    await expect(adminPage.getByText("4242")).toBeVisible({ timeout: 15_000 });
+
+    // No trial badge
+    await expect(adminPage.getByText("Trial")).not.toBeVisible();
+
+    // No trial banner
+    await expect(
+      adminPage.getByText(/your trial is active/i)
+    ).not.toBeVisible();
+  });
+});

--- a/apps/e2e/tests/billing/trial.spec.ts
+++ b/apps/e2e/tests/billing/trial.spec.ts
@@ -135,7 +135,7 @@ test.describe("Trial Billing UI @p1", () => {
     // The add payment button in CurrentPlanCard should NOT be visible
     // (but the one in SubscriptionManagement banner may still be visible)
     const planCardPaymentSection = adminPage
-      .locator("[class*='grid']")
+      .getByTestId("current-plan-payment-section")
       .getByRole("button", { name: /add payment method/i });
     await expect(planCardPaymentSection).not.toBeVisible();
   });

--- a/apps/e2e/tests/billing/trial.spec.ts
+++ b/apps/e2e/tests/billing/trial.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "../../fixtures/test-base.js";
 import { mockTrpcQuery } from "../../helpers/trpc-mock.js";
 
 const now = Math.floor(Date.now() / 1000);
-const thirtyDaysFromNow = now + 30 * 24 * 60 * 60;
+const fourteenDaysFromNow = now + 14 * 24 * 60 * 60;
 
 function makeBillingOverview(
   overrides: {
@@ -15,14 +15,14 @@ function makeBillingOverview(
   const trialEnd =
     overrides.trialEnd !== undefined
       ? overrides.trialEnd
-      : new Date(thirtyDaysFromNow * 1000).toISOString();
+      : new Date(fourteenDaysFromNow * 1000).toISOString();
 
   return {
     workspace: { id: "ws-1", name: "Test Workspace" },
     subscription: {
       id: "sub-db-1",
       status,
-      plan: "DEVELOPER",
+      plan: "ENTERPRISE",
       stripeCustomerId: "cus_test123",
       stripeSubscriptionId: "sub_test123",
       canceledAt: null,
@@ -38,7 +38,7 @@ function makeBillingOverview(
       id: "sub_test123",
       status: status === "TRIALING" ? "trialing" : "active",
       current_period_start: now,
-      current_period_end: thirtyDaysFromNow,
+      current_period_end: fourteenDaysFromNow,
       cancel_at_period_end: false,
       canceled_at: null,
       default_payment_method: null,
@@ -100,7 +100,9 @@ test.describe("Trial Billing UI @p1", () => {
     const addPaymentButtons = adminPage.getByRole("button", {
       name: /add payment method/i,
     });
-    await expect(addPaymentButtons.first()).toBeVisible();
+    await expect(addPaymentButtons).toHaveCount(2);
+    await expect(addPaymentButtons.nth(0)).toBeVisible();
+    await expect(addPaymentButtons.nth(1)).toBeVisible();
 
     // Verify trial end date section is shown
     await expect(adminPage.getByText(/trial ends/i)).toBeVisible();
@@ -132,12 +134,11 @@ test.describe("Trial Billing UI @p1", () => {
     // Card last4 should be shown
     await expect(adminPage.getByText("4242")).toBeVisible();
 
-    // The add payment button in CurrentPlanCard should NOT be visible
-    // (but the one in SubscriptionManagement banner may still be visible)
-    const planCardPaymentSection = adminPage
-      .getByTestId("current-plan-payment-section")
-      .getByRole("button", { name: /add payment method/i });
-    await expect(planCardPaymentSection).not.toBeVisible();
+    // No "Add payment method" buttons should be visible when card is on file
+    const addPaymentButtons = adminPage.getByRole("button", {
+      name: /add payment method/i,
+    });
+    await expect(addPaymentButtons).toHaveCount(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Enable Stripe checkout trials without requiring a credit card upfront (`payment_method_collection: "if_required"`, auto-cancel on trial end if no card added)
- Add trial-specific UI to the billing page: "Trial" badge, trial end date, and "Add payment method" button that opens the Stripe Customer Portal
- Update trial-ending email CTA from "Upgrade Now" → "Add Payment Method", linking to `/billing` instead of `/profile?tab=plans`
- Reduce trial period from 30 to 14 days
- Expose `trialStart`/`trialEnd` in `getBillingOverview` API response
- Add i18n trial keys in all 4 locales (en, es, fr, zh)

## Changed files

**Backend:**
- `apps/api/src/trpc/routers/payment/billing.ts` — expose trial dates
- `apps/api/src/trpc/routers/payment/checkout.ts` — 14-day trial
- `apps/api/src/services/stripe/customer.service.ts` — no-card checkout params
- `apps/api/src/services/email/templates/trial-ending-email.tsx` — updated CTA
- `apps/api/locales/{en,es,fr,zh}/emails.json` — updated CTA text

**Frontend:**
- `apps/app/src/components/billing/CurrentPlanCard.tsx` — trial badge, end date, add payment button
- `apps/app/src/components/billing/SubscriptionManagement.tsx` — trial active banner with CTA
- `apps/app/src/pages/Billing.tsx` — wire new props
- `apps/app/public/locales/{en,es,fr,zh}/billing.json` — trial i18n keys

**E2E:**
- `apps/e2e/tests/billing/trial.spec.ts` — 3 test cases for trial UI states

## Test plan

- [ ] API and app build successfully (`pnpm --filter qarote-api build`, `pnpm --filter qarote-app build`)
- [ ] E2E tests pass for trial billing UI (`pnpm --filter e2e test tests/billing/trial.spec.ts`)
- [ ] Start trial via checkout without card — billing page shows "Trial" badge + "Add payment method" button
- [ ] Click "Add payment method" — Stripe Customer Portal opens in new tab
- [ ] Add card in portal — return to billing page, card is now displayed
- [ ] Trial-ending email shows "Add Payment Method" CTA linking to `/billing`
- [ ] Self-hosted license purchase flow is unaffected (still requires card upfront)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start a free trial without a card; billing UI shows trial badge, trial end date, and "Add Payment Method" actions.
  * Billing overview now includes trial start/end timestamps.

* **Changes**
  * Trial length shortened from 30 to 14 days.
  * Upgrade flow now initiates a trial and surfaces billing-portal actions to add payment methods.
  * Trial-ending emails and CTAs now prompt adding a payment method.
  * Added localized billing and error messages (en/es/fr/zh).

* **Tests**
  * End-to-end tests for trial UI and payment-method flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->