### PR TITLE
fix: align react-i18next version in @qarote/i18n package

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -2,7 +2,8 @@
   "dependencyTypes": ["prod", "dev"],
   "source": [
     "package.json",
-    "apps/*/package.json"
+    "apps/*/package.json",
+    "packages/*/package.json"
   ],
   "semverGroups": [
     {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -21,10 +21,10 @@
     }
   },
   "dependencies": {
-    "i18next": "^25.2.1",
+    "i18next": "^25.8.14",
     "i18next-browser-languagedetector": "^8.0.6",
     "i18next-http-backend": "^3.0.2",
-    "react-i18next": "^15.6.1"
+    "react-i18next": "^16.5.4"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -700,8 +700,8 @@ importers:
   packages/i18n:
     dependencies:
       i18next:
-        specifier: ^25.2.1
-        version: 25.8.13(typescript@5.9.3)
+        specifier: ^25.8.14
+        version: 25.8.14(typescript@5.9.3)
       i18next-browser-languagedetector:
         specifier: ^8.0.6
         version: 8.2.1
@@ -712,8 +712,8 @@ importers:
         specifier: '>=18.0.0'
         version: 19.2.4
       react-i18next:
-        specifier: ^15.6.1
-        version: 15.7.4(i18next@25.8.13(typescript@5.9.3))(react@19.2.4)(typescript@5.9.3)
+        specifier: ^16.5.4
+        version: 16.5.4(i18next@25.8.14(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
     devDependencies:
       typescript:
         specifier: ^5.9.3
@@ -5034,14 +5034,6 @@ packages:
   i18next-http-backend@3.0.2:
     resolution: {integrity: sha512-PdlvPnvIp4E1sYi46Ik4tBYh/v/NbYfFFgTjkwFl0is8A18s7/bx9aXqsrOax9WUbeNS6mD2oix7Z0yGGf6m5g==}
 
-  i18next@25.8.13:
-    resolution: {integrity: sha512-E0vzjBY1yM+nsFrtgkjLhST2NBkirkvOVoQa0MSldhsuZ3jUge7ZNpuwG0Cfc74zwo5ZwRzg3uOgT+McBn32iA==}
-    peerDependencies:
-      typescript: ^5
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   i18next@25.8.14:
     resolution: {integrity: sha512-paMUYkfWJMsWPeE/Hejcw+XLhHrQPehem+4wMo+uELnvIwvCG019L9sAIljwjCmEMtFQQO3YeitJY8Kctei3iA==}
     peerDependencies:
@@ -6201,22 +6193,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
-
-  react-i18next@15.7.4:
-    resolution: {integrity: sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==}
-    peerDependencies:
-      i18next: '>= 23.4.0'
-      react: '>= 16.8.0'
-      react-dom: '*'
-      react-native: '*'
-      typescript: ^5
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-      typescript:
-        optional: true
 
   react-i18next@16.5.4:
     resolution: {integrity: sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g==}
@@ -12337,12 +12313,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  i18next@25.8.13(typescript@5.9.3):
-    dependencies:
-      '@babel/runtime': 7.28.6
-    optionalDependencies:
-      typescript: 5.9.3
-
   i18next@25.8.14(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -13499,15 +13469,6 @@ snapshots:
   react-hook-form@7.71.1(react@19.2.4):
     dependencies:
       react: 19.2.4
-
-  react-i18next@15.7.4(i18next@25.8.13(typescript@5.9.3))(react@19.2.4)(typescript@5.9.3):
-    dependencies:
-      '@babel/runtime': 7.28.6
-      html-parse-stringify: 3.0.1
-      i18next: 25.8.13(typescript@5.9.3)
-      react: 19.2.4
-    optionalDependencies:
-      typescript: 5.9.3
 
   react-i18next@16.5.4(i18next@25.8.14(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary
- Update `react-i18next` from `^15.6.1` to `^16.5.4` and `i18next` from `^25.2.1` to `^25.8.14` in `packages/i18n`
- Aligns versions with what PR #291 (dependabot batch update) set in all three apps

## Root cause
PR #291 bumped `react-i18next` from 15.7.4 → 16.5.4 in `apps/app`, `apps/web`, and `apps/portal`, but **not** in `packages/i18n`. This caused pnpm to install two different versions:
- `packages/i18n` → `react-i18next@15.7.4` (used to initialize i18next with `initReactI18next`)
- `apps/app` → `react-i18next@16.5.4` (used by React hooks like `useTranslation`)

Since these are different module instances, the React hooks couldn't find the i18n instance, causing all translations to render as raw keys.

## Test plan
- [ ] Verify translations load correctly on staging after merge
- [ ] Check all three apps (app, web, portal) show translated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)