### PR TITLE
fix: add packages/i18n to frontend deploy workflow path triggers

### DIFF
--- a/.github/workflows/deploy-frontend-staging.yml
+++ b/.github/workflows/deploy-frontend-staging.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "apps/app/**"
+      - "packages/i18n/**"
       - ".github/workflows/deploy-frontend-staging.yml"
   workflow_dispatch:
 

--- a/.github/workflows/deploy-landing-staging.yml
+++ b/.github/workflows/deploy-landing-staging.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "apps/web/**"
+      - "packages/i18n/**"
       - ".github/workflows/deploy-landing-staging.yml"
   workflow_dispatch:
 

--- a/.github/workflows/deploy-portal-staging.yml
+++ b/.github/workflows/deploy-portal-staging.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "apps/portal/**"
+      - "packages/i18n/**"
       - ".github/workflows/deploy-portal-staging.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Add `packages/i18n/**` to the `paths` trigger of frontend, landing, and portal staging deploy workflows
- Ensures staging deployments are triggered when the i18n package changes (e.g., locale config, exports)

## Context
The `@qarote/i18n` package is a shared dependency used by all frontend apps. Changes to it (like updating exports from source to compiled output) were not triggering frontend redeployments, leading to stale builds in staging.

## Test plan
- [ ] Verify CI workflows trigger on changes to `packages/i18n/`
- [ ] Confirm staging deployments still work correctly for app-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging deployment workflows to trigger when changes occur in the internationalization package, ensuring deployment pipelines run alongside related code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->