### PR TITLE
Remove redundant startTrial endpoint

### DIFF
--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -113,8 +113,6 @@
     "failedToCreatePortalSession": "Failed to create portal session",
     "cannotCheckoutFreePlan": "Cannot create checkout for FREE plan",
     "failedToCreateCheckoutSession": "Failed to create checkout session",
-    "alreadyHasSubscription": "You already have an active subscription",
-    "failedToStartTrial": "Failed to start free trial",
     "noActiveSubscription": "No active subscription found",
     "failedToCancelSubscription": "Failed to cancel subscription",
     "planRequired": "Plan is required",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -114,8 +114,6 @@
     "failedToCreatePortalSession": "Error al crear la sesión del portal",
     "cannotCheckoutFreePlan": "No se puede crear un pago para el plan GRATUITO",
     "failedToCreateCheckoutSession": "Error al crear la sesión de pago",
-    "alreadyHasSubscription": "Ya tienes una suscripción activa",
-    "failedToStartTrial": "Error al iniciar la prueba gratuita",
     "noActiveSubscription": "No se encontró una suscripción activa",
     "failedToCancelSubscription": "Error al cancelar la suscripción",
     "planRequired": "El plan es obligatorio",

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -114,8 +114,6 @@
     "failedToCreatePortalSession": "Échec de la création de la session du portail",
     "cannotCheckoutFreePlan": "Impossible de créer un paiement pour le plan GRATUIT",
     "failedToCreateCheckoutSession": "Échec de la création de la session de paiement",
-    "alreadyHasSubscription": "Vous avez déjà un abonnement actif",
-    "failedToStartTrial": "Échec du démarrage de l'essai gratuit",
     "noActiveSubscription": "Aucun abonnement actif trouvé",
     "failedToCancelSubscription": "Échec de l'annulation de l'abonnement",
     "planRequired": "Le plan est requis",

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -114,8 +114,6 @@
     "failedToCreatePortalSession": "创建门户会话失败",
     "cannotCheckoutFreePlan": "无法为免费套餐创建结账",
     "failedToCreateCheckoutSession": "创建结账会话失败",
-    "alreadyHasSubscription": "您已有活跃的订阅",
-    "failedToStartTrial": "启动免费试用失败",
     "noActiveSubscription": "未找到活动的订阅",
     "failedToCancelSubscription": "取消订阅失败",
     "planRequired": "套餐为必填项",

--- a/apps/api/src/trpc/routers/payment/checkout.ts
+++ b/apps/api/src/trpc/routers/payment/checkout.ts
@@ -2,8 +2,6 @@ import { TRPCError } from "@trpc/server";
 
 import { getUserDisplayName } from "@/core/utils";
 
-import { EmailService } from "@/services/email/email.service";
-import { CoreStripeService } from "@/services/stripe/core.service";
 import { StripeService } from "@/services/stripe/stripe.service";
 
 import { createCheckoutSessionSchema } from "@/schemas/payment";
@@ -12,16 +10,12 @@ import { emailConfig } from "@/config";
 
 import { router, strictRateLimitedProcedure } from "@/trpc/trpc";
 
-import {
-  BillingInterval,
-  SubscriptionStatus,
-  UserPlan,
-} from "@/generated/prisma/client";
+import { UserPlan } from "@/generated/prisma/client";
 import { te } from "@/i18n";
 
 /**
  * Checkout router
- * Handles Stripe checkout session creation and direct trial starts
+ * Handles Stripe checkout session creation
  */
 export const checkoutRouter = router({
   /**
@@ -47,7 +41,7 @@ export const checkoutRouter = router({
             plan,
             billingInterval,
           },
-          "Creating checkout session with 14-day trial"
+          "Creating checkout session"
         );
 
         // Create Stripe customer if not exists
@@ -67,7 +61,6 @@ export const checkoutRouter = router({
           });
         }
 
-        // Create checkout session with 14-day trial
         const session = await StripeService.createCheckoutSession({
           userId: user.id,
           plan,
@@ -75,8 +68,6 @@ export const checkoutRouter = router({
           successUrl: `${emailConfig.frontendUrl}/payment/success?session_id={CHECKOUT_SESSION_ID}`,
           cancelUrl: `${emailConfig.frontendUrl}/payment/cancelled`,
           customerEmail: user.email,
-          // Automatically give 14-day trial to all users during early access period
-          trialDays: 14,
         });
 
         return { url: session.url };
@@ -88,88 +79,4 @@ export const checkoutRouter = router({
         });
       }
     }),
-
-  /**
-   * Start a free trial directly — no Stripe Checkout page, no card required.
-   * Creates a Stripe customer + subscription with trial, and saves to DB.
-   */
-  startTrial: strictRateLimitedProcedure.mutation(async ({ ctx }) => {
-    const { user, prisma } = ctx;
-
-    try {
-      // Check for existing subscription before provisioning
-      const existingSubscription = await prisma.subscription.findFirst({
-        where: {
-          userId: user.id,
-          status: {
-            in: [SubscriptionStatus.ACTIVE, SubscriptionStatus.TRIALING],
-          },
-        },
-      });
-
-      if (existingSubscription) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: te(ctx.locale, "billing.alreadyHasSubscription"),
-        });
-      }
-
-      ctx.logger.info({ userId: user.id }, "Starting free trial");
-
-      const dbSubscription = await StripeService.provisionTrialForNewUser({
-        userId: user.id,
-        email: user.email,
-        name: getUserDisplayName(user),
-        prisma,
-      });
-
-      if (!dbSubscription) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: te(ctx.locale, "billing.failedToStartTrial"),
-        });
-      }
-
-      // Send welcome email (non-critical)
-      const emailResult = await EmailService.sendUpgradeConfirmationEmail({
-        to: user.email,
-        userName: getUserDisplayName(user),
-        workspaceName: te(ctx.locale, "billing.allWorkspaces"),
-        plan: UserPlan.ENTERPRISE,
-        billingInterval: CoreStripeService.mapBillingIntervalToString(
-          BillingInterval.MONTH
-        ),
-      });
-
-      if (!emailResult.success) {
-        ctx.logger.warn(
-          {
-            email: user.email,
-            error: emailResult.error,
-            method: "EmailService.sendUpgradeConfirmationEmail",
-          },
-          "Failed to send trial welcome email"
-        );
-      }
-
-      ctx.logger.info(
-        {
-          userId: user.id,
-          subscriptionId: dbSubscription.stripeSubscriptionId,
-          trialEnd: dbSubscription.trialEnd,
-        },
-        "Free trial started successfully"
-      );
-
-      return { success: true };
-    } catch (error) {
-      // Re-throw TRPCErrors (e.g. alreadyHasSubscription) as-is
-      if (error instanceof TRPCError) throw error;
-      ctx.logger.error({ error }, "Error starting free trial");
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: te(ctx.locale, "billing.failedToStartTrial"),
-      });
-    }
-  }),
 });

--- a/apps/app/src/components/billing/SubscriptionManagement.tsx
+++ b/apps/app/src/components/billing/SubscriptionManagement.tsx
@@ -25,7 +25,7 @@ interface CancelSubscriptionResponse {
 interface SubscriptionManagementProps {
   currentPlan: UserPlan;
   onOpenBillingPortal: () => void;
-  onUpgrade: (plan: UserPlan) => void;
+  onUpgrade: (plan: UserPlan, billingInterval?: "monthly" | "yearly") => void;
   onRenewSubscription?: () => void;
   onCancelSubscription: (data: {
     cancelImmediately: boolean;

--- a/apps/app/src/components/plans/PlanUpgradeModal.tsx
+++ b/apps/app/src/components/plans/PlanUpgradeModal.tsx
@@ -1,14 +1,13 @@
-import React, { useState } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 
 import { Check, Key, Loader2, X, Zap } from "lucide-react";
 
 import { isSelfHostedMode } from "@/lib/featureFlags";
-import { logger } from "@/lib/logger";
-import { trpc } from "@/lib/trpc/client";
 
 import { useAllPlans } from "@/hooks/queries/usePlans";
+import { usePlanUpgrade } from "@/hooks/ui/usePlanUpgrade";
 import { useUser } from "@/hooks/ui/useUser";
 
 import { UserPlan } from "@/types/plans";
@@ -27,41 +26,10 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
   const { t } = useTranslation("billing");
   const { planData, userPlan } = useUser();
   const navigate = useNavigate();
-  const [isUpgrading, setIsUpgrading] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { handleUpgrade, isUpgrading } = usePlanUpgrade();
 
   // Fetch all plans data
   const { data: allPlansData } = useAllPlans();
-
-  const checkoutMutation =
-    trpc.payment.checkout.createCheckoutSession.useMutation({
-      onSuccess: (data) => {
-        if (data.url) {
-          window.location.href = data.url;
-        }
-      },
-      onError: (error) => {
-        logger.error("Failed to create checkout session:", error);
-        setError(t("upgradeModal.upgradeFailed"));
-        setIsUpgrading(null);
-      },
-    });
-
-  const handleUpgrade = async (plan: UserPlan) => {
-    try {
-      setError(null);
-      setIsUpgrading(plan);
-
-      checkoutMutation.mutate({
-        plan,
-        billingInterval: "monthly",
-      });
-    } catch (error) {
-      logger.error("Failed to create checkout session:", error);
-      setError(t("upgradeModal.upgradeFailed"));
-      setIsUpgrading(null);
-    }
-  };
 
   if (!isOpen) return null;
 
@@ -160,12 +128,6 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
         </div>
 
         <div className="p-6">
-          {error && (
-            <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
-              <p className="text-red-800 text-sm">{error}</p>
-            </div>
-          )}
-
           <div className="grid md:grid-cols-2 gap-6">
             {plans.map((planData) => {
               const isPopular = planData.plan === UserPlan.DEVELOPER;
@@ -263,9 +225,9 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
                         : "bg-gray-100 hover:bg-gray-200 text-gray-900 disabled:bg-gray-50 disabled:text-gray-400"
                     }`}
                     onClick={() => handleUpgrade(planData.plan as UserPlan)}
-                    disabled={isUpgrading !== null}
+                    disabled={isUpgrading}
                   >
-                    {isUpgrading === planData.plan ? (
+                    {isUpgrading ? (
                       <>
                         <Loader2 className="w-4 h-4 inline-block mr-2 animate-spin" />
                         {t("upgradeModal.processing")}

--- a/apps/app/src/components/plans/PlanUpgradeModal.tsx
+++ b/apps/app/src/components/plans/PlanUpgradeModal.tsx
@@ -33,28 +33,31 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
   // Fetch all plans data
   const { data: allPlansData } = useAllPlans();
 
-  const startTrialMutation = trpc.payment.checkout.startTrial.useMutation({
-    onSuccess: () => {
-      navigate("/billing");
-    },
-    onError: (error) => {
-      logger.error("Failed to start trial:", error);
-      setError(t("upgradeModal.upgradeFailed"));
-      setIsUpgrading(null);
-    },
-  });
+  const checkoutMutation =
+    trpc.payment.checkout.createCheckoutSession.useMutation({
+      onSuccess: (data) => {
+        if (data.url) {
+          window.location.href = data.url;
+        }
+      },
+      onError: (error) => {
+        logger.error("Failed to create checkout session:", error);
+        setError(t("upgradeModal.upgradeFailed"));
+        setIsUpgrading(null);
+      },
+    });
 
-  const handleUpgrade = async () => {
+  const handleUpgrade = async (plan: UserPlan) => {
     try {
       setError(null);
-      setIsUpgrading("ENTERPRISE");
+      setIsUpgrading(plan);
 
-      logger.info("Starting free trial");
-
-      // Start free trial directly (no Stripe Checkout page)
-      startTrialMutation.mutate();
+      checkoutMutation.mutate({
+        plan,
+        billingInterval: "monthly",
+      });
     } catch (error) {
-      logger.error("Failed to start trial:", error);
+      logger.error("Failed to create checkout session:", error);
       setError(t("upgradeModal.upgradeFailed"));
       setIsUpgrading(null);
     }
@@ -259,7 +262,7 @@ export const PlanUpgradeModal: React.FC<PlanUpgradeModalProps> = ({
                         ? "bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-400"
                         : "bg-gray-100 hover:bg-gray-200 text-gray-900 disabled:bg-gray-50 disabled:text-gray-400"
                     }`}
-                    onClick={() => handleUpgrade()}
+                    onClick={() => handleUpgrade(planData.plan as UserPlan)}
                     disabled={isUpgrading !== null}
                   >
                     {isUpgrading === planData.plan ? (

--- a/apps/app/src/hooks/ui/usePlanUpgrade.ts
+++ b/apps/app/src/hooks/ui/usePlanUpgrade.ts
@@ -10,6 +10,8 @@ import { UserPlan } from "@/types/plans";
 
 import { useWorkspace } from "./useWorkspace";
 
+type BillingInterval = "monthly" | "yearly";
+
 export const usePlanUpgrade = () => {
   const [isUpgrading, setIsUpgrading] = useState(false);
   const navigate = useNavigate();
@@ -21,6 +23,9 @@ export const usePlanUpgrade = () => {
       onSuccess: (data) => {
         if (data.url) {
           window.location.href = data.url;
+        } else {
+          logger.error("Checkout session returned no URL");
+          setIsUpgrading(false);
         }
       },
       onError: (error) => {
@@ -47,7 +52,10 @@ export const usePlanUpgrade = () => {
       },
     });
 
-  const handleUpgrade = async (targetPlan: UserPlan) => {
+  const handleUpgrade = async (
+    targetPlan: UserPlan,
+    billingInterval: BillingInterval = "monthly"
+  ) => {
     if (!workspace || !user) {
       navigate("/auth/signin");
       return;
@@ -67,7 +75,7 @@ export const usePlanUpgrade = () => {
 
       checkoutMutation.mutate({
         plan: targetPlan,
-        billingInterval: "monthly",
+        billingInterval,
       });
     } catch (error) {
       logger.error("Error upgrading plan:", error);

--- a/apps/app/src/hooks/ui/usePlanUpgrade.ts
+++ b/apps/app/src/hooks/ui/usePlanUpgrade.ts
@@ -16,17 +16,21 @@ export const usePlanUpgrade = () => {
   const { workspace } = useWorkspace();
   const { user } = useAuth();
 
-  const startTrialMutation = trpc.payment.checkout.startTrial.useMutation({
-    onSuccess: () => {
-      setIsUpgrading(false);
-      navigate("/billing");
-    },
-    onError: (error) => {
-      logger.error("Error starting trial:", error);
-      alert("There was an error starting your trial. Please try again.");
-      setIsUpgrading(false);
-    },
-  });
+  const checkoutMutation =
+    trpc.payment.checkout.createCheckoutSession.useMutation({
+      onSuccess: (data) => {
+        if (data.url) {
+          window.location.href = data.url;
+        }
+      },
+      onError: (error) => {
+        logger.error("Error creating checkout session:", error);
+        alert(
+          "There was an error creating the checkout session. Please try again."
+        );
+        setIsUpgrading(false);
+      },
+    });
 
   const createPortalMutation =
     trpc.payment.billing.createPortalSession.useMutation({
@@ -61,8 +65,10 @@ export const usePlanUpgrade = () => {
         return;
       }
 
-      // Start free trial directly (no Stripe Checkout page)
-      startTrialMutation.mutate();
+      checkoutMutation.mutate({
+        plan: targetPlan,
+        billingInterval: "monthly",
+      });
     } catch (error) {
       logger.error("Error upgrading plan:", error);
       alert("There was an error upgrading your plan. Please try again.");

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -53,6 +53,7 @@ interface PlanCardProps {
   isCurrentPlan?: boolean;
   onUpgrade: (plan: UserPlan, billingInterval: "monthly" | "yearly") => void;
   billingInterval: "monthly" | "yearly";
+  isUpgrading?: boolean;
 }
 
 const PlanCard: React.FC<PlanCardProps> = ({
@@ -63,6 +64,7 @@ const PlanCard: React.FC<PlanCardProps> = ({
   isCurrentPlan,
   onUpgrade,
   billingInterval,
+  isUpgrading,
 }) => {
   const { t } = useTranslation("billing");
 
@@ -346,8 +348,8 @@ const PlanCard: React.FC<PlanCardProps> = ({
 
         <Button
           onClick={() => onUpgrade(plan.id as UserPlan, billingInterval)}
-          className={`w-full ${isCurrentPlan ? "bg-gray-100 text-gray-600 cursor-not-allowed" : "bg-gradient-button hover:bg-gradient-button-hover text-white"}`}
-          disabled={isCurrentPlan}
+          className={`w-full ${isCurrentPlan || isUpgrading ? "bg-gray-100 text-gray-600 cursor-not-allowed" : "bg-gradient-button hover:bg-gradient-button-hover text-white"}`}
+          disabled={isCurrentPlan || isUpgrading}
         >
           {isCurrentPlan ? t("plans.currentPlan") : t("plans.startFree")}
         </Button>
@@ -358,9 +360,13 @@ const PlanCard: React.FC<PlanCardProps> = ({
 
 interface PlansPageProps {
   onUpgrade?: (plan: UserPlan, billingInterval: "monthly" | "yearly") => void;
+  isUpgrading?: boolean;
 }
 
-export const PlansPage: React.FC<PlansPageProps> = ({ onUpgrade }) => {
+export const PlansPage: React.FC<PlansPageProps> = ({
+  onUpgrade,
+  isUpgrading,
+}) => {
   const { t } = useTranslation("billing");
   const [billingPeriod, setBillingPeriod] = useState<"monthly" | "yearly">(
     "monthly"
@@ -597,6 +603,7 @@ export const PlansPage: React.FC<PlansPageProps> = ({ onUpgrade }) => {
                         isCurrentPlan={isCurrentPlan}
                         onUpgrade={onUpgrade || (() => {})}
                         billingInterval={billingPeriod}
+                        isUpgrading={isUpgrading}
                       />
                     );
                   })}
@@ -612,9 +619,9 @@ export const PlansPage: React.FC<PlansPageProps> = ({ onUpgrade }) => {
 
 // Default export for lazy loading
 const Plans: React.FC = () => {
-  const { handleUpgrade } = usePlanUpgrade();
+  const { handleUpgrade, isUpgrading } = usePlanUpgrade();
 
-  return <PlansPage onUpgrade={handleUpgrade} />;
+  return <PlansPage onUpgrade={handleUpgrade} isUpgrading={isUpgrading} />;
 };
 
 export default Plans;

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -51,7 +51,8 @@ interface PlanCardProps {
   period: "month" | "year";
   originalPrice?: string;
   isCurrentPlan?: boolean;
-  onUpgrade: (plan: UserPlan) => void;
+  onUpgrade: (plan: UserPlan, billingInterval: "monthly" | "yearly") => void;
+  billingInterval: "monthly" | "yearly";
 }
 
 const PlanCard: React.FC<PlanCardProps> = ({
@@ -61,6 +62,7 @@ const PlanCard: React.FC<PlanCardProps> = ({
   originalPrice,
   isCurrentPlan,
   onUpgrade,
+  billingInterval,
 }) => {
   const { t } = useTranslation("billing");
 
@@ -343,7 +345,7 @@ const PlanCard: React.FC<PlanCardProps> = ({
         </div>
 
         <Button
-          onClick={() => onUpgrade(plan.id as UserPlan)}
+          onClick={() => onUpgrade(plan.id as UserPlan, billingInterval)}
           className={`w-full ${isCurrentPlan ? "bg-gray-100 text-gray-600 cursor-not-allowed" : "bg-gradient-button hover:bg-gradient-button-hover text-white"}`}
           disabled={isCurrentPlan}
         >
@@ -355,7 +357,7 @@ const PlanCard: React.FC<PlanCardProps> = ({
 };
 
 interface PlansPageProps {
-  onUpgrade?: (plan: UserPlan) => void;
+  onUpgrade?: (plan: UserPlan, billingInterval: "monthly" | "yearly") => void;
 }
 
 export const PlansPage: React.FC<PlansPageProps> = ({ onUpgrade }) => {
@@ -594,6 +596,7 @@ export const PlansPage: React.FC<PlansPageProps> = ({ onUpgrade }) => {
                         period={billingPeriod === "monthly" ? "month" : "year"}
                         isCurrentPlan={isCurrentPlan}
                         onUpgrade={onUpgrade || (() => {})}
+                        billingInterval={billingPeriod}
                       />
                     );
                   })}


### PR DESCRIPTION
## Summary
- Removed the `startTrial` tRPC endpoint — free trial is already auto-provisioned on user registration
- Removed the 14-day trial period from `createCheckoutSession` — upgrades now go through standard Stripe Checkout
- Updated `usePlanUpgrade` and `PlanUpgradeModal` to use `createCheckoutSession` with the actual selected plan
- Cleaned up unused i18n keys (`alreadyHasSubscription`, `failedToStartTrial`) from all 4 locale files

## Test plan
- [ ] Register a new user → verify 14-day Enterprise trial is still provisioned
- [ ] Click upgrade from billing page → verify Stripe Checkout opens (no trial)
- [ ] Click upgrade from feature-gate modal → verify correct plan is passed to Stripe Checkout
- [ ] Verify existing trial users still see trial badge and trial UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgrades now support choosing a billing interval (monthly or yearly) during checkout.
* **Behavior Changes**
  * Free trial signup removed — users go directly to checkout when upgrading.
  * Upgrade flow unified into a single checkout experience for all paid plans.
* **Documentation/Localization**
  * Trial-related billing error messages removed across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->