### PR TITLE
feat: increase developer plan limits from 2 to 3

### DIFF
--- a/apps/api/src/services/plan/__tests__/features.service.test.ts
+++ b/apps/api/src/services/plan/__tests__/features.service.test.ts
@@ -59,20 +59,20 @@ describe("getPlanFeatures", () => {
   });
 
   describe("DEVELOPER plan", () => {
-    it("returns maxServers of 2", () => {
-      expect(getPlanFeatures(UserPlan.DEVELOPER).maxServers).toBe(2);
+    it("returns maxServers of 3", () => {
+      expect(getPlanFeatures(UserPlan.DEVELOPER).maxServers).toBe(3);
     });
 
-    it("returns maxWorkspaces of 2", () => {
-      expect(getPlanFeatures(UserPlan.DEVELOPER).maxWorkspaces).toBe(2);
+    it("returns maxWorkspaces of 3", () => {
+      expect(getPlanFeatures(UserPlan.DEVELOPER).maxWorkspaces).toBe(3);
     });
 
-    it("returns maxUsers of 2", () => {
-      expect(getPlanFeatures(UserPlan.DEVELOPER).maxUsers).toBe(2);
+    it("returns maxUsers of 3", () => {
+      expect(getPlanFeatures(UserPlan.DEVELOPER).maxUsers).toBe(3);
     });
 
-    it("returns maxInvitations of 1", () => {
-      expect(getPlanFeatures(UserPlan.DEVELOPER).maxInvitations).toBe(1);
+    it("returns maxInvitations of 2", () => {
+      expect(getPlanFeatures(UserPlan.DEVELOPER).maxInvitations).toBe(2);
     });
 
     it("returns canInviteUsers as true", () => {

--- a/apps/api/src/services/plan/__tests__/features.service.test.ts
+++ b/apps/api/src/services/plan/__tests__/features.service.test.ts
@@ -95,6 +95,15 @@ describe("getPlanFeatures", () => {
     it("returns displayName of 'Developer'", () => {
       expect(getPlanFeatures(UserPlan.DEVELOPER).displayName).toBe("Developer");
     });
+
+    it("has featureDescriptions matching numeric limits", () => {
+      const descriptions = getPlanFeatures(
+        UserPlan.DEVELOPER
+      ).featureDescriptions;
+      expect(descriptions).toContain("3 RabbitMQ servers");
+      expect(descriptions).toContain("3 workspaces");
+      expect(descriptions).toContain("3 users");
+    });
   });
 
   describe("ENTERPRISE plan", () => {

--- a/apps/api/src/services/plan/__tests__/plan.service.test.ts
+++ b/apps/api/src/services/plan/__tests__/plan.service.test.ts
@@ -229,12 +229,12 @@ describe("validateServerCreation", () => {
     );
   });
 
-  it("does not throw when count is 1 for DEVELOPER (below limit of 2)", () => {
-    expect(() => validateServerCreation(UserPlan.DEVELOPER, 1)).not.toThrow();
+  it("does not throw when count is 2 for DEVELOPER (below limit of 3)", () => {
+    expect(() => validateServerCreation(UserPlan.DEVELOPER, 2)).not.toThrow();
   });
 
-  it("throws PlanLimitExceededError when count equals maxServers for DEVELOPER (count 2)", () => {
-    expect(() => validateServerCreation(UserPlan.DEVELOPER, 2)).toThrow(
+  it("throws PlanLimitExceededError when count equals maxServers for DEVELOPER (count 3)", () => {
+    expect(() => validateServerCreation(UserPlan.DEVELOPER, 3)).toThrow(
       PlanLimitExceededError
     );
   });
@@ -257,8 +257,8 @@ describe("validateWorkspaceCreation", () => {
     );
   });
 
-  it("throws PlanLimitExceededError when count equals maxWorkspaces for DEVELOPER (count 2)", () => {
-    expect(() => validateWorkspaceCreation(UserPlan.DEVELOPER, 2)).toThrow(
+  it("throws PlanLimitExceededError when count equals maxWorkspaces for DEVELOPER (count 3)", () => {
+    expect(() => validateWorkspaceCreation(UserPlan.DEVELOPER, 3)).toThrow(
       PlanLimitExceededError
     );
   });
@@ -283,15 +283,15 @@ describe("validateUserInvitation", () => {
     ).not.toThrow();
   });
 
-  it("throws PlanLimitExceededError for DEVELOPER when totalUsers equals maxUsers (2)", () => {
-    // totalUsers = currentUserCount + pendingInvitations = 2 + 0 = 2 >= maxUsers (2)
-    expect(() => validateUserInvitation(UserPlan.DEVELOPER, 2, 0)).toThrow(
+  it("throws PlanLimitExceededError for DEVELOPER when totalUsers equals maxUsers (3)", () => {
+    // totalUsers = currentUserCount + pendingInvitations = 3 + 0 = 3 >= maxUsers (3)
+    expect(() => validateUserInvitation(UserPlan.DEVELOPER, 3, 0)).toThrow(
       PlanLimitExceededError
     );
   });
 
-  it("throws PlanLimitExceededError for DEVELOPER when pending invitations equals maxInvitations (1)", () => {
-    expect(() => validateUserInvitation(UserPlan.DEVELOPER, 0, 1)).toThrow(
+  it("throws PlanLimitExceededError for DEVELOPER when pending invitations equals maxInvitations (2)", () => {
+    expect(() => validateUserInvitation(UserPlan.DEVELOPER, 0, 2)).toThrow(
       PlanLimitExceededError
     );
   });

--- a/apps/api/src/services/plan/__tests__/plan.service.test.ts
+++ b/apps/api/src/services/plan/__tests__/plan.service.test.ts
@@ -257,6 +257,12 @@ describe("validateWorkspaceCreation", () => {
     );
   });
 
+  it("does not throw when count is 2 for DEVELOPER (below limit of 3)", () => {
+    expect(() =>
+      validateWorkspaceCreation(UserPlan.DEVELOPER, 2)
+    ).not.toThrow();
+  });
+
   it("throws PlanLimitExceededError when count equals maxWorkspaces for DEVELOPER (count 3)", () => {
     expect(() => validateWorkspaceCreation(UserPlan.DEVELOPER, 3)).toThrow(
       PlanLimitExceededError
@@ -280,6 +286,18 @@ describe("validateUserInvitation", () => {
   it("does not throw for DEVELOPER with 1 user and 0 invitations (below limits)", () => {
     expect(() =>
       validateUserInvitation(UserPlan.DEVELOPER, 1, 0)
+    ).not.toThrow();
+  });
+
+  it("does not throw for DEVELOPER with 2 users and 0 invitations (last allowed seat)", () => {
+    expect(() =>
+      validateUserInvitation(UserPlan.DEVELOPER, 2, 0)
+    ).not.toThrow();
+  });
+
+  it("does not throw for DEVELOPER with 0 users and 1 invitation (below maxInvitations)", () => {
+    expect(() =>
+      validateUserInvitation(UserPlan.DEVELOPER, 0, 1)
     ).not.toThrow();
   });
 

--- a/apps/api/src/services/plan/features.service.ts
+++ b/apps/api/src/services/plan/features.service.ts
@@ -93,10 +93,10 @@ export const PLAN_FEATURES: Record<UserPlan, PlanFeatures> = {
     canInviteUsers: true,
 
     // Limits
-    maxServers: 2,
-    maxWorkspaces: 2,
-    maxUsers: 2,
-    maxInvitations: 1,
+    maxServers: 3,
+    maxWorkspaces: 3,
+    maxUsers: 3,
+    maxInvitations: 2,
 
     // Support features
     hasCommunitySupport: true,
@@ -133,9 +133,9 @@ export const PLAN_FEATURES: Record<UserPlan, PlanFeatures> = {
     description: "Ideal for individual developers and small projects",
     color: "text-white bg-blue-600",
     featureDescriptions: [
-      "2 RabbitMQ servers",
-      "2 workspaces",
-      "2 users",
+      "3 RabbitMQ servers",
+      "3 workspaces",
+      "3 users",
       "Can add exchanges, virtual hosts, and RabbitMQ users",
       "Can add queues",
       "Community support",

--- a/apps/api/src/trpc/routers/workspace/__tests__/plan.test.ts
+++ b/apps/api/src/trpc/routers/workspace/__tests__/plan.test.ts
@@ -159,7 +159,7 @@ describe("planRouter.getCurrentPlan", () => {
 
       expect(result.user.plan).toBe(UserPlan.DEVELOPER);
       expect(result.planFeatures.displayName).toBe("Developer");
-      expect(result.planFeatures.maxServers).toBe(2);
+      expect(result.planFeatures.maxServers).toBe(3);
       expect(result.planFeatures.canInviteUsers).toBe(true);
     });
 
@@ -216,9 +216,9 @@ describe("planRouter.getCurrentPlan", () => {
       const result = await caller.getCurrentPlan();
 
       expect(result.usage.servers.current).toBe(1);
-      expect(result.usage.servers.limit).toBe(2);
+      expect(result.usage.servers.limit).toBe(3);
       expect(result.usage.servers.canAdd).toBe(true);
-      expect(result.usage.users.limit).toBe(2);
+      expect(result.usage.users.limit).toBe(3);
     });
 
     it("does not use license fallback in cloud mode", async () => {

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -65,7 +65,7 @@
         "servers": "Up to 3",
         "rabbitMQVersionSupport": "All versions 3.x and 4.x",
         "workspaces": "3 Workspaces",
-        "teamMembers": "5 Team Members"
+        "teamMembers": "3 Team Members"
       }
     },
     "enterprise": {

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -65,7 +65,7 @@
         "servers": "Hasta 3",
         "rabbitMQVersionSupport": "Todas las versiones 3.x y 4.x",
         "workspaces": "3 Espacios de trabajo",
-        "teamMembers": "5 Miembros"
+        "teamMembers": "3 Miembros"
       }
     },
     "enterprise": {

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -65,7 +65,7 @@
         "servers": "Jusqu'à 3",
         "rabbitMQVersionSupport": "Toutes les versions 3.x et 4.x",
         "workspaces": "3 Espaces de travail",
-        "teamMembers": "5 Membres"
+        "teamMembers": "3 Membres"
       }
     },
     "enterprise": {

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -65,7 +65,7 @@
         "servers": "最多 3 个",
         "rabbitMQVersionSupport": "所有 3.x 和 4.x 版本",
         "workspaces": "3 个工作区",
-        "teamMembers": "5 个成员"
+        "teamMembers": "3 个成员"
       }
     },
     "enterprise": {


### PR DESCRIPTION
## Summary
- Increase Developer plan limits: servers, workspaces, and users from 2 to 3
- Increase Developer plan invitations from 1 to 2
- Update feature description strings and test assertions to match

## Test plan
- [ ] Verify Developer plan users can now create up to 3 servers, workspaces, and have 3 users
- [ ] Verify invitation limit is now 2 for Developer plan
- [ ] Run `plan.test.ts` to confirm assertions pass with new limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Developer plan limits increased: max servers, workspaces, and users raised to 3 (from 2); max invitations raised to 2 (from 1).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->