### PR TITLE
feat: ui polish for plans page, settings, and profile

### DIFF
--- a/.env.selfhosted.example
+++ b/.env.selfhosted.example
@@ -29,6 +29,9 @@ BACKEND_PORT=3000
 # Backend API URL for frontend (baked at build time, must match BACKEND_PORT)
 VITE_API_URL=http://localhost:3000
 
+# Portal URL for license purchase and upgrade links
+VITE_PORTAL_URL=https://portal.getqarote.com
+
 # Frontend port mapping (host:container)
 FRONTEND_PORT=8080
 

--- a/apps/api/src/mappers/auth/__tests__/auth.mapper.test.ts
+++ b/apps/api/src/mappers/auth/__tests__/auth.mapper.test.ts
@@ -77,10 +77,17 @@ describe("UserMapper", () => {
     });
   });
 
-  it("maps an array of users", () => {
-    const results = UserMapper.toApiResponseArray([baseUser, baseUser]);
+  it("maps an array of users independently", () => {
+    const secondUser = {
+      ...baseUser,
+      id: "user-2",
+      email: "other@example.com",
+    };
+    const results = UserMapper.toApiResponseArray([baseUser, secondUser]);
 
     expect(results).toHaveLength(2);
     expect(results[0].id).toBe("user-1");
+    expect(results[1].id).toBe("user-2");
+    expect(results[1].email).toBe("other@example.com");
   });
 });

--- a/apps/api/src/mappers/auth/__tests__/auth.mapper.test.ts
+++ b/apps/api/src/mappers/auth/__tests__/auth.mapper.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import type { PrismaUserWithDates } from "../auth.interfaces";
+import { UserMapper } from "../auth.mapper";
+
+const baseUser: PrismaUserWithDates = {
+  id: "user-1",
+  email: "test@example.com",
+  firstName: "Test",
+  lastName: "User",
+  role: "MEMBER",
+  workspaceId: "ws-1",
+  isActive: true,
+  emailVerified: true,
+  lastLogin: new Date("2026-03-01T00:00:00Z"),
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-02-01T00:00:00Z"),
+};
+
+describe("UserMapper", () => {
+  it("serialises dates to ISO strings", () => {
+    const result = UserMapper.toApiResponse(baseUser);
+
+    expect(result.lastLogin).toBe("2026-03-01T00:00:00.000Z");
+    expect(result.createdAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(result.updatedAt).toBe("2026-02-01T00:00:00.000Z");
+  });
+
+  it("handles null lastLogin", () => {
+    const result = UserMapper.toApiResponse({ ...baseUser, lastLogin: null });
+
+    expect(result.lastLogin).toBeNull();
+  });
+
+  it('derives authProvider "google" when googleId is present', () => {
+    const result = UserMapper.toApiResponse({
+      ...baseUser,
+      googleId: "google-123",
+    });
+
+    expect(result.authProvider).toBe("google");
+  });
+
+  it('derives authProvider "password" when googleId is null', () => {
+    const result = UserMapper.toApiResponse({
+      ...baseUser,
+      googleId: null,
+    });
+
+    expect(result.authProvider).toBe("password");
+  });
+
+  it("omits authProvider when googleId is not in the select", () => {
+    const result = UserMapper.toApiResponse(baseUser);
+
+    expect(result.authProvider).toBeUndefined();
+  });
+
+  it("includes pendingEmail when present", () => {
+    const result = UserMapper.toApiResponse({
+      ...baseUser,
+      pendingEmail: "new@example.com",
+    });
+
+    expect(result.pendingEmail).toBe("new@example.com");
+  });
+
+  it("includes subscription when present", () => {
+    const result = UserMapper.toApiResponse({
+      ...baseUser,
+      subscription: { plan: "DEVELOPER", status: "ACTIVE" },
+    });
+
+    expect(result.subscription).toEqual({
+      plan: "DEVELOPER",
+      status: "ACTIVE",
+    });
+  });
+
+  it("maps an array of users", () => {
+    const results = UserMapper.toApiResponseArray([baseUser, baseUser]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].id).toBe("user-1");
+  });
+});

--- a/apps/api/src/mappers/auth/auth.interfaces.ts
+++ b/apps/api/src/mappers/auth/auth.interfaces.ts
@@ -43,6 +43,7 @@ export type UserApiResponse = {
   createdAt: string;
   updatedAt: string;
   pendingEmail?: string | null;
+  googleId?: string | null;
   subscription?: SubscriptionData;
   workspace?: WorkspaceData;
 };

--- a/apps/api/src/mappers/auth/auth.interfaces.ts
+++ b/apps/api/src/mappers/auth/auth.interfaces.ts
@@ -43,7 +43,7 @@ export type UserApiResponse = {
   createdAt: string;
   updatedAt: string;
   pendingEmail?: string | null;
-  googleId?: string | null;
+  authProvider?: "google" | "password";
   subscription?: SubscriptionData;
   workspace?: WorkspaceData;
 };

--- a/apps/api/src/mappers/auth/auth.mapper.ts
+++ b/apps/api/src/mappers/auth/auth.mapper.ts
@@ -33,6 +33,11 @@ export class UserMapper {
       response.pendingEmail = user.pendingEmail ?? null;
     }
 
+    // Include googleId if present
+    if ("googleId" in user) {
+      response.googleId = (user.googleId as string) ?? null;
+    }
+
     // Include subscription if present (can be null)
     if ("subscription" in user) {
       response.subscription =

--- a/apps/api/src/mappers/auth/auth.mapper.ts
+++ b/apps/api/src/mappers/auth/auth.mapper.ts
@@ -33,9 +33,9 @@ export class UserMapper {
       response.pendingEmail = user.pendingEmail ?? null;
     }
 
-    // Include googleId if present
+    // Derive authProvider from googleId
     if ("googleId" in user) {
-      response.googleId = (user.googleId as string) ?? null;
+      response.authProvider = user.googleId ? "google" : "password";
     }
 
     // Include subscription if present (can be null)

--- a/apps/api/src/trpc/routers/auth/session.ts
+++ b/apps/api/src/trpc/routers/auth/session.ts
@@ -161,6 +161,7 @@ export const sessionRouter = router({
           lastLogin: true,
           createdAt: true,
           updatedAt: true,
+          googleId: true,
           pendingEmail: true,
           subscription: {
             select: {

--- a/apps/app/Dockerfile
+++ b/apps/app/Dockerfile
@@ -24,8 +24,9 @@ COPY apps/app ./apps/app
 # Accept build arguments (Vite embeds env vars at build time, not runtime)
 ARG DEPLOYMENT_MODE=selfhosted
 ARG VITE_API_URL
+ARG VITE_PORTAL_URL
 WORKDIR /app/apps/app
-RUN VITE_DEPLOYMENT_MODE=${DEPLOYMENT_MODE} VITE_API_URL=${VITE_API_URL} pnpm run build
+RUN VITE_DEPLOYMENT_MODE=${DEPLOYMENT_MODE} VITE_API_URL=${VITE_API_URL} VITE_PORTAL_URL=${VITE_PORTAL_URL} pnpm run build
 
 # Production stage
 FROM nginx:alpine

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -4,7 +4,9 @@
     "subtitle": "Scale your RabbitMQ monitoring with plans designed for teams of all sizes.",
     "pricingTitle": "Simple, transparent pricing",
     "currentPlan": "Current Plan",
+    "mostPopular": "Most popular",
     "startFree": "Start free",
+    "getStarted": "Get started",
     "save20": "Save 20%",
     "backToPlans": "Back to Plans",
     "pricing": {
@@ -26,7 +28,9 @@
     },
     "billingToggle": {
       "monthly": "Monthly",
-      "yearly": "Yearly"
+      "yearly": "Yearly",
+      "billedYearly": "Billed yearly",
+      "billedMonthly": "Billed monthly"
     },
     "period": {
       "month": "month",

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -30,7 +30,8 @@
       "monthly": "Monthly",
       "yearly": "Yearly",
       "billedYearly": "Billed yearly",
-      "billedMonthly": "Billed monthly"
+      "billedMonthly": "Billed monthly",
+      "label": "Toggle billing period"
     },
     "period": {
       "month": "month",

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -30,7 +30,8 @@
       "monthly": "Mensual",
       "yearly": "Anual",
       "billedYearly": "Facturación anual",
-      "billedMonthly": "Facturación mensual"
+      "billedMonthly": "Facturación mensual",
+      "label": "Alternar período de facturación"
     },
     "period": {
       "month": "mes",

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -4,7 +4,9 @@
     "subtitle": "Escala tu monitoreo de RabbitMQ con planes diseñados para equipos de todos los tamaños.",
     "pricingTitle": "Precios simples y transparentes",
     "currentPlan": "Plan actual",
+    "mostPopular": "Más popular",
     "startFree": "Comenzar gratis",
+    "getStarted": "Comenzar",
     "save20": "Ahorra 20%",
     "backToPlans": "Volver a los planes",
     "pricing": {
@@ -26,7 +28,9 @@
     },
     "billingToggle": {
       "monthly": "Mensual",
-      "yearly": "Anual"
+      "yearly": "Anual",
+      "billedYearly": "Facturación anual",
+      "billedMonthly": "Facturación mensual"
     },
     "period": {
       "month": "mes",

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -4,7 +4,9 @@
     "subtitle": "Faites évoluer votre surveillance RabbitMQ avec des forfaits conçus pour des équipes de toutes tailles.",
     "pricingTitle": "Tarification simple et transparente",
     "currentPlan": "Forfait actuel",
+    "mostPopular": "Le plus populaire",
     "startFree": "Commencer gratuitement",
+    "getStarted": "Commencer",
     "save20": "Économisez 20%",
     "backToPlans": "Retour aux forfaits",
     "pricing": {
@@ -26,7 +28,9 @@
     },
     "billingToggle": {
       "monthly": "Mensuel",
-      "yearly": "Annuel"
+      "yearly": "Annuel",
+      "billedYearly": "Facturation annuelle",
+      "billedMonthly": "Facturation mensuelle"
     },
     "period": {
       "month": "mois",

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -30,7 +30,8 @@
       "monthly": "Mensuel",
       "yearly": "Annuel",
       "billedYearly": "Facturation annuelle",
-      "billedMonthly": "Facturation mensuelle"
+      "billedMonthly": "Facturation mensuelle",
+      "label": "Basculer la période de facturation"
     },
     "period": {
       "month": "mois",

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -30,7 +30,8 @@
       "monthly": "按月",
       "yearly": "按年",
       "billedYearly": "按年计费",
-      "billedMonthly": "按月计费"
+      "billedMonthly": "按月计费",
+      "label": "切换计费周期"
     },
     "period": {
       "month": "月",

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -4,7 +4,9 @@
     "subtitle": "通过专为各种规模团队设计的方案扩展您的 RabbitMQ 监控能力。",
     "pricingTitle": "简单透明的定价",
     "currentPlan": "当前方案",
+    "mostPopular": "最受欢迎",
     "startFree": "免费开始",
+    "getStarted": "开始使用",
     "save20": "节省 20%",
     "backToPlans": "返回套餐",
     "pricing": {
@@ -26,7 +28,9 @@
     },
     "billingToggle": {
       "monthly": "按月",
-      "yearly": "按年"
+      "yearly": "按年",
+      "billedYearly": "按年计费",
+      "billedMonthly": "按月计费"
     },
     "period": {
       "month": "月",

--- a/apps/app/src/components/profile/EnhancedTeamTab.tsx
+++ b/apps/app/src/components/profile/EnhancedTeamTab.tsx
@@ -40,8 +40,6 @@ import {
 import { useUser } from "@/hooks/ui/useUser";
 import { useWorkspace } from "@/hooks/ui/useWorkspace";
 
-import { UserPlan } from "@/types/plans";
-
 import { InviteUserDialog } from "./InviteUserDialogEnhanced";
 import { formatDate, getRoleColor, InviteFormState } from "./profileUtils";
 
@@ -61,7 +59,6 @@ interface EnhancedTeamTabProps {
   isInviting: boolean;
   isRevoking: boolean;
   isRemoving: boolean;
-  userPlan: UserPlan;
   canInviteMoreUsers: boolean;
   emailEnabled?: boolean;
 }
@@ -82,7 +79,6 @@ export const EnhancedTeamTab = ({
   isInviting,
   isRevoking,
   isRemoving,
-  userPlan: _userPlan,
   canInviteMoreUsers,
   emailEnabled,
 }: EnhancedTeamTabProps) => {

--- a/apps/app/src/components/profile/EnhancedTeamTab.tsx
+++ b/apps/app/src/components/profile/EnhancedTeamTab.tsx
@@ -82,7 +82,7 @@ export const EnhancedTeamTab = ({
   isInviting,
   isRevoking,
   isRemoving,
-  userPlan,
+  userPlan: _userPlan,
   canInviteMoreUsers,
   emailEnabled,
 }: EnhancedTeamTabProps) => {
@@ -408,24 +408,6 @@ export const EnhancedTeamTab = ({
           </CardContent>
         </Card>
       )}
-
-      {/* Plan Limits Info */}
-      <Card>
-        <CardContent className="pt-6">
-          <div className="text-sm text-muted-foreground">
-            <p>
-              <strong>{userPlan} Plan:</strong>{" "}
-              {maxUsers ? `Up to ${maxUsers} users allowed` : "Unlimited users"}
-            </p>
-            {!canInviteMoreUsers && maxUsers && (
-              <p className="text-amber-600 mt-1">
-                You've reached your user limit. Upgrade your plan to invite more
-                users.
-              </p>
-            )}
-          </div>
-        </CardContent>
-      </Card>
 
       <InviteUserDialog
         open={inviteDialogOpen}

--- a/apps/app/src/components/profile/PersonalInfoTab.tsx
+++ b/apps/app/src/components/profile/PersonalInfoTab.tsx
@@ -198,7 +198,7 @@ export const PersonalInfoTab = ({
       </Card>
 
       {/* Security Settings Section - Only show for non-Google OAuth users */}
-      {profile.authProvider !== "google" ? (
+      {profile.authProvider === "password" ? (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">

--- a/apps/app/src/components/profile/PersonalInfoTab.tsx
+++ b/apps/app/src/components/profile/PersonalInfoTab.tsx
@@ -198,7 +198,7 @@ export const PersonalInfoTab = ({
       </Card>
 
       {/* Security Settings Section - Only show for non-Google OAuth users */}
-      {!profile.googleId ? (
+      {profile.authProvider !== "google" ? (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">

--- a/apps/app/src/components/profile/PersonalInfoTab.tsx
+++ b/apps/app/src/components/profile/PersonalInfoTab.tsx
@@ -1,6 +1,6 @@
 import {
   Calendar,
-  Crown,
+  Carrot,
   Edit,
   Lock,
   Mail,
@@ -98,7 +98,7 @@ export const PersonalInfoTab = ({
                 {profile.role}
               </Badge>
               {profile.role === "ADMIN" && (
-                <Crown className="h-4 w-4 text-yellow-500" />
+                <Carrot className="h-4 w-4 text-orange-500" />
               )}
             </div>
           </CardTitle>

--- a/apps/app/src/components/profile/WorkspaceFormFields.tsx
+++ b/apps/app/src/components/profile/WorkspaceFormFields.tsx
@@ -62,7 +62,7 @@ export const WorkspaceFormFields = ({
             />
           ) : (
             <p className="text-sm p-2 border rounded-md bg-muted">
-              {workspace.contactEmail || "Not set"}
+              {workspace.contactEmail || userEmail || "Not set"}
             </p>
           )}
         </div>

--- a/apps/app/src/components/profile/WorkspaceInfoTab.tsx
+++ b/apps/app/src/components/profile/WorkspaceInfoTab.tsx
@@ -10,9 +10,9 @@ import {
 } from "lucide-react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PlanBadge } from "@/components/ui/PlanBadge";
 import { Separator } from "@/components/ui/separator";
 
 import { ExtendedWorkspace } from "@/contexts/WorkspaceContextDefinition";
@@ -20,7 +20,7 @@ import { ExtendedWorkspace } from "@/contexts/WorkspaceContextDefinition";
 import { useUser } from "@/hooks/ui/useUser";
 
 import { NoWorkspaceCard } from "./NoWorkspaceCard";
-import { formatDate, getPlanColor, WorkspaceFormState } from "./profileUtils";
+import { formatDate, WorkspaceFormState } from "./profileUtils";
 import { WorkspaceFormFields } from "./WorkspaceFormFields";
 
 interface WorkspaceInfoTabProps {
@@ -44,7 +44,7 @@ export const WorkspaceInfoTab = ({
   onUpdateWorkspace,
   isUpdating,
 }: WorkspaceInfoTabProps) => {
-  const { user, userPlan, planData } = useUser();
+  const { user, planData } = useUser();
 
   if (!workspace) {
     return <NoWorkspaceCard />;
@@ -58,7 +58,7 @@ export const WorkspaceInfoTab = ({
             <Building2 className="h-6 w-6" />
             <span>Workspace Information</span>
           </div>
-          <Badge className={getPlanColor(userPlan)}>{userPlan}</Badge>
+          <PlanBadge />
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">

--- a/apps/app/src/components/profile/profileUtils.ts
+++ b/apps/app/src/components/profile/profileUtils.ts
@@ -39,19 +39,3 @@ export const getRoleColor = (role: string) => {
       return "bg-gray-100 text-gray-800";
   }
 };
-
-export const getPlanColor = (plan: string) => {
-  switch (plan.toUpperCase()) {
-    case "PREMIUM":
-    case "DEVELOPER":
-      return "bg-purple-100 text-purple-800";
-    case "ENTERPRISE":
-      return "bg-yellow-100 text-yellow-800";
-    case "STARTUP":
-    case "BUSINESS":
-      return "bg-blue-100 text-blue-800";
-    case "FREE":
-    default:
-      return "bg-green-100 text-green-800";
-  }
-};

--- a/apps/app/src/components/settings/SettingsSidebar.tsx
+++ b/apps/app/src/components/settings/SettingsSidebar.tsx
@@ -3,10 +3,10 @@ import { Link, useLocation } from "react-router";
 
 import {
   Building,
-  Crown,
   KeyRound,
   Mail,
   MessageSquare,
+  Rabbit,
   Shield,
   User,
   Users,
@@ -25,6 +25,7 @@ interface NavItem {
   labelKey: string;
   adminOnly?: boolean;
   selfHostedOnly?: boolean;
+  cloudOnly?: boolean;
 }
 
 interface NavGroup {
@@ -52,7 +53,7 @@ const navGroups: NavGroup[] = [
       {
         key: "plans",
         path: "/settings/plans",
-        icon: Crown,
+        icon: Rabbit,
         labelKey: "settings:nav.plans",
       },
     ],
@@ -102,6 +103,7 @@ const navGroups: NavGroup[] = [
         path: "/settings/feedback",
         icon: MessageSquare,
         labelKey: "settings:nav.feedback",
+        cloudOnly: true,
       },
     ],
   },
@@ -118,6 +120,7 @@ export const SettingsSidebar = () => {
   const filterItem = (item: NavItem) => {
     if (item.adminOnly && !isAdmin) return false;
     if (item.selfHostedOnly && cloudMode) return false;
+    if (item.cloudOnly && !cloudMode) return false;
     return true;
   };
 

--- a/apps/app/src/lib/api/authTypes.ts
+++ b/apps/app/src/lib/api/authTypes.ts
@@ -19,7 +19,7 @@ export interface User {
   lastLogin?: string;
   createdAt: string;
   updatedAt: string;
-  googleId?: string | null;
+  authProvider?: "google" | "password";
 }
 
 interface Workspace {

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -118,12 +118,12 @@ const PlanCard: React.FC<{
     <Card className="relative flex h-full flex-col bg-transparent">
       <CardContent className="p-6 flex flex-col h-full">
         {isCurrentPlan && (
-          <span className="absolute top-4 right-4 text-xs font-medium px-2 py-0.5 border border-[#FF691B] text-[#FF691B]">
+          <span className="absolute top-4 right-4 text-xs font-medium px-2 py-0.5 border border-primary text-primary">
             {t("plans.currentPlan")}
           </span>
         )}
         {!isCurrentPlan && plan.isPopular && (
-          <span className="absolute top-4 right-4 text-xs font-medium px-2 py-0.5 border border-[#FF691B] text-[#FF691B]">
+          <span className="absolute top-4 right-4 text-xs font-medium px-2 py-0.5 border border-primary text-primary">
             {t("plans.mostPopular")}
           </span>
         )}
@@ -383,7 +383,7 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                     )
                   }
                   className={`relative inline-flex items-center w-[27px] h-[15px] rounded-full transition-colors ${
-                    billingPeriod === "yearly" ? "bg-[#FF691B]" : "bg-muted"
+                    billingPeriod === "yearly" ? "bg-primary" : "bg-muted"
                   }`}
                 >
                   <span

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -374,6 +374,7 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                   {t("plans.billingToggle.monthly")}
                 </span>
                 <button
+                  type="button"
                   role="switch"
                   aria-checked={billingPeriod === "yearly"}
                   aria-label={t("plans.billingToggle.label")}

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -251,7 +251,6 @@ const PlanCard: React.FC<{
         </div>
 
         <Button
-          size={undefined}
           onClick={() => onUpgrade(plan.plan as UserPlan, billingInterval)}
           className={`w-full mt-6 px-4 py-3 sm:px-7 sm:py-3 transition-colors duration-200 text-base sm:text-lg h-auto rounded-full ${
             isCurrentPlan
@@ -341,7 +340,7 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                 <button
                   type="button"
                   onClick={() => navigate("/settings/plans")}
-                  className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+                  className="p-2 hover:bg-muted rounded-lg transition-colors"
                   title={t("plans.backToPlans")}
                   aria-label={t("plans.backToPlans")}
                 >
@@ -349,7 +348,7 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                 </button>
                 <div>
                   <h1 className="title-page">{t("plans.chooseYourPlan")}</h1>
-                  <p className="text-gray-500">{t("plans.subtitle")}</p>
+                  <p className="text-muted-foreground">{t("plans.subtitle")}</p>
                 </div>
               </div>
               <PlanBadge />

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -47,28 +47,14 @@ const FeatureItem: React.FC<{
   soonLabel?: string;
 }> = ({ label, detail, soonLabel }) => (
   <li className="flex items-start gap-3">
-    <div
-      style={{
-        marginTop: "0.4rem",
-        width: "0.875rem",
-        flexShrink: 0,
-        display: "flex",
-        alignItems: "flex-start",
-      }}
-    >
-      <Check
-        className="text-green-500"
-        style={{ width: "0.7rem", height: "0.7rem" }}
-      />
+    <div className="mt-1.5 w-3.5 shrink-0 flex items-start">
+      <Check className="text-green-500 w-[0.7rem] h-[0.7rem]" />
     </div>
     <div className="flex-1">
       <span className="text-sm text-foreground flex items-center gap-2">
         {label}
         {soonLabel && (
-          <span
-            className="font-medium px-1 border border-border text-muted-foreground"
-            style={{ fontSize: "0.65rem" }}
-          >
+          <span className="font-medium px-1 border border-border text-muted-foreground text-[0.65rem]">
             {soonLabel}
           </span>
         )}
@@ -270,9 +256,7 @@ const PlanCard: React.FC<{
           className={`w-full mt-6 px-4 py-3 sm:px-7 sm:py-3 transition-colors duration-200 text-base sm:text-lg h-auto rounded-full ${
             isCurrentPlan
               ? "bg-transparent border border-border text-muted-foreground cursor-not-allowed"
-              : plan.monthlyPrice === 0
-                ? "bg-transparent border border-border text-foreground hover:bg-muted"
-                : "bg-gradient-button hover:bg-gradient-button-hover text-white"
+              : "bg-gradient-button hover:bg-gradient-button-hover text-white"
           }`}
           disabled={isCurrentPlan || isUpgrading}
         >
@@ -390,26 +374,24 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                   {t("plans.billingToggle.monthly")}
                 </span>
                 <button
+                  role="switch"
+                  aria-checked={billingPeriod === "yearly"}
+                  aria-label={t("plans.billingToggle.label")}
                   onClick={() =>
                     setBillingPeriod(
                       billingPeriod === "monthly" ? "yearly" : "monthly"
                     )
                   }
-                  className={`relative inline-flex items-center transition-colors ${
+                  className={`relative inline-flex items-center w-[27px] h-[15px] rounded-full transition-colors ${
                     billingPeriod === "yearly" ? "bg-[#FF691B]" : "bg-muted"
                   }`}
-                  style={{ width: "27px", height: "15px" }}
                 >
                   <span
-                    className="inline-block bg-white transition-transform"
-                    style={{
-                      width: "9px",
-                      height: "9px",
-                      transform:
-                        billingPeriod === "yearly"
-                          ? "translateX(15px)"
-                          : "translateX(3px)",
-                    }}
+                    className={`inline-block w-[9px] h-[9px] rounded-full bg-white transition-transform ${
+                      billingPeriod === "yearly"
+                        ? "translate-x-[15px]"
+                        : "translate-x-[3px]"
+                    }`}
                   />
                 </button>
                 <span

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -2,17 +2,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 
-import {
-  AlertCircle,
-  ArrowLeft,
-  Check,
-  Headphones,
-  Loader2,
-  Shield,
-  TrendingUp,
-  X,
-  Zap,
-} from "lucide-react";
+import { AlertCircle, ArrowLeft, Check, Loader2 } from "lucide-react";
 
 import { AppSidebar } from "@/components/AppSidebar";
 import { Badge } from "@/components/ui/badge";
@@ -32,7 +22,7 @@ import { UserPlan } from "@/types/plans";
 /** Format a limit number (null = unlimited) into a display string */
 function formatLimit(
   value: number | null | undefined,
-  t: (key: string, opts?: Record<string, unknown>) => string,
+  t: (key: string, opts?: Record<string, unknown>) => string
 ): string {
   if (value === null || value === undefined) return t("plans.limits.unlimited");
   return t("plans.limits.upTo", { count: value });
@@ -54,29 +44,36 @@ function yearlyToMonthly(yearlyCents: number): number {
 const FeatureItem: React.FC<{
   label: string;
   detail?: string;
-  enabled?: boolean;
   soonLabel?: string;
-}> = ({ label, detail, enabled = true, soonLabel }) => (
+}> = ({ label, detail, soonLabel }) => (
   <li className="flex items-start gap-3">
-    <div className="mt-1">
-      {enabled ? (
-        <Check className="w-4 h-4 text-green-500" />
-      ) : (
-        <X className="w-4 h-4 text-muted-foreground" />
-      )}
+    <div
+      style={{
+        marginTop: "0.4rem",
+        width: "0.875rem",
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "flex-start",
+      }}
+    >
+      <Check
+        className="text-green-500"
+        style={{ width: "0.7rem", height: "0.7rem" }}
+      />
     </div>
     <div className="flex-1">
-      <span className={`text-sm ${enabled ? "text-foreground" : "text-muted-foreground"} flex items-center gap-2`}>
+      <span className="text-sm text-foreground flex items-center gap-2">
         {label}
         {soonLabel && (
-          <Badge variant="outline" className="text-[0.65rem] px-1 py-0">
+          <span
+            className="font-medium px-1 border border-border text-muted-foreground"
+            style={{ fontSize: "0.65rem" }}
+          >
             {soonLabel}
-          </Badge>
+          </span>
         )}
       </span>
-      {detail && (
-        <div className="text-xs text-muted-foreground">{detail}</div>
-      )}
+      {detail && <p className="text-xs text-muted-foreground mt-1">{detail}</p>}
     </div>
   </li>
 );
@@ -107,6 +104,7 @@ const PlanCard: React.FC<{
   price: string;
   periodLabel: string;
   originalPrice?: string;
+  altPriceLabel?: string;
   isCurrentPlan: boolean;
   onUpgrade: (plan: UserPlan, billingInterval: "monthly" | "yearly") => void;
   billingInterval: "monthly" | "yearly";
@@ -117,16 +115,13 @@ const PlanCard: React.FC<{
   price,
   periodLabel,
   originalPrice,
+  altPriceLabel,
   isCurrentPlan,
   onUpgrade,
   billingInterval,
   isUpgrading,
   t,
 }) => {
-  const ringClass = isCurrentPlan
-    ? "ring-2 ring-blue-500 shadow-lg scale-105"
-    : "";
-
   const soonLabel = t("plans.features.soon");
 
   const versionDetail = plan.ltsOnly
@@ -134,144 +129,158 @@ const PlanCard: React.FC<{
     : t("plans.features.allVersions");
 
   return (
-    <Card
-      className={`relative border-gray-200 ${ringClass} transition-all duration-200 hover:shadow-lg`}
-    >
-      {isCurrentPlan && (
-        <div className="absolute -top-4 left-1/2 transform -translate-x-1/2">
-          <Badge className="bg-gradient-button text-white px-4 py-1 text-sm font-medium">
+    <Card className="relative flex h-full flex-col bg-transparent">
+      <CardContent className="p-6 flex flex-col h-full">
+        {isCurrentPlan && (
+          <span className="absolute top-4 right-4 text-xs font-medium px-2 py-0.5 border border-[#FF691B] text-[#FF691B]">
             {t("plans.currentPlan")}
-          </Badge>
-        </div>
-      )}
+          </span>
+        )}
+        {!isCurrentPlan && plan.isPopular && (
+          <span className="absolute top-4 right-4 text-xs font-medium px-2 py-0.5 border border-[#FF691B] text-[#FF691B]">
+            {t("plans.mostPopular")}
+          </span>
+        )}
 
-      <CardContent className="p-6">
-        <div className="text-center mb-6">
-          <h3 className="text-2xl font-bold text-gray-600 mb-2">
-            {plan.displayName}
-          </h3>
-          <p className="text-muted-foreground text-sm mb-4">
-            {plan.description}
-          </p>
+        <div className="text-left">
+          <div className="flex items-center gap-2 mb-4">
+            <h3 className="text-2xl font-normal text-foreground">
+              {plan.displayName}
+            </h3>
+          </div>
 
-          <div className="mb-4">
-            <div className="flex items-baseline justify-center gap-1">
-              <span className="text-4xl font-bold text-foreground">
+          <div className="mb-2 flex flex-col justify-start min-h-[90px]">
+            <div className="flex items-center justify-start gap-4">
+              <span className="text-5xl font-medium text-foreground">
                 {price}
               </span>
               {plan.monthlyPrice > 0 && (
-                <span className="text-muted-foreground">/{periodLabel}</span>
+                <div className="flex flex-col leading-tight">
+                  <span className="text-sm text-muted-foreground">
+                    /{periodLabel}
+                  </span>
+                  {billingInterval === "yearly" && (
+                    <span className="text-sm text-muted-foreground">
+                      {t("plans.billingToggle.billedYearly")}
+                    </span>
+                  )}
+                </div>
               )}
             </div>
-            {originalPrice && (
-              <div className="flex items-center justify-center gap-2 mt-1">
-                <span className="text-muted-foreground line-through text-sm">
+            {originalPrice && altPriceLabel && (
+              <span className="text-sm text-muted-foreground mt-4">
+                <span className="font-medium text-foreground">
                   {originalPrice}
-                </span>
-                <Badge variant="secondary" className="text-xs">
-                  {t("plans.save20")}
-                </Badge>
-              </div>
+                </span>{" "}
+                {altPriceLabel}
+              </span>
             )}
           </div>
         </div>
 
-        <div className="space-y-6 mb-6">
+        <hr className="border-border mt-4 mb-8" />
+
+        <div className="space-y-6 flex-1">
           {/* Core Features */}
           <div>
-            <h4 className="font-semibold text-foreground mb-3 text-sm uppercase tracking-wide">
+            <h4 className="font-semibold text-foreground mb-3 text-xs sm:text-sm uppercase tracking-wide whitespace-nowrap">
               {t("plans.features.coreFeatures")}
             </h4>
             <ul className="space-y-2">
               <FeatureItem
                 label={t("plans.features.rabbitMQServers")}
                 detail={formatLimit(plan.maxServers, t)}
-                enabled
               />
               <FeatureItem
                 label={t("plans.features.workspaces")}
                 detail={formatLimit(plan.maxWorkspaces, t)}
-                enabled
               />
               <FeatureItem
                 label={t("plans.features.teamMembers")}
                 detail={formatLimit(plan.maxUsers, t)}
-                enabled
               />
-              <FeatureItem
-                label={t("plans.features.advancedAnalytics")}
-                enabled={plan.hasAdvancedAnalytics}
-              />
-              <FeatureItem
-                label={t("plans.features.queueManagement")}
-                enabled
-              />
-              <FeatureItem
-                label={t("plans.features.alertsWebhooks")}
-                enabled={plan.hasAlerts}
-              />
+              {plan.hasAdvancedAnalytics && (
+                <FeatureItem label={t("plans.features.advancedAnalytics")} />
+              )}
+              <FeatureItem label={t("plans.features.queueManagement")} />
+              {plan.hasAlerts && (
+                <FeatureItem label={t("plans.features.alertsWebhooks")} />
+              )}
               {plan.hasTopologyVisualization && (
                 <FeatureItem
                   label={t("plans.features.topologyVisualization")}
-                  enabled
-                  soonLabel={plan.hasTopologyVisualization === "coming_soon" ? soonLabel : undefined}
+                  soonLabel={
+                    plan.hasTopologyVisualization === "coming_soon"
+                      ? soonLabel
+                      : undefined
+                  }
                 />
               )}
               {plan.hasRoleBasedAccess && (
                 <FeatureItem
                   label={t("plans.features.roleBasedAccess")}
-                  enabled
-                  soonLabel={plan.hasRoleBasedAccess === "coming_soon" ? soonLabel : undefined}
+                  soonLabel={
+                    plan.hasRoleBasedAccess === "coming_soon"
+                      ? soonLabel
+                      : undefined
+                  }
                 />
               )}
             </ul>
           </div>
 
           {/* Security & Compatibility */}
-          <div>
+          <div className="mt-auto space-y-4">
             <h4 className="font-semibold text-foreground mb-3 text-sm uppercase tracking-wide">
               {t("plans.features.securityCompatibility")}
             </h4>
             <ul className="space-y-2">
               {plan.hasSsoSamlOidc && (
-                <FeatureItem label={t("plans.features.ssoSamlOidc")} enabled />
+                <FeatureItem label={t("plans.features.ssoSamlOidc")} />
               )}
-              <FeatureItem
-                label={t("plans.features.soc2Compliance")}
-                enabled={plan.hasSoc2Compliance}
-              />
+              {plan.hasSoc2Compliance && (
+                <FeatureItem label={t("plans.features.soc2Compliance")} />
+              )}
               <FeatureItem
                 label={t("plans.features.rabbitMQVersionSupport")}
                 detail={versionDetail}
-                enabled
               />
             </ul>
           </div>
 
           {/* Support */}
-          <div>
+          <div className="mt-auto space-y-4">
             <h4 className="font-semibold text-foreground mb-3 text-sm uppercase tracking-wide">
               {t("plans.features.support")}
             </h4>
             <ul className="space-y-2">
-              <FeatureItem
-                label={t("plans.features.communitySupport")}
-                enabled={plan.hasCommunitySupport}
-              />
-              <FeatureItem
-                label={t("plans.features.prioritySupport")}
-                enabled={plan.hasPrioritySupport}
-              />
+              {plan.hasCommunitySupport && (
+                <FeatureItem label={t("plans.features.communitySupport")} />
+              )}
+              {plan.hasPrioritySupport && (
+                <FeatureItem label={t("plans.features.prioritySupport")} />
+              )}
             </ul>
           </div>
         </div>
 
         <Button
+          size={undefined}
           onClick={() => onUpgrade(plan.plan as UserPlan, billingInterval)}
-          className={`w-full ${isCurrentPlan || isUpgrading ? "bg-gray-100 text-gray-600 cursor-not-allowed" : "bg-gradient-button hover:bg-gradient-button-hover text-white"}`}
+          className={`w-full mt-6 px-4 py-3 sm:px-7 sm:py-3 transition-colors duration-200 text-base sm:text-lg h-auto rounded-full ${
+            isCurrentPlan
+              ? "bg-transparent border border-border text-muted-foreground cursor-not-allowed"
+              : plan.monthlyPrice === 0
+                ? "bg-transparent border border-border text-foreground hover:bg-muted"
+                : "bg-gradient-button hover:bg-gradient-button-hover text-white"
+          }`}
           disabled={isCurrentPlan || isUpgrading}
         >
-          {isCurrentPlan ? t("plans.currentPlan") : t("plans.startFree")}
+          {isCurrentPlan
+            ? t("plans.currentPlan")
+            : plan.monthlyPrice === 0
+              ? t("plans.getStarted")
+              : t("plans.startFree")}
         </Button>
       </CardContent>
     </Card>
@@ -295,18 +304,27 @@ export const PlansPage: React.FC<PlansPageProps> = ({
   );
   const navigate = useNavigate();
   const { userPlan } = useUser();
-  const { data: allPlansData, isLoading, isError, error, refetch } = useAllPlans();
+  const {
+    data: allPlansData,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useAllPlans();
 
   const plans: ApiPlan[] = allPlansData?.plans ?? [];
 
-  /** Get price string, localized period label, and optional original price for a plan */
-  function getPricing(plan: ApiPlan): { price: string; periodLabel: string; originalPrice?: string } {
-    const periodLabel = billingPeriod === "monthly"
-      ? t("plans.period.month")
-      : t("plans.period.month"); // yearly still shows per-month equivalent
+  /** Get price string, localized period label, and optional alt price for a plan */
+  function getPricing(plan: ApiPlan): {
+    price: string;
+    periodLabel: string;
+    originalPrice?: string;
+    altPriceLabel?: string;
+  } {
+    const periodLabel = t("plans.period.month");
 
     if (plan.monthlyPrice === 0) {
-      return { price: t("plans.pricing.free"), periodLabel };
+      return { price: formatPrice(0), periodLabel };
     }
     if (billingPeriod === "yearly") {
       const monthlyEquivalent = yearlyToMonthly(plan.yearlyPrice);
@@ -314,9 +332,16 @@ export const PlansPage: React.FC<PlansPageProps> = ({
         price: formatPrice(monthlyEquivalent),
         periodLabel,
         originalPrice: formatPrice(plan.monthlyPrice),
+        altPriceLabel: t("plans.billingToggle.billedMonthly"),
       };
     }
-    return { price: formatPrice(plan.monthlyPrice), periodLabel };
+    const yearlyMonthly = yearlyToMonthly(plan.yearlyPrice);
+    return {
+      price: formatPrice(plan.monthlyPrice),
+      periodLabel,
+      originalPrice: formatPrice(yearlyMonthly),
+      altPriceLabel: t("plans.billingToggle.billedYearly"),
+    };
   }
 
   return (
@@ -347,9 +372,9 @@ export const PlansPage: React.FC<PlansPageProps> = ({
             </div>
 
             {/* Pricing Section */}
-            <div className="py-8">
-              <div className="text-center mb-12">
-                <h2 className="text-3xl sm:text-4xl font-bold text-foreground mb-4">
+            <div className="pt-4 pb-12">
+              <div className="text-center mb-16">
+                <h2 className="text-3xl sm:text-4xl lg:text-5xl text-foreground mb-4 max-w-4xl mx-auto leading-[1.2] font-normal">
                   {t("plans.pricingTitle")}
                 </h2>
                 <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
@@ -357,58 +382,8 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                 </p>
               </div>
 
-              {/* Feature Highlights */}
-              <div className="flex justify-center mb-12">
-                <div className="grid md:grid-cols-4 gap-6 max-w-4xl">
-                  <div className="flex flex-col items-center p-4">
-                    <div className="bg-blue-100 p-3 rounded-full mb-3">
-                      <Zap className="w-6 h-6 text-blue-600" />
-                    </div>
-                    <h3 className="font-semibold text-foreground mb-1">
-                      {t("plans.highlights.liveMonitoring")}
-                    </h3>
-                    <p className="text-sm text-muted-foreground text-center">
-                      {t("plans.highlights.liveMonitoringDesc")}
-                    </p>
-                  </div>
-                  <div className="flex flex-col items-center p-4">
-                    <div className="bg-purple-100 p-3 rounded-full mb-3">
-                      <TrendingUp className="w-6 h-6 text-purple-600" />
-                    </div>
-                    <h3 className="font-semibold text-foreground mb-1">
-                      {t("plans.highlights.smartAnalytics")}
-                    </h3>
-                    <p className="text-sm text-muted-foreground text-center">
-                      {t("plans.highlights.smartAnalyticsDesc")}
-                    </p>
-                  </div>
-                  <div className="flex flex-col items-center p-4">
-                    <div className="bg-green-100 p-3 rounded-full mb-3">
-                      <Shield className="w-6 h-6 text-green-600" />
-                    </div>
-                    <h3 className="font-semibold text-foreground mb-1">
-                      {t("plans.highlights.enterpriseSecurity")}
-                    </h3>
-                    <p className="text-sm text-muted-foreground text-center">
-                      {t("plans.highlights.enterpriseSecurityDesc")}
-                    </p>
-                  </div>
-                  <div className="flex flex-col items-center p-4">
-                    <div className="bg-orange-100 p-3 rounded-full mb-3">
-                      <Headphones className="w-6 h-6 text-orange-600" />
-                    </div>
-                    <h3 className="font-semibold text-foreground mb-1">
-                      {t("plans.highlights.support247")}
-                    </h3>
-                    <p className="text-sm text-muted-foreground text-center">
-                      {t("plans.highlights.support247Desc")}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
               {/* Billing Toggle */}
-              <div className="flex items-center justify-center gap-4 mb-16">
+              <div className="flex items-center justify-center gap-3 mb-8">
                 <span
                   className={`text-sm font-medium ${billingPeriod === "monthly" ? "text-foreground" : "text-muted-foreground"}`}
                 >
@@ -420,16 +395,21 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                       billingPeriod === "monthly" ? "yearly" : "monthly"
                     )
                   }
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                    billingPeriod === "yearly" ? "bg-primary" : "bg-muted"
+                  className={`relative inline-flex items-center transition-colors ${
+                    billingPeriod === "yearly" ? "bg-[#FF691B]" : "bg-muted"
                   }`}
+                  style={{ width: "27px", height: "15px" }}
                 >
                   <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      billingPeriod === "yearly"
-                        ? "translate-x-6"
-                        : "translate-x-1"
-                    }`}
+                    className="inline-block bg-white transition-transform"
+                    style={{
+                      width: "9px",
+                      height: "9px",
+                      transform:
+                        billingPeriod === "yearly"
+                          ? "translateX(15px)"
+                          : "translateX(3px)",
+                    }}
                   />
                 </button>
                 <span
@@ -438,14 +418,14 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                   {t("plans.billingToggle.yearly")}
                 </span>
                 {billingPeriod === "yearly" && (
-                  <Badge className="bg-green-100 text-green-800">
+                  <Badge className="bg-green-100 text-green-800 text-xs">
                     {t("plans.save20")}
                   </Badge>
                 )}
               </div>
 
               {/* Plans Grid */}
-              <div className="flex justify-center">
+              <div className="flex justify-center w-full">
                 {isLoading ? (
                   <div className="flex items-center gap-2 text-muted-foreground py-16">
                     <Loader2 className="w-5 h-5 animate-spin" />
@@ -461,17 +441,19 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                     <p className="text-muted-foreground">
                       {error?.message ?? t("upgradeModal.upgradeFailed")}
                     </p>
-                    <Button
-                      variant="outline"
-                      onClick={() => refetch()}
-                    >
+                    <Button variant="outline" onClick={() => refetch()}>
                       {t("paymentCancelled.tryAgain")}
                     </Button>
                   </div>
                 ) : (
-                  <div className="grid lg:grid-cols-3 gap-8 max-w-5xl">
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-7xl">
                     {plans.map((plan) => {
-                      const { price, periodLabel, originalPrice } = getPricing(plan);
+                      const {
+                        price,
+                        periodLabel,
+                        originalPrice,
+                        altPriceLabel,
+                      } = getPricing(plan);
                       const isCurrentPlan =
                         plan.plan === userPlan?.toUpperCase();
 
@@ -481,6 +463,7 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                           plan={plan}
                           price={price}
                           originalPrice={originalPrice}
+                          altPriceLabel={altPriceLabel}
                           periodLabel={periodLabel}
                           isCurrentPlan={isCurrentPlan}
                           onUpgrade={onUpgrade}

--- a/apps/app/src/pages/settings/TeamSection.tsx
+++ b/apps/app/src/pages/settings/TeamSection.tsx
@@ -182,7 +182,6 @@ const TeamSection = () => {
         isInviting={sendInvitationMutation.isPending}
         isRevoking={revokeInvitationMutation.isPending}
         isRemoving={removeUserMutation.isPending}
-        userPlan={userPlan}
         canInviteMoreUsers={canInviteMoreUsers()}
         emailEnabled={publicConfig?.emailEnabled ?? true}
       />

--- a/apps/e2e/tests/profile/google-oauth-profile.spec.ts
+++ b/apps/e2e/tests/profile/google-oauth-profile.spec.ts
@@ -27,7 +27,7 @@ test.describe("Google OAuth Profile Security @p1", () => {
         lastLogin: new Date().toISOString(),
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
-        googleId: "google-oauth-123456",
+        authProvider: "google",
         subscription: null,
         workspace: { id: "mock-workspace-id" },
       },

--- a/apps/e2e/tests/profile/google-oauth-profile.spec.ts
+++ b/apps/e2e/tests/profile/google-oauth-profile.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "../../fixtures/test-base.js";
+import { mockTrpcQuery } from "../../helpers/trpc-mock.js";
+
+/**
+ * Regression test: Google OAuth users must NOT see the password / email
+ * change forms on the profile page.  They should instead see the
+ * "Your account is managed by Google" card.
+ *
+ * We simulate a Google-authenticated session by mocking the getSession
+ * tRPC response to include a non-null `googleId`.
+ */
+test.describe("Google OAuth Profile Security @p1", () => {
+  test("should hide password and email change forms for Google OAuth users", async ({
+    adminPage,
+  }) => {
+    // Mock getSession to return a user with googleId set (simulates Google OAuth login)
+    await mockTrpcQuery(adminPage, "auth.session.getSession", {
+      user: {
+        id: "mock-google-user-id",
+        email: "admin@e2e-test.local",
+        firstName: "E2E",
+        lastName: "Admin",
+        role: "ADMIN",
+        workspaceId: "mock-workspace-id",
+        isActive: true,
+        emailVerified: true,
+        lastLogin: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        googleId: "google-oauth-123456",
+        subscription: null,
+        workspace: { id: "mock-workspace-id" },
+      },
+    });
+
+    await adminPage.goto("/settings/profile");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    // Should see the "managed by Google" card
+    await expect(
+      adminPage.getByText(/account is managed by google/i)
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Should NOT see password change form
+    await expect(
+      adminPage.getByText(/change password/i)
+    ).not.toBeVisible();
+
+    // Should NOT see email change form
+    await expect(
+      adminPage.getByRole("heading", { name: /email address/i })
+    ).not.toBeVisible();
+  });
+
+  test("should show password and email change forms for non-Google users", async ({
+    adminPage,
+  }) => {
+    // No mock — uses the real seeded admin user (no googleId)
+    await adminPage.goto("/settings/profile");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    // Should see the Security Settings section with password change
+    await expect(
+      adminPage.getByText(/security settings/i)
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expect(
+      adminPage.getByText(/change password/i)
+    ).toBeVisible();
+
+    // Should NOT see "managed by Google" card
+    await expect(
+      adminPage.getByText(/account is managed by google/i)
+    ).not.toBeVisible();
+  });
+});

--- a/apps/web/src/pages/Index.tsx
+++ b/apps/web/src/pages/Index.tsx
@@ -111,13 +111,13 @@ const Index = () => {
       price: "$348",
       period: "/ year",
       cta: "Choose Developer",
-      url: import.meta.env.VITE_SELFHOST_PORTAL_URL,
+      url: import.meta.env.VITE_PORTAL_URL,
     },
     ENTERPRISE: {
       price: "$1,188",
       period: "/ year",
       cta: "Choose Enterprise",
-      url: import.meta.env.VITE_SELFHOST_PORTAL_URL,
+      url: import.meta.env.VITE_PORTAL_URL,
     },
   };
 

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -3,7 +3,6 @@
 interface ImportMetaEnv {
   readonly VITE_APP_BASE_URL: string;
   readonly VITE_PORTAL_URL: string;
-  readonly VITE_SELFHOST_PORTAL_URL?: string;
 }
 
 interface ImportMeta {

--- a/docker-compose.selfhosted.yml
+++ b/docker-compose.selfhosted.yml
@@ -81,6 +81,7 @@ services:
       dockerfile: ./apps/app/Dockerfile
       args:
         VITE_API_URL: ${VITE_API_URL}
+        VITE_PORTAL_URL: ${VITE_PORTAL_URL}
     container_name: qarote_frontend
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- Align app plans page CSS with marketing site (left-aligned cards, rounded buttons, hr separators, matching toggle style, no feature highlights section)
- Hide feedback nav item for self-hosted users via new `cloudOnly` filter
- Replace ENTERPRISE text badge with PlanBadge rabbit icon on workspace settings
- Replace Crown icon with Carrot on profile page, Rabbit on settings sidebar
- Show user signup email as fallback for workspace contact email
- Remove redundant "ENTERPRISE Plan: Unlimited users" card from team section
- Fix Google OAuth users incorrectly seeing password/email change forms (missing `googleId` in `getSession` API response)
- Consolidate self-host portal URL env var in web app

## Test plan
- [ ] Verify plans page at `/plans` matches marketing site styling
- [ ] Verify feedback link hidden in self-hosted mode settings sidebar
- [ ] Verify PlanBadge rabbit icon shows on workspace settings page
- [ ] Verify Carrot icon next to ADMIN badge on profile page
- [ ] Verify contact email shows user email when not explicitly set
- [ ] Verify team section no longer shows plan limits card
- [ ] Verify Google OAuth users see "managed by Google" card instead of password/email forms
- [ ] Verify billing toggle, pricing display, and plan cards render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accounts now surface an auth provider: Google-authenticated accounts show a “managed by Google” card and hide password/email change forms.

* **Improvements**
  * Redesigned Plans page with refreshed layout, billing toggle, monthly/yearly pricing and alternate price labels.
  * Expanded billing/localization text for en/es/fr/zh.
  * UI tweaks: updated icons, contact email falls back to user email, plan display simplified, settings can show cloud-only items.
  
* **Tests**
  * Added end-to-end tests for Google OAuth profile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->