### PR TITLE
fix: use theme-aware colors on auth pages for dark mode

### DIFF
--- a/apps/app/src/pages/AcceptInvitation.tsx
+++ b/apps/app/src/pages/AcceptInvitation.tsx
@@ -145,7 +145,7 @@ const AcceptInvitation = () => {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-auth py-12 px-4 sm:px-6 lg:px-8">
-        <Card className="w-full max-w-md bg-white/95 backdrop-blur-xs border-white/20 shadow-2xl">
+        <Card className="w-full max-w-md bg-card/95 backdrop-blur-xs border-border/20 shadow-2xl">
           <CardContent className="flex items-center justify-center py-8">
             <Loader2 className="h-8 w-8 animate-spin" />
           </CardContent>
@@ -157,7 +157,7 @@ const AcceptInvitation = () => {
   if (error && !invitation) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-auth py-12 px-4 sm:px-6 lg:px-8">
-        <Card className="w-full max-w-md bg-white/95 backdrop-blur-xs border-white/20 shadow-2xl">
+        <Card className="w-full max-w-md bg-card/95 backdrop-blur-xs border-border/20 shadow-2xl">
           <CardHeader className="text-center">
             <CardTitle className="text-red-600">
               {t("invalidInvitation")}
@@ -186,7 +186,7 @@ const AcceptInvitation = () => {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-auth py-12 px-4 sm:px-6 lg:px-8">
-      <Card className="w-full max-w-md bg-white/95 backdrop-blur-xs border-white/20 shadow-2xl">
+      <Card className="w-full max-w-md bg-card/95 backdrop-blur-xs border-border/20 shadow-2xl">
         <CardHeader className="text-center">
           <div className="mx-auto mb-4 h-12 w-12 rounded-full bg-blue-100 flex items-center justify-center">
             <Mail className="h-6 w-6 text-blue-600" />

--- a/apps/app/src/pages/SSOCallback.tsx
+++ b/apps/app/src/pages/SSOCallback.tsx
@@ -77,9 +77,9 @@ const SSOCallback: React.FC = () => {
   if (error) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-auth py-12 px-4">
-        <Card className="max-w-md w-full bg-white/95 backdrop-blur-xs">
+        <Card className="max-w-md w-full bg-card/95 backdrop-blur-xs border-border/20 shadow-2xl">
           <CardHeader>
-            <CardTitle className="text-gray-900">
+            <CardTitle className="text-card-foreground">
               Authentication Error
             </CardTitle>
           </CardHeader>

--- a/apps/app/src/pages/SignIn.tsx
+++ b/apps/app/src/pages/SignIn.tsx
@@ -80,9 +80,11 @@ const SignIn: React.FC = () => {
           )}
         </div>
 
-        <Card className="bg-white/95 backdrop-blur-xs border-white/20 shadow-2xl">
+        <Card className="bg-card/95 backdrop-blur-xs border-border/20 shadow-2xl">
           <CardHeader>
-            <CardTitle className="text-gray-900">{t("welcomeBack")}</CardTitle>
+            <CardTitle className="text-card-foreground">
+              {t("welcomeBack")}
+            </CardTitle>
             <CardDescription>{t("enterCredentials")}</CardDescription>
           </CardHeader>
           <CardContent>
@@ -188,7 +190,7 @@ const SignIn: React.FC = () => {
                     <span className="w-full border-t" />
                   </div>
                   <div className="relative flex justify-center text-xs uppercase">
-                    <span className="bg-white px-2 text-muted-foreground">
+                    <span className="bg-card px-2 text-muted-foreground">
                       {t("orContinueWith")}
                     </span>
                   </div>

--- a/apps/app/src/pages/SignUp.tsx
+++ b/apps/app/src/pages/SignUp.tsx
@@ -114,9 +114,11 @@ const SignUp: React.FC = () => {
           </p>
         </div>
 
-        <Card className="bg-white/95 backdrop-blur-xs border-white/20 shadow-2xl">
+        <Card className="bg-card/95 backdrop-blur-xs border-border/20 shadow-2xl">
           <CardHeader>
-            <CardTitle className="text-gray-900">{t("getStarted")}</CardTitle>
+            <CardTitle className="text-card-foreground">
+              {t("getStarted")}
+            </CardTitle>
             <CardDescription>{t("createAccountDescription")}</CardDescription>
           </CardHeader>
           <CardContent>
@@ -349,7 +351,7 @@ const SignUp: React.FC = () => {
                     <span className="w-full border-t" />
                   </div>
                   <div className="relative flex justify-center text-xs uppercase">
-                    <span className="bg-white px-2 text-muted-foreground">
+                    <span className="bg-card px-2 text-muted-foreground">
                       {t("orContinueWith")}
                     </span>
                   </div>

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -274,6 +274,7 @@
     --sidebar-border: 25 15% 15%;
     --sidebar-ring: 25 95% 53%;
   }
+
 }
 
 @layer base {

--- a/apps/portal/src/pages/Login.tsx
+++ b/apps/portal/src/pages/Login.tsx
@@ -82,9 +82,11 @@ const Login = () => {
           </p>
         </div>
 
-        <Card className="bg-white/95 backdrop-blur-xs border-white/20 shadow-2xl">
+        <Card className="bg-card/95 backdrop-blur-xs border-border/20 shadow-2xl">
           <CardHeader>
-            <CardTitle className="text-gray-900">{t("welcomeBack")}</CardTitle>
+            <CardTitle className="text-card-foreground">
+              {t("welcomeBack")}
+            </CardTitle>
             <CardDescription>{t("enterCredentials")}</CardDescription>
           </CardHeader>
           <CardContent>
@@ -188,7 +190,7 @@ const Login = () => {
                 <span className="w-full border-t" />
               </div>
               <div className="relative flex justify-center text-xs uppercase">
-                <span className="bg-white px-2 text-muted-foreground">
+                <span className="bg-card px-2 text-muted-foreground">
                   {t("orContinueWith")}
                 </span>
               </div>

--- a/apps/portal/src/pages/SignUp.tsx
+++ b/apps/portal/src/pages/SignUp.tsx
@@ -101,9 +101,11 @@ const SignUp = () => {
           </p>
         </div>
 
-        <Card className="bg-white/95 backdrop-blur-xs border-white/20 shadow-2xl">
+        <Card className="bg-card/95 backdrop-blur-xs border-border/20 shadow-2xl">
           <CardHeader>
-            <CardTitle className="text-gray-900">{t("getStarted")}</CardTitle>
+            <CardTitle className="text-card-foreground">
+              {t("getStarted")}
+            </CardTitle>
             <CardDescription>{t("createAccountDescription")}</CardDescription>
           </CardHeader>
           <CardContent>
@@ -313,7 +315,7 @@ const SignUp = () => {
                     <span className="w-full border-t" />
                   </div>
                   <div className="relative flex justify-center text-xs uppercase">
-                    <span className="bg-white px-2 text-muted-foreground">
+                    <span className="bg-card px-2 text-muted-foreground">
                       {t("orContinueWith")}
                     </span>
                   </div>

--- a/apps/portal/src/styles/index.css
+++ b/apps/portal/src/styles/index.css
@@ -346,6 +346,7 @@
     --sidebar-border: 25 14% 12%;
     --sidebar-ring: 25 95% 53%;
   }
+
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- Replace hardcoded white colors (`bg-white/95`, `text-gray-900`, `border-white/20`) with theme CSS variables (`bg-card/95`, `text-card-foreground`, `border-border/20`) on all auth pages
- Fix divider "OR CONTINUE WITH" spans using `bg-card` instead of `bg-white`
- Applies to both `app` and `portal` auth pages (SignIn, SignUp, AcceptInvitation, SSOCallback)

## Test plan
- [ ] Toggle dark mode and verify sign-in page cards use dark background with readable inputs
- [ ] Toggle dark mode and verify sign-up page cards use dark background with readable inputs
- [ ] Verify light mode auth pages still look correct (cream/white card)
- [ ] Check AcceptInvitation and SSOCallback pages in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)