### PR TITLE
fix: update stale back navigation on billing and plans pages

### DIFF
--- a/apps/api/src/services/email/templates/upcoming-invoice-email.tsx
+++ b/apps/api/src/services/email/templates/upcoming-invoice-email.tsx
@@ -202,7 +202,7 @@ export default function UpcomingInvoiceEmail({
             <Section style={buttonStyles.buttonSection}>
               <Button
                 style={buttonStyles.secondaryButton}
-                href={`${frontendUrl}/profile?tab=plans`}
+                href={`${frontendUrl}/settings/plans`}
               >
                 Manage Billing
               </Button>

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -6,7 +6,7 @@
     "currentPlan": "Current Plan",
     "startFree": "Start free",
     "save20": "Save 20%",
-    "backToProfile": "Back to Profile",
+    "backToPlans": "Back to Plans",
     "pricing": {
       "free": "Free"
     },

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -6,7 +6,7 @@
     "currentPlan": "Plan actual",
     "startFree": "Comenzar gratis",
     "save20": "Ahorra 20%",
-    "backToProfile": "Volver al perfil",
+    "backToPlans": "Volver a los planes",
     "pricing": {
       "free": "Gratuito"
     },

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -6,7 +6,7 @@
     "currentPlan": "Forfait actuel",
     "startFree": "Commencer gratuitement",
     "save20": "Économisez 20%",
-    "backToProfile": "Retour au profil",
+    "backToPlans": "Retour aux forfaits",
     "pricing": {
       "free": "Gratuit"
     },

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -6,7 +6,7 @@
     "currentPlan": "当前方案",
     "startFree": "免费开始",
     "save20": "节省 20%",
-    "backToProfile": "返回个人资料",
+    "backToPlans": "返回套餐",
     "pricing": {
       "free": "免费"
     },

--- a/apps/app/src/components/billing/BillingHeader.tsx
+++ b/apps/app/src/components/billing/BillingHeader.tsx
@@ -9,7 +9,7 @@ export const BillingHeader = () => {
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-4">
         <button
-          onClick={() => navigate("/profile?tab=plans")}
+          onClick={() => navigate("/settings/plans")}
           className="p-2 hover:bg-muted rounded-lg transition-colors"
           title="Back to Profile"
         >

--- a/apps/app/src/components/billing/BillingHeader.tsx
+++ b/apps/app/src/components/billing/BillingHeader.tsx
@@ -11,7 +11,8 @@ export const BillingHeader = () => {
         <button
           onClick={() => navigate("/settings/plans")}
           className="p-2 hover:bg-muted rounded-lg transition-colors"
-          title="Back to Profile"
+          title="Back to Plans"
+          aria-label="Back to Plans"
         >
           <ArrowLeft className="w-4 h-4" />
         </button>

--- a/apps/app/src/components/billing/BillingHeader.tsx
+++ b/apps/app/src/components/billing/BillingHeader.tsx
@@ -1,18 +1,21 @@
+import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 
 import { ArrowLeft } from "lucide-react";
 
 export const BillingHeader = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation("billing");
 
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-4">
         <button
+          type="button"
           onClick={() => navigate("/settings/plans")}
           className="p-2 hover:bg-muted rounded-lg transition-colors"
-          title="Back to Plans"
-          aria-label="Back to Plans"
+          title={t("plans.backToPlans")}
+          aria-label={t("plans.backToPlans")}
         >
           <ArrowLeft className="w-4 h-4" />
         </button>

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -471,6 +471,7 @@ export const PlansPage: React.FC<PlansPageProps> = ({
               <div className="flex items-center gap-4">
                 <SidebarTrigger />
                 <button
+                  type="button"
                   onClick={() => navigate("/settings/plans")}
                   className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
                   title={t("plans.backToPlans")}

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -471,7 +471,7 @@ export const PlansPage: React.FC<PlansPageProps> = ({
               <div className="flex items-center gap-4">
                 <SidebarTrigger />
                 <button
-                  onClick={() => navigate("/profile?tab=plans")}
+                  onClick={() => navigate("/settings/plans")}
                   className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
                   title={t("plans.backToProfile")}
                 >

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -473,7 +473,8 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                 <button
                   onClick={() => navigate("/settings/plans")}
                   className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
-                  title={t("plans.backToProfile")}
+                  title={t("plans.backToPlans")}
+                  aria-label={t("plans.backToPlans")}
                 >
                   <ArrowLeft className="w-4 h-4" />
                 </button>


### PR DESCRIPTION
## Summary
- Back buttons on `/billing` and `/plans` pages navigated to `/profile?tab=plans`, which no longer exists (404)
- Updated all 3 occurrences to use the correct `/settings/plans` route (2 in frontend, 1 in email template)

## Test plan
- [ ] Navigate to `/billing`, click the back arrow → should go to `/settings/plans`
- [ ] Navigate to `/plans`, click the back arrow → should go to `/settings/plans`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Updated billing/plans navigation so "Manage Billing" and back button go to the Plans settings.
  * Button label changed from "Back to Profile" to "Back to Plans".

* **Accessibility**
  * Added descriptive aria-labels for the back button.

* **Localization**
  * Updated translations for the new "Back to Plans" label across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->