### PR TITLE
feat: add client-side pagination to queues list

### DIFF
--- a/apps/app/src/components/Queues/QueueTable.tsx
+++ b/apps/app/src/components/Queues/QueueTable.tsx
@@ -104,6 +104,7 @@ export function QueueTable({
                       <TableCell className="font-medium">
                         <div className="flex items-center gap-2">
                           <button
+                            type="button"
                             onClick={() =>
                               onNavigateToQueue(encodeURIComponent(queue.name))
                             }

--- a/apps/app/src/components/Queues/QueueTable.tsx
+++ b/apps/app/src/components/Queues/QueueTable.tsx
@@ -6,6 +6,7 @@ import { PurgeQueueDialog } from "@/components/PurgeQueueDialog";
 import { QueueStatusBadge } from "@/components/Queues/queue-status-badge";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PaginationControls } from "@/components/ui/PaginationControls";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -22,6 +23,11 @@ interface QueueTableProps {
   searchTerm: string;
   onNavigateToQueue: (queueName: string) => void;
   onRefetch: () => void;
+  total: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
 }
 
 export function QueueTable({
@@ -30,6 +36,11 @@ export function QueueTable({
   searchTerm,
   onNavigateToQueue,
   onRefetch,
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
 }: QueueTableProps) {
   const getQueueMetrics = (queue: Queue) => {
     return {
@@ -64,101 +75,111 @@ export function QueueTable({
             ))}
           </div>
         ) : queues.length > 0 ? (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Queue Name</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Messages</TableHead>
-                <TableHead>Ready</TableHead>
-                <TableHead>Unacked</TableHead>
-                <TableHead>Consumers</TableHead>
-                <TableHead>Incoming</TableHead>
-                <TableHead>Deliver / Get</TableHead>
-                <TableHead>Ack</TableHead>
-                <TableHead>Memory (MB)</TableHead>
-                <TableHead>VHost</TableHead>
-                <TableHead>Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {queues.map((queue) => {
-                const metrics = getQueueMetrics(queue);
-                return (
-                  <TableRow
-                    key={`${queue.name}-${queue.vhost}`}
-                    className="hover:bg-accent/50"
-                  >
-                    <TableCell className="font-medium">
-                      <div className="flex items-center gap-2">
-                        <button
-                          onClick={() =>
-                            onNavigateToQueue(encodeURIComponent(queue.name))
-                          }
-                          className="text-left font-medium text-orange-600 hover:text-orange-700 hover:underline transition-colors cursor-pointer"
-                        >
-                          {queue.name}
-                        </button>
-                        {queue.internal && (
-                          <Badge
-                            variant="secondary"
-                            className="text-xs flex items-center gap-1"
-                            title="Internal queue (not accessible via AMQP)"
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Queue Name</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Messages</TableHead>
+                  <TableHead>Ready</TableHead>
+                  <TableHead>Unacked</TableHead>
+                  <TableHead>Consumers</TableHead>
+                  <TableHead>Incoming</TableHead>
+                  <TableHead>Deliver / Get</TableHead>
+                  <TableHead>Ack</TableHead>
+                  <TableHead>Memory (MB)</TableHead>
+                  <TableHead>VHost</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {queues.map((queue) => {
+                  const metrics = getQueueMetrics(queue);
+                  return (
+                    <TableRow
+                      key={`${queue.name}-${queue.vhost}`}
+                      className="hover:bg-accent/50"
+                    >
+                      <TableCell className="font-medium">
+                        <div className="flex items-center gap-2">
+                          <button
+                            onClick={() =>
+                              onNavigateToQueue(encodeURIComponent(queue.name))
+                            }
+                            className="text-left font-medium text-orange-600 hover:text-orange-700 hover:underline transition-colors cursor-pointer"
                           >
-                            <Lock className="w-3 h-3" />
-                            Internal
-                          </Badge>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <QueueStatusBadge state={queue.state} />
-                    </TableCell>
-                    <TableCell className="font-mono">
-                      {metrics.messages}
-                    </TableCell>
-                    <TableCell className="font-mono text-blue-600">
-                      {metrics.messagesReady}
-                    </TableCell>
-                    <TableCell className="font-mono text-orange-600">
-                      {metrics.messagesUnacked}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-1">
-                        <Users className="w-3 h-3 text-gray-400" />
-                        {metrics.consumers}
-                      </div>
-                    </TableCell>
-                    <TableCell className="font-mono">
-                      {metrics.incomingRate.toFixed(1)}
-                    </TableCell>
-                    <TableCell className="font-mono">
-                      {metrics.deliverGetRate.toFixed(1)}
-                    </TableCell>
-                    <TableCell className="font-mono">
-                      {metrics.ackRate.toFixed(1)}
-                    </TableCell>
-                    <TableCell className="font-mono">
-                      {metrics.memory.toFixed(1)}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant="outline" className="font-mono text-xs">
-                        {metrics.vhost}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <PurgeQueueDialog
-                        queueName={queue.name}
-                        messageCount={queue.messages}
-                        vhost={metrics.vhost}
-                        onSuccess={() => onRefetch()}
-                      />
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
+                            {queue.name}
+                          </button>
+                          {queue.internal && (
+                            <Badge
+                              variant="secondary"
+                              className="text-xs flex items-center gap-1"
+                              title="Internal queue (not accessible via AMQP)"
+                            >
+                              <Lock className="w-3 h-3" />
+                              Internal
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <QueueStatusBadge state={queue.state} />
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {metrics.messages}
+                      </TableCell>
+                      <TableCell className="font-mono text-blue-600">
+                        {metrics.messagesReady}
+                      </TableCell>
+                      <TableCell className="font-mono text-orange-600">
+                        {metrics.messagesUnacked}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1">
+                          <Users className="w-3 h-3 text-gray-400" />
+                          {metrics.consumers}
+                        </div>
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {metrics.incomingRate.toFixed(1)}
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {metrics.deliverGetRate.toFixed(1)}
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {metrics.ackRate.toFixed(1)}
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {metrics.memory.toFixed(1)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="font-mono text-xs">
+                          {metrics.vhost}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <PurgeQueueDialog
+                          queueName={queue.name}
+                          messageCount={queue.messages}
+                          vhost={metrics.vhost}
+                          onSuccess={() => onRefetch()}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+            <PaginationControls
+              total={total}
+              page={page}
+              pageSize={pageSize}
+              onPageChange={onPageChange}
+              onPageSizeChange={onPageSizeChange}
+              itemLabel="queues"
+            />
+          </>
         ) : (
           <div className="text-center py-8">
             <MessageSquare className="h-12 w-12 text-gray-400 mx-auto mb-4" />

--- a/apps/app/src/components/alerts/ActiveAlertsList.tsx
+++ b/apps/app/src/components/alerts/ActiveAlertsList.tsx
@@ -6,22 +6,7 @@ import { RabbitMQAlert } from "@/lib/api/alertTypes";
 import { getUpgradePath } from "@/lib/featureFlags";
 
 import { Button } from "@/components/ui/button";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { PaginationControls } from "@/components/ui/PaginationControls";
 
 import { UserPlan } from "@/types/plans";
 
@@ -54,10 +39,6 @@ export const ActiveAlertsList = ({
   onPageSizeChange,
 }: ActiveAlertsListProps) => {
   const navigate = useNavigate();
-
-  const totalPages = Math.ceil(total / pageSize);
-  const startItem = total === 0 ? 0 : (page - 1) * pageSize + 1;
-  const endItem = Math.min(page * pageSize, total);
 
   // Show upgrade notification for free users
   if (userPlan === UserPlan.FREE) {
@@ -108,100 +89,14 @@ export const ActiveAlertsList = ({
         <AlertItem key={alert.id} alert={alert} />
       ))}
 
-      {/* Pagination Controls - Always show when there are alerts */}
-      {total > 0 && (
-        <div className="mt-6 space-y-4">
-          {/* Total count and page size selector */}
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">
-              Showing {startItem}-{endItem} of {total} alerts
-            </p>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">
-                Items per page:
-              </span>
-              <Select
-                value={pageSize.toString()}
-                onValueChange={(value) => onPageSizeChange(Number(value))}
-              >
-                <SelectTrigger className="w-20">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="10">10</SelectItem>
-                  <SelectItem value="25">25</SelectItem>
-                  <SelectItem value="50">50</SelectItem>
-                  <SelectItem value="100">100</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {/* Pagination buttons - Only show when there are multiple pages */}
-          {totalPages > 1 && (
-            <div className="flex justify-center">
-              <Pagination>
-                <PaginationContent>
-                  <PaginationItem>
-                    <PaginationPrevious
-                      onClick={() => onPageChange(Math.max(1, page - 1))}
-                      className={
-                        page <= 1
-                          ? "pointer-events-none opacity-50"
-                          : "cursor-pointer"
-                      }
-                    />
-                  </PaginationItem>
-
-                  {[...Array(Math.min(5, totalPages))].map((_, i) => {
-                    let pageNum: number;
-                    if (totalPages <= 5) {
-                      pageNum = i + 1;
-                    } else if (page <= 3) {
-                      pageNum = i + 1;
-                    } else if (page >= totalPages - 2) {
-                      pageNum = totalPages - 4 + i;
-                    } else {
-                      pageNum = page - 2 + i;
-                    }
-
-                    return (
-                      <PaginationItem key={pageNum}>
-                        <PaginationLink
-                          onClick={() => onPageChange(pageNum)}
-                          isActive={page === pageNum}
-                          className="cursor-pointer"
-                        >
-                          {pageNum}
-                        </PaginationLink>
-                      </PaginationItem>
-                    );
-                  })}
-
-                  {totalPages > 5 && page < totalPages - 2 && (
-                    <PaginationItem>
-                      <PaginationEllipsis />
-                    </PaginationItem>
-                  )}
-
-                  <PaginationItem>
-                    <PaginationNext
-                      onClick={() =>
-                        onPageChange(Math.min(totalPages, page + 1))
-                      }
-                      className={
-                        page >= totalPages
-                          ? "pointer-events-none opacity-50"
-                          : "cursor-pointer"
-                      }
-                    />
-                  </PaginationItem>
-                </PaginationContent>
-              </Pagination>
-            </div>
-          )}
-        </div>
-      )}
+      <PaginationControls
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={onPageChange}
+        onPageSizeChange={onPageSizeChange}
+        itemLabel="alerts"
+      />
     </div>
   );
 };

--- a/apps/app/src/components/alerts/ResolvedAlertsList.tsx
+++ b/apps/app/src/components/alerts/ResolvedAlertsList.tsx
@@ -2,22 +2,7 @@ import { CheckCircle, Loader2 } from "lucide-react";
 import { AlertTriangle } from "lucide-react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { PaginationControls } from "@/components/ui/PaginationControls";
 
 import { AlertItem } from "./AlertItem";
 
@@ -64,9 +49,6 @@ export const ResolvedAlertsList = ({
   onPageChange,
   onPageSizeChange,
 }: ResolvedAlertsListProps) => {
-  const totalPages = Math.ceil(total / pageSize);
-  const startItem = total === 0 ? 0 : (page - 1) * pageSize + 1;
-  const endItem = Math.min(page * pageSize, total);
   if (isLoading) {
     return (
       <div className="text-center py-8">
@@ -105,100 +87,14 @@ export const ResolvedAlertsList = ({
         <AlertItem key={alert.id} alert={alert} isResolved={true} />
       ))}
 
-      {/* Pagination Controls - Always show when there are alerts */}
-      {total > 0 && (
-        <div className="mt-6 space-y-4">
-          {/* Total count and page size selector */}
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">
-              Showing {startItem}-{endItem} of {total} resolved alerts
-            </p>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">
-                Items per page:
-              </span>
-              <Select
-                value={pageSize.toString()}
-                onValueChange={(value) => onPageSizeChange(Number(value))}
-              >
-                <SelectTrigger className="w-20">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="10">10</SelectItem>
-                  <SelectItem value="25">25</SelectItem>
-                  <SelectItem value="50">50</SelectItem>
-                  <SelectItem value="100">100</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {/* Pagination buttons - Only show when there are multiple pages */}
-          {totalPages > 1 && (
-            <div className="flex justify-center">
-              <Pagination>
-                <PaginationContent>
-                  <PaginationItem>
-                    <PaginationPrevious
-                      onClick={() => onPageChange(Math.max(1, page - 1))}
-                      className={
-                        page <= 1
-                          ? "pointer-events-none opacity-50"
-                          : "cursor-pointer"
-                      }
-                    />
-                  </PaginationItem>
-
-                  {[...Array(Math.min(5, totalPages))].map((_, i) => {
-                    let pageNum: number;
-                    if (totalPages <= 5) {
-                      pageNum = i + 1;
-                    } else if (page <= 3) {
-                      pageNum = i + 1;
-                    } else if (page >= totalPages - 2) {
-                      pageNum = totalPages - 4 + i;
-                    } else {
-                      pageNum = page - 2 + i;
-                    }
-
-                    return (
-                      <PaginationItem key={pageNum}>
-                        <PaginationLink
-                          onClick={() => onPageChange(pageNum)}
-                          isActive={page === pageNum}
-                          className="cursor-pointer"
-                        >
-                          {pageNum}
-                        </PaginationLink>
-                      </PaginationItem>
-                    );
-                  })}
-
-                  {totalPages > 5 && page < totalPages - 2 && (
-                    <PaginationItem>
-                      <PaginationEllipsis />
-                    </PaginationItem>
-                  )}
-
-                  <PaginationItem>
-                    <PaginationNext
-                      onClick={() =>
-                        onPageChange(Math.min(totalPages, page + 1))
-                      }
-                      className={
-                        page >= totalPages
-                          ? "pointer-events-none opacity-50"
-                          : "cursor-pointer"
-                      }
-                    />
-                  </PaginationItem>
-                </PaginationContent>
-              </Pagination>
-            </div>
-          )}
-        </div>
-      )}
+      <PaginationControls
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={onPageChange}
+        onPageSizeChange={onPageSizeChange}
+        itemLabel="resolved alerts"
+      />
     </div>
   );
 };

--- a/apps/app/src/components/ui/PaginationControls.tsx
+++ b/apps/app/src/components/ui/PaginationControls.tsx
@@ -80,6 +80,12 @@ export function PaginationControls({
                 />
               </PaginationItem>
 
+              {totalPages > 5 && page > 3 && (
+                <PaginationItem>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              )}
+
               {[...Array(Math.min(5, totalPages))].map((_, i) => {
                 let pageNum: number;
                 if (totalPages <= 5) {

--- a/apps/app/src/components/ui/PaginationControls.tsx
+++ b/apps/app/src/components/ui/PaginationControls.tsx
@@ -1,0 +1,130 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface PaginationControlsProps {
+  total: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+  itemLabel?: string;
+}
+
+export function PaginationControls({
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+  itemLabel = "items",
+}: PaginationControlsProps) {
+  const totalPages = Math.ceil(total / pageSize);
+  const startItem = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const endItem = Math.min(page * pageSize, total);
+
+  if (total <= 0) return null;
+
+  return (
+    <div className="mt-6 space-y-4">
+      {/* Total count and page size selector */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Showing {startItem}-{endItem} of {total} {itemLabel}
+        </p>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Items per page:</span>
+          <Select
+            value={pageSize.toString()}
+            onValueChange={(value) => onPageSizeChange(Number(value))}
+          >
+            <SelectTrigger className="w-20">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="10">10</SelectItem>
+              <SelectItem value="25">25</SelectItem>
+              <SelectItem value="50">50</SelectItem>
+              <SelectItem value="100">100</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Pagination buttons - Only show when there are multiple pages */}
+      {totalPages > 1 && (
+        <div className="flex justify-center">
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  onClick={() => onPageChange(Math.max(1, page - 1))}
+                  className={
+                    page <= 1
+                      ? "pointer-events-none opacity-50"
+                      : "cursor-pointer"
+                  }
+                />
+              </PaginationItem>
+
+              {[...Array(Math.min(5, totalPages))].map((_, i) => {
+                let pageNum: number;
+                if (totalPages <= 5) {
+                  pageNum = i + 1;
+                } else if (page <= 3) {
+                  pageNum = i + 1;
+                } else if (page >= totalPages - 2) {
+                  pageNum = totalPages - 4 + i;
+                } else {
+                  pageNum = page - 2 + i;
+                }
+
+                return (
+                  <PaginationItem key={pageNum}>
+                    <PaginationLink
+                      onClick={() => onPageChange(pageNum)}
+                      isActive={page === pageNum}
+                      className="cursor-pointer"
+                    >
+                      {pageNum}
+                    </PaginationLink>
+                  </PaginationItem>
+                );
+              })}
+
+              {totalPages > 5 && page < totalPages - 2 && (
+                <PaginationItem>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              )}
+
+              <PaginationItem>
+                <PaginationNext
+                  onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+                  className={
+                    page >= totalPages
+                      ? "pointer-events-none opacity-50"
+                      : "cursor-pointer"
+                  }
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/pages/Queues.tsx
+++ b/apps/app/src/pages/Queues.tsx
@@ -23,6 +23,8 @@ const Queues = () => {
   const navigate = useNavigate();
   const { isLoading: workspaceLoading } = useUser();
   const [filterRegex, setFilterRegex] = useState("");
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
   const { selectedServerId, hasServers } = useServerContext();
   const { selectedVHost } = useVHostContext();
   const { data: queuesData, isLoading } = useQueues(
@@ -48,6 +50,11 @@ const Queues = () => {
       }
     });
   }, [queues, filterRegex]);
+
+  const paginatedQueues = useMemo(
+    () => filteredQueues.slice((page - 1) * pageSize, page * pageSize),
+    [filteredQueues, page, pageSize]
+  );
 
   if (!hasServers) {
     return (
@@ -117,7 +124,10 @@ const Queues = () => {
               <Input
                 placeholder={t("filterRegex")}
                 value={filterRegex}
-                onChange={(e) => setFilterRegex(e.target.value)}
+                onChange={(e) => {
+                  setFilterRegex(e.target.value);
+                  setPage(1);
+                }}
                 className="max-w-xs"
               />
               <div className="flex items-center gap-1 text-sm text-muted-foreground">
@@ -127,13 +137,21 @@ const Queues = () => {
 
             {/* Queues Table */}
             <QueueTable
-              queues={filteredQueues}
+              queues={paginatedQueues}
               isLoading={isLoading}
               searchTerm={filterRegex}
               onNavigateToQueue={(queueName) =>
                 navigate(`/queues/${queueName}`)
               }
               onRefetch={handleRefetch}
+              total={filteredQueues.length}
+              page={page}
+              pageSize={pageSize}
+              onPageChange={setPage}
+              onPageSizeChange={(size) => {
+                setPageSize(size);
+                setPage(1);
+              }}
             />
           </div>
         </main>


### PR DESCRIPTION
## Summary
- Extract shared `PaginationControls` component from duplicated alerts pagination code (~90 lines removed per file)
- Add client-side pagination to the queues table (page/pageSize state, slicing, page reset on filter change)
- Reuse `PaginationControls` in `ActiveAlertsList`, `ResolvedAlertsList`, and `QueueTable`

## Test plan
- [ ] Queues page: pagination controls appear below table, page navigation works
- [ ] Queues page: changing page size resets to page 1
- [ ] Queues page: typing in filter resets to page 1
- [ ] Alerts page: active and resolved alerts pagination still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified pagination controls across queue and alert lists with page-size options (10, 25, 50, 100), page numbers, and Previous/Next navigation.
* **Improvements**
  * Replaced manual pagination UIs with the new controls for consistent behavior and simplified list views.
  * Page resets to the first page when search/filter or page-size changes to keep results predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->