### PR TITLE
fix: capture signup and payment errors as sentry exceptions

### DIFF
--- a/apps/api/src/services/sentry/index.ts
+++ b/apps/api/src/services/sentry/index.ts
@@ -157,11 +157,12 @@ export function trackSignUpError(
     },
   });
 
+  if (error === undefined) return;
+
   const Sentry = getSentry();
   if (!Sentry) return;
 
-  const exception =
-    error instanceof Error ? error : new Error(`Signup failed: ${errorType}`);
+  const exception = error instanceof Error ? error : new Error(String(error));
 
   Sentry.withScope((scope) => {
     scope.setTag("component", "signup");
@@ -188,11 +189,12 @@ export function trackPaymentError(
     },
   });
 
+  if (error === undefined) return;
+
   const Sentry = getSentry();
   if (!Sentry) return;
 
-  const exception =
-    error instanceof Error ? error : new Error(`Payment failed: ${errorType}`);
+  const exception = error instanceof Error ? error : new Error(String(error));
 
   Sentry.withScope((scope) => {
     scope.setTag("component", "payment");

--- a/apps/api/src/services/sentry/index.ts
+++ b/apps/api/src/services/sentry/index.ts
@@ -142,12 +142,13 @@ export function captureMessageProcessingError(
 }
 
 /**
- * Track sign up errors as metrics
+ * Track sign up errors as metrics and capture as Sentry exception
  * Only tracks in production environment
  */
 export function trackSignUpError(
   errorType: SignUpErrorType,
-  attributes: MetricAttributes
+  attributes: MetricAttributes,
+  error?: unknown
 ) {
   trackMetricCount("signup.error", 1, {
     tags: {
@@ -155,21 +156,50 @@ export function trackSignUpError(
       ...attributes,
     },
   });
+
+  const Sentry = getSentry();
+  if (!Sentry) return;
+
+  const exception =
+    error instanceof Error ? error : new Error(`Signup failed: ${errorType}`);
+
+  Sentry.withScope((scope) => {
+    scope.setTag("component", "signup");
+    scope.setTag("error_type", errorType);
+    scope.setLevel("error");
+    scope.setContext("signup", attributes);
+    Sentry.captureException(exception);
+  });
 }
 
 /**
- * Track payment errors as metrics
+ * Track payment errors as metrics and capture as Sentry exception
  * Only tracks in production environment
  */
 export function trackPaymentError(
   errorType: PaymentErrorType,
-  attributes: MetricAttributes
+  attributes: MetricAttributes,
+  error?: unknown
 ) {
   trackMetricCount("payment.error", 1, {
     tags: {
       error_type: errorType,
       ...attributes,
     },
+  });
+
+  const Sentry = getSentry();
+  if (!Sentry) return;
+
+  const exception =
+    error instanceof Error ? error : new Error(`Payment failed: ${errorType}`);
+
+  Sentry.withScope((scope) => {
+    scope.setTag("component", "payment");
+    scope.setTag("error_type", errorType);
+    scope.setLevel("error");
+    scope.setContext("payment", attributes);
+    Sentry.captureException(exception);
   });
 }
 

--- a/apps/api/src/services/stripe/core.service.ts
+++ b/apps/api/src/services/stripe/core.service.ts
@@ -403,19 +403,15 @@ export class CoreStripeService {
     });
 
     // Track payment error metric
-    trackPaymentError(
-      "stripe_operation",
-      {
-        operation,
-        error_message: Error.isError(error) ? error.message : "Unknown error",
-        ...Object.fromEntries(
-          Object.entries(context).map(([k, v]) => [
-            k,
-            typeof v === "string" ? v : String(v),
-          ])
-        ),
-      },
-      error
-    );
+    trackPaymentError("stripe_operation", {
+      operation,
+      error_message: Error.isError(error) ? error.message : "Unknown error",
+      ...Object.fromEntries(
+        Object.entries(context).map(([k, v]) => [
+          k,
+          typeof v === "string" ? v : String(v),
+        ])
+      ),
+    });
   }
 }

--- a/apps/api/src/services/stripe/core.service.ts
+++ b/apps/api/src/services/stripe/core.service.ts
@@ -403,15 +403,19 @@ export class CoreStripeService {
     });
 
     // Track payment error metric
-    trackPaymentError("stripe_operation", {
-      operation,
-      error_message: Error.isError(error) ? error.message : "Unknown error",
-      ...Object.fromEntries(
-        Object.entries(context).map(([k, v]) => [
-          k,
-          typeof v === "string" ? v : String(v),
-        ])
-      ),
-    });
+    trackPaymentError(
+      "stripe_operation",
+      {
+        operation,
+        error_message: Error.isError(error) ? error.message : "Unknown error",
+        ...Object.fromEntries(
+          Object.entries(context).map(([k, v]) => [
+            k,
+            typeof v === "string" ? v : String(v),
+          ])
+        ),
+      },
+      error
+    );
   }
 }

--- a/apps/api/src/services/stripe/webhook-handlers.ts
+++ b/apps/api/src/services/stripe/webhook-handlers.ts
@@ -186,10 +186,14 @@ export async function handleCheckoutSessionCompleted(session: Session) {
     logger.info(`User ${userId} upgraded to ${plan}`);
   } catch (error) {
     logger.error({ error }, "Error handling checkout session completed");
-    trackPaymentError("webhook", {
-      handler: "handleCheckoutSessionCompleted",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handleCheckoutSessionCompleted",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -304,10 +308,14 @@ async function handleLicensePurchase(
     });
   } catch (error) {
     logger.error({ error }, "Error handling license purchase");
-    trackPaymentError("webhook", {
-      handler: "handleLicensePurchase",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handleLicensePurchase",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -394,10 +402,14 @@ export async function handleSubscriptionChange(subscription: Subscription) {
     );
   } catch (error) {
     logger.error({ error }, "Error handling subscription change");
-    trackPaymentError("webhook", {
-      handler: "handleSubscriptionChange",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handleSubscriptionChange",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -490,10 +502,14 @@ export async function handleCustomerSubscriptionDeleted(
     }
   } catch (error) {
     logger.error({ error }, "Error handling subscription deletion");
-    trackPaymentError("webhook", {
-      handler: "handleCustomerSubscriptionDeleted",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handleCustomerSubscriptionDeleted",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -667,10 +683,14 @@ export async function handleInvoicePaymentSucceeded(invoice: Invoice) {
     );
   } catch (error) {
     logger.error({ error }, "Error handling invoice payment succeeded");
-    trackPaymentError("webhook", {
-      handler: "handleInvoicePaymentSucceeded",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handleInvoicePaymentSucceeded",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -825,10 +845,14 @@ export async function handleInvoicePaymentFailed(invoice: Invoice) {
     );
   } catch (error) {
     logger.error({ error }, "Error handling invoice payment failed");
-    trackPaymentError("webhook", {
-      handler: "handleInvoicePaymentFailed",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handleInvoicePaymentFailed",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -877,10 +901,14 @@ export async function handleTrialWillEnd(subscription: Subscription) {
     logger.info({ subscriptionId, userId: user.id }, "Trial ending email sent");
   } catch (error) {
     logger.error({ error }, "Error handling trial will end");
-    trackPaymentError("webhook", {
-      handler: "handleTrialWillEnd",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handleTrialWillEnd",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -935,10 +963,14 @@ export async function handlePaymentActionRequired(invoice: Invoice) {
     );
   } catch (error) {
     logger.error({ error }, "Error handling payment action required");
-    trackPaymentError("webhook", {
-      handler: "handlePaymentActionRequired",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handlePaymentActionRequired",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -973,10 +1005,14 @@ export async function handleUpcomingInvoice(invoice: Invoice) {
     );
   } catch (error) {
     logger.error({ error }, "Error handling upcoming invoice");
-    trackPaymentError("webhook", {
-      handler: "handleUpcomingInvoice",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handleUpcomingInvoice",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -986,10 +1022,14 @@ export async function handlePaymentIntentFailed(paymentIntent: PaymentIntent) {
     // Add any custom logic for failed payment intents
   } catch (error) {
     logger.error({ error }, "Error handling payment intent failed");
-    trackPaymentError("webhook", {
-      handler: "handlePaymentIntentFailed",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handlePaymentIntentFailed",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 
@@ -1004,10 +1044,14 @@ export async function handlePaymentIntentSucceeded(
     // Add any custom logic for succeeded payment intents
   } catch (error) {
     logger.error({ error }, "Error handling payment intent succeeded");
-    trackPaymentError("webhook", {
-      handler: "handlePaymentIntentSucceeded",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-    });
+    trackPaymentError(
+      "webhook",
+      {
+        handler: "handlePaymentIntentSucceeded",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+      },
+      error
+    );
   }
 }
 

--- a/apps/api/src/trpc/routers/auth/google.ts
+++ b/apps/api/src/trpc/routers/auth/google.ts
@@ -247,13 +247,17 @@ export const googleRouter = router({
                 );
               });
           } catch (createError) {
-            trackSignUpError("google_oauth", {
-              email,
-              error:
-                createError instanceof Error
-                  ? createError.message
-                  : String(createError),
-            });
+            trackSignUpError(
+              "google_oauth",
+              {
+                email,
+                error:
+                  createError instanceof Error
+                    ? createError.message
+                    : String(createError),
+              },
+              createError
+            );
             throw new TRPCError({
               code: "INTERNAL_SERVER_ERROR",
               message: te(ctx.locale, "auth.failedToCreateUserAccount"),


### PR DESCRIPTION
## Summary
- `trackSignUpError` and `trackPaymentError` previously only incremented Sentry metric counters — they did **not** create Sentry issues, so no alerts could be triggered
- Both functions now also call `captureException` with scoped tags (`component`, `error_type`) and context, making signup and payment failures visible as Sentry issues
- All 13 call sites updated to pass the original `error` object for proper stack traces

## Test plan
- [x] TypeScript compiles without errors
- [x] All 49 Stripe tests pass (webhook-handlers, core-service, webhook-idempotency)
- [ ] Verify in Sentry that new issues appear with correct tags after deployment
- [ ] Configure Sentry alert rules for `component:signup`, `component:payment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced error tracking and monitoring capabilities by improving the capture of error context during sign-up and payment processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->