### PR TITLE
fix: remove coming_soon type and badge from topology visualization

### DIFF
--- a/apps/api/src/services/plan/features.service.ts
+++ b/apps/api/src/services/plan/features.service.ts
@@ -24,7 +24,7 @@ export interface PlanFeatures {
   // Display features (for pricing page rendering)
   hasAdvancedAnalytics: boolean;
   hasAlerts: boolean;
-  hasTopologyVisualization: boolean | "coming_soon";
+  hasTopologyVisualization: boolean;
   hasRoleBasedAccess: boolean | "coming_soon";
   hasSsoSamlOidc: boolean;
   hasSoc2Compliance: boolean;

--- a/apps/app/src/lib/api/planClient.ts
+++ b/apps/app/src/lib/api/planClient.ts
@@ -38,7 +38,7 @@ export interface CurrentPlanResponse {
     // Display features
     hasAdvancedAnalytics: boolean;
     hasAlerts: boolean;
-    hasTopologyVisualization: boolean | "coming_soon";
+    hasTopologyVisualization: boolean;
     hasRoleBasedAccess: boolean | "coming_soon";
     hasSsoSamlOidc: boolean;
     hasSoc2Compliance: boolean;

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -77,7 +77,7 @@ interface ApiPlan {
   hasPrioritySupport: boolean;
   hasAdvancedAnalytics: boolean;
   hasAlerts: boolean;
-  hasTopologyVisualization: boolean | "coming_soon";
+  hasTopologyVisualization: boolean;
   hasRoleBasedAccess: boolean | "coming_soon";
   hasSsoSamlOidc: boolean;
   hasSoc2Compliance: boolean;
@@ -195,11 +195,6 @@ const PlanCard: React.FC<{
               {plan.hasTopologyVisualization && (
                 <FeatureItem
                   label={t("plans.features.topologyVisualization")}
-                  soonLabel={
-                    plan.hasTopologyVisualization === "coming_soon"
-                      ? soonLabel
-                      : undefined
-                  }
                 />
               )}
               {plan.hasRoleBasedAccess && (


### PR DESCRIPTION
## Summary
- Removes `"coming_soon"` from the `hasTopologyVisualization` type in `features.service.ts`, `planClient.ts`, and `Plans.tsx`
- Simplifies the topology `FeatureItem` in the Plans page (no more "Soon" badge conditional)
- Topology visualization is now fully implemented for Developer and Enterprise plans

## Test plan
- [ ] Visit the Plans page in the app — topology visualization should show without any "Soon" badge for Developer and Enterprise plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)