### PR TITLE
fix: show server name as primary label in server selector

### DIFF
--- a/apps/app/src/components/AppSidebar.tsx
+++ b/apps/app/src/components/AppSidebar.tsx
@@ -150,8 +150,14 @@ export function AppSidebar() {
                       <div className="flex items-center gap-2 w-full min-w-0">
                         <Server className="h-3 w-3 shrink-0" />
                         <div className="flex flex-col min-w-0 flex-1">
+                          <span className="truncate font-medium">
+                            {
+                              servers.find((s) => s.id === selectedServerId)
+                                ?.name
+                            }
+                          </span>
                           <span
-                            className="truncate font-medium"
+                            className="text-xs text-sidebar-foreground/70 truncate"
                             title={
                               servers.find((s) => s.id === selectedServerId)
                                 ?.host
@@ -161,12 +167,6 @@ export function AppSidebar() {
                               servers.find((s) => s.id === selectedServerId)
                                 ?.host || ""
                             )}
-                          </span>
-                          <span className="text-xs text-sidebar-foreground/70 truncate">
-                            {
-                              servers.find((s) => s.id === selectedServerId)
-                                ?.name
-                            }
                           </span>
                         </div>
                       </div>
@@ -179,11 +179,12 @@ export function AppSidebar() {
                     <div className="flex items-center gap-2 w-full min-w-0">
                       <Server className="h-3 w-3 shrink-0" />
                       <div className="flex flex-col min-w-0 flex-1">
-                        <span className="font-medium" title={server.host}>
+                        <span className="font-medium">{server.name}</span>
+                        <span
+                          className="text-xs text-muted-foreground truncate"
+                          title={server.host}
+                        >
                           {shortenHost(server.host)}
-                        </span>
-                        <span className="text-xs text-muted-foreground truncate">
-                          {server.name}
                         </span>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Swap host and server name display order in the server selector so the human-readable name (e.g. "AWS RabbitMQ") is the primary bold label and the host is shown as secondary text underneath
- Applies to both the trigger display and the dropdown items
- Full host remains available via tooltip on hover

## Test plan
- [ ] Open the sidebar and verify the server selector shows the server name as the bold primary text
- [ ] Verify the host appears as smaller secondary text below
- [ ] Hover over the host text and confirm the full hostname appears in a tooltip
- [ ] Open the dropdown and verify the same ordering in the list items

🤖 Generated with [Claude Code](https://claude.com/claude-code)