### PR TITLE
fix: enforce workspace-scoped RBAC on admin endpoints

### DIFF
--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -60,7 +60,8 @@
     "failedToAcceptInvitationGoogle": "Failed to accept invitation with Google",
     "insufficientPermissionsAdmin": "Insufficient permissions - Admin role required",
     "insufficientPermissions": "Insufficient permissions",
-    "workspaceAdminRequired": "Workspace admin role required to perform this action"
+    "workspaceAdminRequired": "Workspace admin role required to perform this action",
+    "cannotAssignHigherRole": "Cannot assign a role higher than your own"
   },
   "workspace": {
     "idRequired": "Workspace ID is required",

--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -96,6 +96,7 @@
     "failedToFetchUser": "Failed to fetch user",
     "doesNotBelongToWorkspace": "User does not belong to this workspace",
     "failedToUpdateUser": "Failed to update user",
+    "cannotUpdateIsActive": "isActive cannot be updated via this endpoint",
     "isNotMemberOfWorkspace": "User is not a member of this workspace",
     "cannotRemoveSelf": "Cannot remove yourself from the workspace",
     "onlyOwnerCanRemoveAdmin": "Only workspace owners can remove admin users",

--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -59,7 +59,8 @@
     "googleEmailMismatchInvitation": "Google account email does not match invitation email",
     "failedToAcceptInvitationGoogle": "Failed to accept invitation with Google",
     "insufficientPermissionsAdmin": "Insufficient permissions - Admin role required",
-    "insufficientPermissions": "Insufficient permissions"
+    "insufficientPermissions": "Insufficient permissions",
+    "workspaceAdminRequired": "Workspace admin role required to perform this action"
   },
   "workspace": {
     "idRequired": "Workspace ID is required",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -60,7 +60,7 @@
     "failedToAcceptInvitationGoogle": "Error al aceptar la invitación con Google",
     "insufficientPermissionsAdmin": "Permisos insuficientes — Se requiere rol de administrador",
     "insufficientPermissions": "Permisos insuficientes",
-    "workspaceAdminRequired": "Se requiere el rol de administrador del espacio de trabajo para realizar esta accion"
+    "workspaceAdminRequired": "Se requiere el rol de administrador del espacio de trabajo para realizar esta acción"
   },
   "workspace": {
     "idRequired": "Se requiere el ID del espacio de trabajo",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -96,6 +96,7 @@
     "failedToFetchUser": "Error al obtener el usuario",
     "doesNotBelongToWorkspace": "El usuario no pertenece a este espacio de trabajo",
     "failedToUpdateUser": "Error al actualizar el usuario",
+    "cannotUpdateIsActive": "isActive no se puede actualizar a través de este endpoint",
     "isNotMemberOfWorkspace": "El usuario no es miembro de este espacio de trabajo",
     "cannotRemoveSelf": "No puede eliminarse a sí mismo del espacio de trabajo",
     "onlyOwnerCanRemoveAdmin": "Solo los propietarios del espacio de trabajo pueden eliminar usuarios administradores",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -59,7 +59,8 @@
     "googleEmailMismatchInvitation": "El correo electrónico de la cuenta de Google no coincide con el de la invitación",
     "failedToAcceptInvitationGoogle": "Error al aceptar la invitación con Google",
     "insufficientPermissionsAdmin": "Permisos insuficientes — Se requiere rol de administrador",
-    "insufficientPermissions": "Permisos insuficientes"
+    "insufficientPermissions": "Permisos insuficientes",
+    "workspaceAdminRequired": "Se requiere el rol de administrador del espacio de trabajo para realizar esta accion"
   },
   "workspace": {
     "idRequired": "Se requiere el ID del espacio de trabajo",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -60,7 +60,8 @@
     "failedToAcceptInvitationGoogle": "Error al aceptar la invitación con Google",
     "insufficientPermissionsAdmin": "Permisos insuficientes — Se requiere rol de administrador",
     "insufficientPermissions": "Permisos insuficientes",
-    "workspaceAdminRequired": "Se requiere el rol de administrador del espacio de trabajo para realizar esta acción"
+    "workspaceAdminRequired": "Se requiere el rol de administrador del espacio de trabajo para realizar esta acción",
+    "cannotAssignHigherRole": "No se puede asignar un rol superior al propio"
   },
   "workspace": {
     "idRequired": "Se requiere el ID del espacio de trabajo",

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -59,7 +59,8 @@
     "googleEmailMismatchInvitation": "L'adresse e-mail du compte Google ne correspond pas à celle de l'invitation",
     "failedToAcceptInvitationGoogle": "Échec de l'acceptation de l'invitation avec Google",
     "insufficientPermissionsAdmin": "Permissions insuffisantes — Rôle administrateur requis",
-    "insufficientPermissions": "Permissions insuffisantes"
+    "insufficientPermissions": "Permissions insuffisantes",
+    "workspaceAdminRequired": "Le rôle administrateur de l'espace de travail est requis pour effectuer cette action"
   },
   "workspace": {
     "idRequired": "L'identifiant de l'espace de travail est requis",

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -60,7 +60,8 @@
     "failedToAcceptInvitationGoogle": "Échec de l'acceptation de l'invitation avec Google",
     "insufficientPermissionsAdmin": "Permissions insuffisantes — Rôle administrateur requis",
     "insufficientPermissions": "Permissions insuffisantes",
-    "workspaceAdminRequired": "Le rôle administrateur de l'espace de travail est requis pour effectuer cette action"
+    "workspaceAdminRequired": "Le rôle administrateur de l'espace de travail est requis pour effectuer cette action",
+    "cannotAssignHigherRole": "Impossible d'attribuer un rôle supérieur au vôtre"
   },
   "workspace": {
     "idRequired": "L'identifiant de l'espace de travail est requis",

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -96,6 +96,7 @@
     "failedToFetchUser": "Échec de la récupération de l'utilisateur",
     "doesNotBelongToWorkspace": "L'utilisateur n'appartient pas à cet espace de travail",
     "failedToUpdateUser": "Échec de la mise à jour de l'utilisateur",
+    "cannotUpdateIsActive": "isActive ne peut pas être mis à jour via cet endpoint",
     "isNotMemberOfWorkspace": "L'utilisateur n'est pas membre de cet espace de travail",
     "cannotRemoveSelf": "Impossible de vous retirer de l'espace de travail",
     "onlyOwnerCanRemoveAdmin": "Seuls les propriétaires de l'espace de travail peuvent retirer les administrateurs",

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -59,7 +59,8 @@
     "googleEmailMismatchInvitation": "Google 账户的邮箱地址与邀请邮箱地址不匹配",
     "failedToAcceptInvitationGoogle": "通过 Google 接受邀请失败",
     "insufficientPermissionsAdmin": "权限不足 — 需要管理员角色",
-    "insufficientPermissions": "权限不足"
+    "insufficientPermissions": "权限不足",
+    "workspaceAdminRequired": "需要工作区管理员角色才能执行此操作"
   },
   "workspace": {
     "idRequired": "工作区 ID 为必填项",

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -60,7 +60,8 @@
     "failedToAcceptInvitationGoogle": "通过 Google 接受邀请失败",
     "insufficientPermissionsAdmin": "权限不足 — 需要管理员角色",
     "insufficientPermissions": "权限不足",
-    "workspaceAdminRequired": "需要工作区管理员角色才能执行此操作"
+    "workspaceAdminRequired": "需要工作区管理员角色才能执行此操作",
+    "cannotAssignHigherRole": "无法分配高于自身的角色"
   },
   "workspace": {
     "idRequired": "工作区 ID 为必填项",

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -96,6 +96,7 @@
     "failedToFetchUser": "获取用户信息失败",
     "doesNotBelongToWorkspace": "用户不属于此工作区",
     "failedToUpdateUser": "更新用户信息失败",
+    "cannotUpdateIsActive": "无法通过此端点更新 isActive",
     "isNotMemberOfWorkspace": "用户不是此工作区的成员",
     "cannotRemoveSelf": "无法将自己从工作区中移除",
     "onlyOwnerCanRemoveAdmin": "只有工作区所有者才能移除管理员用户",

--- a/apps/api/prisma/migrations/20260311000000_add_workspace_role_enum/migration.sql
+++ b/apps/api/prisma/migrations/20260311000000_add_workspace_role_enum/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+CREATE TYPE "WorkspaceRole" AS ENUM ('OWNER', 'ADMIN', 'MEMBER', 'READONLY');
+
+-- AlterTable: WorkspaceMember.role from UserRole to WorkspaceRole
+ALTER TABLE "WorkspaceMember" ALTER COLUMN "role" TYPE "WorkspaceRole" USING "role"::text::"WorkspaceRole";
+
+-- AlterTable: Invitation.role from UserRole to WorkspaceRole
+ALTER TABLE "Invitation" ALTER COLUMN "role" TYPE "WorkspaceRole" USING "role"::text::"WorkspaceRole";
+ALTER TABLE "Invitation" ALTER COLUMN "role" SET DEFAULT 'MEMBER'::"WorkspaceRole";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -95,7 +95,7 @@ model Invitation {
   token                               String           @unique
   invitedById                         String
   invitedUserId                       String?
-  role                                UserRole         @default(MEMBER)
+  role                                WorkspaceRole    @default(MEMBER)
   status                              InvitationStatus @default(PENDING)
   expiresAt                           DateTime
   createdAt                           DateTime         @default(now())
@@ -272,10 +272,10 @@ model WorkspaceMember {
   id          String    @id @default(uuid())
   userId      String
   workspaceId String
-  role        UserRole
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  user        User      @relation("WorkspaceMembers", fields: [userId], references: [id], onDelete: Cascade)
+  role        WorkspaceRole
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  user        User          @relation("WorkspaceMembers", fields: [userId], references: [id], onDelete: Cascade)
   workspace   Workspace @relation("WorkspaceMembers", fields: [workspaceId], references: [id], onDelete: Cascade)
 
   @@unique([userId, workspaceId])
@@ -625,6 +625,13 @@ enum UserPlan {
 }
 
 enum UserRole {
+  ADMIN
+  MEMBER
+  READONLY
+}
+
+enum WorkspaceRole {
+  OWNER
   ADMIN
   MEMBER
   READONLY

--- a/apps/api/src/core/__tests__/workspace-roles.test.ts
+++ b/apps/api/src/core/__tests__/workspace-roles.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canAssignRole,
+  hasMinimumWorkspaceRole,
+  INVITABLE_ROLES,
+  WORKSPACE_ROLE_LEVELS,
+} from "../workspace-roles";
+
+import { WorkspaceRole } from "@/generated/prisma/client";
+
+describe("workspace-roles", () => {
+  describe("WORKSPACE_ROLE_LEVELS", () => {
+    it("defines correct hierarchy order", () => {
+      expect(WORKSPACE_ROLE_LEVELS[WorkspaceRole.READONLY]).toBeLessThan(
+        WORKSPACE_ROLE_LEVELS[WorkspaceRole.MEMBER]
+      );
+      expect(WORKSPACE_ROLE_LEVELS[WorkspaceRole.MEMBER]).toBeLessThan(
+        WORKSPACE_ROLE_LEVELS[WorkspaceRole.ADMIN]
+      );
+      expect(WORKSPACE_ROLE_LEVELS[WorkspaceRole.ADMIN]).toBeLessThan(
+        WORKSPACE_ROLE_LEVELS[WorkspaceRole.OWNER]
+      );
+    });
+  });
+
+  describe("hasMinimumWorkspaceRole", () => {
+    it("OWNER has at least ADMIN", () => {
+      expect(
+        hasMinimumWorkspaceRole(WorkspaceRole.OWNER, WorkspaceRole.ADMIN)
+      ).toBe(true);
+    });
+
+    it("ADMIN has at least ADMIN", () => {
+      expect(
+        hasMinimumWorkspaceRole(WorkspaceRole.ADMIN, WorkspaceRole.ADMIN)
+      ).toBe(true);
+    });
+
+    it("MEMBER does not have at least ADMIN", () => {
+      expect(
+        hasMinimumWorkspaceRole(WorkspaceRole.MEMBER, WorkspaceRole.ADMIN)
+      ).toBe(false);
+    });
+
+    it("READONLY does not have at least MEMBER", () => {
+      expect(
+        hasMinimumWorkspaceRole(WorkspaceRole.READONLY, WorkspaceRole.MEMBER)
+      ).toBe(false);
+    });
+
+    it("every role has at least READONLY", () => {
+      for (const role of Object.values(WorkspaceRole)) {
+        expect(hasMinimumWorkspaceRole(role, WorkspaceRole.READONLY)).toBe(
+          true
+        );
+      }
+    });
+  });
+
+  describe("canAssignRole", () => {
+    it("OWNER can assign any role", () => {
+      for (const target of Object.values(WorkspaceRole)) {
+        expect(canAssignRole(WorkspaceRole.OWNER, target)).toBe(true);
+      }
+    });
+
+    it("ADMIN can assign ADMIN, MEMBER, READONLY", () => {
+      expect(canAssignRole(WorkspaceRole.ADMIN, WorkspaceRole.ADMIN)).toBe(
+        true
+      );
+      expect(canAssignRole(WorkspaceRole.ADMIN, WorkspaceRole.MEMBER)).toBe(
+        true
+      );
+      expect(canAssignRole(WorkspaceRole.ADMIN, WorkspaceRole.READONLY)).toBe(
+        true
+      );
+    });
+
+    it("ADMIN cannot assign OWNER", () => {
+      expect(canAssignRole(WorkspaceRole.ADMIN, WorkspaceRole.OWNER)).toBe(
+        false
+      );
+    });
+
+    it("MEMBER cannot assign ADMIN", () => {
+      expect(canAssignRole(WorkspaceRole.MEMBER, WorkspaceRole.ADMIN)).toBe(
+        false
+      );
+    });
+
+    it("READONLY cannot assign MEMBER", () => {
+      expect(canAssignRole(WorkspaceRole.READONLY, WorkspaceRole.MEMBER)).toBe(
+        false
+      );
+    });
+  });
+
+  describe("INVITABLE_ROLES", () => {
+    it("excludes OWNER", () => {
+      expect(INVITABLE_ROLES).not.toContain(WorkspaceRole.OWNER);
+    });
+
+    it("includes ADMIN, MEMBER, READONLY", () => {
+      expect(INVITABLE_ROLES).toContain(WorkspaceRole.ADMIN);
+      expect(INVITABLE_ROLES).toContain(WorkspaceRole.MEMBER);
+      expect(INVITABLE_ROLES).toContain(WorkspaceRole.READONLY);
+    });
+  });
+});

--- a/apps/api/src/core/bootstrap-admin.ts
+++ b/apps/api/src/core/bootstrap-admin.ts
@@ -8,7 +8,7 @@ import { ensureWorkspaceMember } from "@/core/workspace-access";
 
 import { adminBootstrapConfig } from "@/config";
 
-import { UserRole } from "@/generated/prisma/client";
+import { UserRole, WorkspaceRole } from "@/generated/prisma/client";
 
 /**
  * Bootstrap the first admin user on first boot.
@@ -71,7 +71,7 @@ export async function bootstrapAdmin(): Promise<void> {
       data: { ownerId: user.id },
     });
 
-    await ensureWorkspaceMember(user.id, workspace.id, UserRole.ADMIN, tx);
+    await ensureWorkspaceMember(user.id, workspace.id, WorkspaceRole.ADMIN, tx);
 
     logger.info(
       { userId: user.id, workspaceId: workspace.id, email },

--- a/apps/api/src/core/workspace-access.ts
+++ b/apps/api/src/core/workspace-access.ts
@@ -1,14 +1,15 @@
 import { prisma } from "@/core/prisma";
 
-import { Prisma, UserRole } from "@/generated/prisma/client";
+import { Prisma, WorkspaceRole } from "@/generated/prisma/client";
 
 /**
- * Get user's role in a workspace (from WorkspaceMember or ADMIN if owner)
+ * Get user's role in a workspace.
+ * Returns OWNER if the user owns the workspace, otherwise the WorkspaceMember role.
  */
 export async function getUserWorkspaceRole(
   userId: string,
   workspaceId: string
-): Promise<UserRole | null> {
+): Promise<WorkspaceRole | null> {
   // Check if user is the workspace owner
   const workspace = await prisma.workspace.findUnique({
     where: { id: workspaceId },
@@ -16,7 +17,7 @@ export async function getUserWorkspaceRole(
   });
 
   if (workspace?.ownerId === userId) {
-    return UserRole.ADMIN;
+    return WorkspaceRole.OWNER;
   }
 
   // Get role from WorkspaceMember
@@ -40,7 +41,7 @@ export async function getUserWorkspaceRole(
 export async function ensureWorkspaceMember(
   userId: string,
   workspaceId: string,
-  role: UserRole,
+  role: WorkspaceRole,
   tx?: Omit<
     Prisma.TransactionClient,
     "$connect" | "$disconnect" | "$on" | "$transaction" | "$extends"

--- a/apps/api/src/core/workspace-roles.ts
+++ b/apps/api/src/core/workspace-roles.ts
@@ -1,0 +1,31 @@
+import { WorkspaceRole } from "@/generated/prisma/client";
+
+export const WORKSPACE_ROLE_LEVELS: Record<WorkspaceRole, number> = {
+  [WorkspaceRole.READONLY]: 0,
+  [WorkspaceRole.MEMBER]: 1,
+  [WorkspaceRole.ADMIN]: 2,
+  [WorkspaceRole.OWNER]: 3,
+};
+
+/** True when `role` is at least `minimumRole` in the hierarchy. */
+export function hasMinimumWorkspaceRole(
+  role: WorkspaceRole,
+  minimumRole: WorkspaceRole
+): boolean {
+  return WORKSPACE_ROLE_LEVELS[role] >= WORKSPACE_ROLE_LEVELS[minimumRole];
+}
+
+/** True when `callerRole` can assign/invite `targetRole` (at or below own level). */
+export function canAssignRole(
+  callerRole: WorkspaceRole,
+  targetRole: WorkspaceRole
+): boolean {
+  return WORKSPACE_ROLE_LEVELS[targetRole] <= WORKSPACE_ROLE_LEVELS[callerRole];
+}
+
+/** Roles that may be assigned via invitation or admin update (excludes OWNER). */
+export const INVITABLE_ROLES = [
+  WorkspaceRole.READONLY,
+  WorkspaceRole.MEMBER,
+  WorkspaceRole.ADMIN,
+] as const;

--- a/apps/api/src/schemas/invitation.ts
+++ b/apps/api/src/schemas/invitation.ts
@@ -1,10 +1,12 @@
 import { z } from "zod/v4";
 
-import { UserRole } from "@/generated/prisma/client";
+import { INVITABLE_ROLES } from "@/core/workspace-roles";
+
+import { WorkspaceRole } from "@/generated/prisma/client";
 
 export const inviteUserSchema = z.object({
   email: z.email("Invalid email address"),
-  role: z.enum(UserRole).default(UserRole.MEMBER),
+  role: z.enum(INVITABLE_ROLES).default(WorkspaceRole.MEMBER),
   message: z
     .string()
     .optional()

--- a/apps/api/src/schemas/user.ts
+++ b/apps/api/src/schemas/user.ts
@@ -1,12 +1,12 @@
 import { z } from "zod/v4";
 
-import { UserRole } from "@/generated/prisma/client";
+import { INVITABLE_ROLES } from "@/core/workspace-roles";
 
 // Schema for updating a user
 const UpdateUserSchema = z.object({
   firstName: z.string().min(1, "First name is required").optional(),
   lastName: z.string().min(1, "Last name is required").optional(),
-  role: z.enum(UserRole).optional(),
+  role: z.enum(INVITABLE_ROLES).optional(),
   isActive: z.boolean().optional(),
   workspaceId: z.uuid("Invalid workspace ID").optional(),
 });

--- a/apps/api/src/trpc/routers/__tests__/user-workspace-auth.test.ts
+++ b/apps/api/src/trpc/routers/__tests__/user-workspace-auth.test.ts
@@ -1,0 +1,403 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+// Mock workspace packages that aren't resolved in worktrees
+vi.mock("@qarote/i18n", () => ({
+  SUPPORTED_LOCALES: ["en", "fr", "es", "zh"],
+}));
+vi.mock("@qarote/i18n/server", () => ({
+  createServerI18nInstance: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockWorkspaceMemberFindMany = vi.fn();
+const mockWorkspaceMemberFindUnique = vi.fn();
+const mockWorkspaceMemberDeleteMany = vi.fn();
+const mockWorkspaceFindUnique = vi.fn();
+const mockWorkspaceFindFirst = vi.fn();
+const mockUserFindUnique = vi.fn();
+const mockUserUpdate = vi.fn();
+const mockInvitationFindMany = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    workspace: {
+      findUnique: (...args: unknown[]) => mockWorkspaceFindUnique(...args),
+      findFirst: (...args: unknown[]) => mockWorkspaceFindFirst(...args),
+    },
+    workspaceMember: {
+      findMany: (...args: unknown[]) => mockWorkspaceMemberFindMany(...args),
+      findUnique: (...args: unknown[]) =>
+        mockWorkspaceMemberFindUnique(...args),
+      deleteMany: (...args: unknown[]) =>
+        mockWorkspaceMemberDeleteMany(...args),
+    },
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+      update: (...args: unknown[]) => mockUserUpdate(...args),
+    },
+    invitation: {
+      findMany: (...args: unknown[]) => mockInvitationFindMany(...args),
+    },
+    $transaction: (...args: unknown[]) => mockTransaction(...args),
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock rate limiter to be a passthrough
+vi.mock("../../middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+// Mock plan service
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+// Mock workspace middleware — hasWorkspaceAccess
+const mockHasWorkspaceAccess = vi.fn().mockResolvedValue(true);
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: (...args: unknown[]) => mockHasWorkspaceAccess(...args),
+}));
+
+// Mock workspace-access (getUserWorkspaceRole)
+const mockGetUserWorkspaceRole = vi.fn();
+vi.mock("@/core/workspace-access", () => ({
+  getUserWorkspaceRole: (...args: unknown[]) =>
+    mockGetUserWorkspaceRole(...args),
+}));
+
+// Mock UserMapper
+vi.mock("@/mappers/auth", () => ({
+  UserMapper: {
+    toApiResponse: (u: Record<string, unknown>) => ({
+      ...u,
+      lastLogin: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    }),
+  },
+}));
+
+// Mock email verification
+vi.mock("@/services/email/email-verification.service", () => ({
+  EmailVerificationService: {
+    generateVerificationToken: vi.fn(),
+    sendVerificationEmail: vi.fn(),
+  },
+}));
+
+// Import after mocks
+const { userRouter } = await import("../user");
+
+// --- Helpers ---
+
+const WORKSPACE_ID = "ws-1";
+
+function makeAdminCtx(workspaceId = WORKSPACE_ID) {
+  return {
+    prisma: {
+      workspaceMember: {
+        findMany: mockWorkspaceMemberFindMany,
+        findUnique: mockWorkspaceMemberFindUnique,
+        deleteMany: mockWorkspaceMemberDeleteMany,
+      },
+      workspace: {
+        findUnique: mockWorkspaceFindUnique,
+        findFirst: mockWorkspaceFindFirst,
+      },
+      user: {
+        findUnique: mockUserFindUnique,
+        update: mockUserUpdate,
+      },
+      invitation: {
+        findMany: mockInvitationFindMany,
+      },
+      $transaction: mockTransaction,
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "admin-1",
+      role: "ADMIN",
+      isActive: true,
+      email: "admin@test.com",
+      firstName: "Admin",
+      lastName: "User",
+      workspaceId,
+    },
+    workspaceId,
+    req: {},
+  };
+}
+
+function makeMemberCtx(workspaceId = WORKSPACE_ID) {
+  return {
+    ...makeAdminCtx(workspaceId),
+    user: {
+      id: "member-1",
+      role: "MEMBER",
+      isActive: true,
+      email: "member@test.com",
+      firstName: "Member",
+      lastName: "User",
+      workspaceId,
+    },
+  };
+}
+
+function makeReadonlyCtx(workspaceId = WORKSPACE_ID) {
+  return {
+    ...makeAdminCtx(workspaceId),
+    user: {
+      id: "readonly-1",
+      role: "READONLY",
+      isActive: true,
+      email: "readonly@test.com",
+      firstName: "Readonly",
+      lastName: "User",
+      workspaceId,
+    },
+  };
+}
+
+// --- Tests ---
+
+describe("userRouter workspace-scoped authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: workspace exists and user is a member
+    mockHasWorkspaceAccess.mockResolvedValue(true);
+  });
+
+  describe("getInvitations", () => {
+    it("allows workspace admin to get invitations", async () => {
+      // getUserWorkspaceRole returns ADMIN for the workspace
+      mockGetUserWorkspaceRole.mockResolvedValue("ADMIN");
+      mockInvitationFindMany.mockResolvedValue([]);
+
+      const caller = userRouter.createCaller(makeAdminCtx() as never);
+      const result = await caller.getInvitations({
+        workspaceId: WORKSPACE_ID,
+      });
+
+      expect(result.invitations).toEqual([]);
+    });
+
+    it("rejects workspace member (non-admin) from getting invitations", async () => {
+      // getUserWorkspaceRole returns MEMBER
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+
+      const caller = userRouter.createCaller(makeMemberCtx() as never);
+      await expect(
+        caller.getInvitations({ workspaceId: WORKSPACE_ID })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+
+    it("rejects readonly user from getting invitations", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("READONLY");
+
+      const caller = userRouter.createCaller(makeReadonlyCtx() as never);
+      await expect(
+        caller.getInvitations({ workspaceId: WORKSPACE_ID })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+
+    it("rejects user who is admin in different workspace", async () => {
+      // User is admin globally but NOT in the target workspace
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+
+      const ctx = makeAdminCtx(WORKSPACE_ID);
+      // The user's global role is ADMIN, but workspace role is MEMBER
+      const caller = userRouter.createCaller(ctx as never);
+      await expect(
+        caller.getInvitations({ workspaceId: WORKSPACE_ID })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+  });
+
+  describe("updateUser", () => {
+    it("allows workspace admin to update a user", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("ADMIN");
+      mockUserFindUnique.mockResolvedValue({
+        id: "target-user",
+        email: "target@test.com",
+      });
+      mockHasWorkspaceAccess.mockResolvedValue(true);
+      mockUserUpdate.mockResolvedValue({
+        id: "target-user",
+        email: "target@test.com",
+        firstName: "Updated",
+        lastName: "User",
+        role: "MEMBER",
+        workspaceId: WORKSPACE_ID,
+        isActive: true,
+        emailVerified: true,
+        lastLogin: null,
+        createdAt: new Date("2025-01-01"),
+        updatedAt: new Date("2025-01-01"),
+      });
+
+      const caller = userRouter.createCaller(makeAdminCtx() as never);
+      const result = await caller.updateUser({
+        id: "target-user",
+        workspaceId: WORKSPACE_ID,
+        firstName: "Updated",
+      });
+
+      expect(result.user).toBeDefined();
+    });
+
+    it("rejects workspace member from updating a user", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+
+      const caller = userRouter.createCaller(makeMemberCtx() as never);
+      await expect(
+        caller.updateUser({
+          id: "target-user",
+          workspaceId: WORKSPACE_ID,
+          firstName: "Hacked",
+        })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+  });
+
+  describe("updateWorkspace", () => {
+    it("allows workspace admin to update workspace info", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("ADMIN");
+
+      const mockPrisma = makeAdminCtx().prisma;
+      const mockWorkspaceUpdate = vi.fn().mockResolvedValue({
+        id: WORKSPACE_ID,
+        name: "Updated WS",
+        contactEmail: "ws@test.com",
+        logoUrl: null,
+        createdAt: new Date("2025-01-01"),
+        updatedAt: new Date("2025-01-01"),
+        _count: { users: 1, servers: 0 },
+      });
+
+      const ctx = {
+        ...makeAdminCtx(),
+        prisma: {
+          ...mockPrisma,
+          workspace: {
+            ...mockPrisma.workspace,
+            update: mockWorkspaceUpdate,
+          },
+        },
+      };
+
+      const caller = userRouter.createCaller(ctx as never);
+      const result = await caller.updateWorkspace({ name: "Updated WS" });
+
+      expect(result.workspace.name).toBe("Updated WS");
+    });
+
+    it("rejects workspace member from updating workspace info", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+
+      const caller = userRouter.createCaller(makeMemberCtx() as never);
+      await expect(
+        caller.updateWorkspace({ name: "Hacked WS" })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+  });
+
+  describe("removeFromWorkspace", () => {
+    it("allows workspace admin to remove a member", async () => {
+      mockGetUserWorkspaceRole
+        .mockResolvedValueOnce("ADMIN") // for workspaceAdminProcedure check (caller)
+        .mockResolvedValueOnce("MEMBER"); // for target user role check
+
+      mockUserFindUnique.mockResolvedValue({
+        id: "target-user",
+        email: "target@test.com",
+        firstName: "Target",
+        lastName: "User",
+      });
+
+      mockTransaction.mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          return fn({
+            workspaceMember: { deleteMany: vi.fn() },
+            user: { update: vi.fn() },
+          });
+        }
+      );
+
+      const caller = userRouter.createCaller(makeAdminCtx() as never);
+      const result = await caller.removeFromWorkspace({
+        userId: "target-user",
+        workspaceId: WORKSPACE_ID,
+      });
+
+      expect(result.removedUser.id).toBe("target-user");
+    });
+
+    it("rejects workspace member from removing another user", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+
+      const caller = userRouter.createCaller(makeMemberCtx() as never);
+      await expect(
+        caller.removeFromWorkspace({
+          userId: "admin-1",
+          workspaceId: WORKSPACE_ID,
+        })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+
+    it("rejects readonly user from removing another user", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("READONLY");
+
+      const caller = userRouter.createCaller(makeReadonlyCtx() as never);
+      await expect(
+        caller.removeFromWorkspace({
+          userId: "member-1",
+          workspaceId: WORKSPACE_ID,
+        })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+
+    it("prevents cross-workspace admin from removing users", async () => {
+      // User is ADMIN in ws-other but MEMBER in ws-1
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+      mockHasWorkspaceAccess.mockResolvedValue(true);
+
+      const ctx = makeMemberCtx(WORKSPACE_ID);
+      // Override global role to ADMIN (to prove global role doesn't matter)
+      ctx.user.role = "ADMIN";
+
+      const caller = userRouter.createCaller(ctx as never);
+      await expect(
+        caller.removeFromWorkspace({
+          userId: "target-user",
+          workspaceId: WORKSPACE_ID,
+        })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+  });
+
+  describe("getWorkspaceUsers (unchanged - uses workspaceProcedure)", () => {
+    it("allows any workspace member to list users", async () => {
+      mockWorkspaceMemberFindMany.mockResolvedValue([]);
+      mockHasWorkspaceAccess.mockResolvedValue(true);
+
+      const caller = userRouter.createCaller(makeMemberCtx() as never);
+      const result = await caller.getWorkspaceUsers({
+        workspaceId: WORKSPACE_ID,
+      });
+
+      expect(result.users).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/__tests__/user-workspace-auth.test.ts
+++ b/apps/api/src/trpc/routers/__tests__/user-workspace-auth.test.ts
@@ -15,6 +15,7 @@ vi.mock("@qarote/i18n/server", () => ({
 const mockWorkspaceMemberFindMany = vi.fn();
 const mockWorkspaceMemberFindUnique = vi.fn();
 const mockWorkspaceMemberDeleteMany = vi.fn();
+const mockWorkspaceMemberUpdate = vi.fn();
 const mockWorkspaceFindUnique = vi.fn();
 const mockWorkspaceFindFirst = vi.fn();
 const mockUserFindUnique = vi.fn();
@@ -34,6 +35,7 @@ vi.mock("@/core/prisma", () => ({
         mockWorkspaceMemberFindUnique(...args),
       deleteMany: (...args: unknown[]) =>
         mockWorkspaceMemberDeleteMany(...args),
+      update: (...args: unknown[]) => mockWorkspaceMemberUpdate(...args),
     },
     user: {
       findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
@@ -111,6 +113,7 @@ function makeAdminCtx(workspaceId = WORKSPACE_ID) {
         findMany: mockWorkspaceMemberFindMany,
         findUnique: mockWorkspaceMemberFindUnique,
         deleteMany: mockWorkspaceMemberDeleteMany,
+        update: mockWorkspaceMemberUpdate,
       },
       workspace: {
         findUnique: mockWorkspaceFindUnique,

--- a/apps/api/src/trpc/routers/__tests__/user-workspace-auth.test.ts
+++ b/apps/api/src/trpc/routers/__tests__/user-workspace-auth.test.ts
@@ -412,6 +412,65 @@ describe("userRouter workspace-scoped authorization", () => {
     });
   });
 
+  describe("updateUser privilege escalation", () => {
+    it("admin can change user role to MEMBER", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("ADMIN");
+      mockUserFindUnique.mockResolvedValue({
+        id: "target-user",
+        email: "target@test.com",
+      });
+      mockHasWorkspaceAccess.mockResolvedValue(true);
+
+      const updatedUser = {
+        id: "target-user",
+        email: "target@test.com",
+        firstName: "Target",
+        lastName: "User",
+        role: "MEMBER",
+        workspaceId: WORKSPACE_ID,
+        isActive: true,
+        emailVerified: true,
+        lastLogin: null,
+        createdAt: new Date("2025-01-01"),
+        updatedAt: new Date("2025-01-01"),
+      };
+
+      mockTransaction.mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          return fn({
+            user: { update: vi.fn().mockResolvedValue(updatedUser) },
+            workspaceMember: {
+              findUnique: vi.fn().mockResolvedValue({ role: "MEMBER" }),
+              update: vi.fn().mockResolvedValue({ role: "MEMBER" }),
+            },
+          });
+        }
+      );
+
+      const caller = userRouter.createCaller(makeAdminCtx() as never);
+      const result = await caller.updateUser({
+        id: "target-user",
+        workspaceId: WORKSPACE_ID,
+        role: "MEMBER",
+      });
+
+      expect(result.user).toBeDefined();
+    });
+
+    it("rejects OWNER role in updateUser (not in INVITABLE_ROLES)", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("ADMIN");
+
+      const caller = userRouter.createCaller(makeAdminCtx() as never);
+      await expect(
+        caller.updateUser({
+          id: "target-user",
+          workspaceId: WORKSPACE_ID,
+          role: "OWNER" as never,
+        })
+      ).rejects.toThrow();
+    });
+  });
+
   describe("getWorkspaceUsers (unchanged - uses workspaceProcedure)", () => {
     it("allows any workspace member to list users", async () => {
       mockWorkspaceMemberFindMany.mockResolvedValue([]);

--- a/apps/api/src/trpc/routers/__tests__/user-workspace-auth.test.ts
+++ b/apps/api/src/trpc/routers/__tests__/user-workspace-auth.test.ts
@@ -236,7 +236,8 @@ describe("userRouter workspace-scoped authorization", () => {
         email: "target@test.com",
       });
       mockHasWorkspaceAccess.mockResolvedValue(true);
-      mockUserUpdate.mockResolvedValue({
+
+      const updatedUser = {
         id: "target-user",
         email: "target@test.com",
         firstName: "Updated",
@@ -248,7 +249,19 @@ describe("userRouter workspace-scoped authorization", () => {
         lastLogin: null,
         createdAt: new Date("2025-01-01"),
         updatedAt: new Date("2025-01-01"),
-      });
+      };
+
+      mockTransaction.mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          return fn({
+            user: { update: vi.fn().mockResolvedValue(updatedUser) },
+            workspaceMember: {
+              findUnique: vi.fn().mockResolvedValue({ role: "MEMBER" }),
+              update: vi.fn(),
+            },
+          });
+        }
+      );
 
       const caller = userRouter.createCaller(makeAdminCtx() as never);
       const result = await caller.updateUser({
@@ -258,6 +271,7 @@ describe("userRouter workspace-scoped authorization", () => {
       });
 
       expect(result.user).toBeDefined();
+      expect(result.user.role).toBe("MEMBER");
     });
 
     it("rejects workspace member from updating a user", async () => {
@@ -332,8 +346,16 @@ describe("userRouter workspace-scoped authorization", () => {
       mockTransaction.mockImplementation(
         async (fn: (tx: unknown) => Promise<unknown>) => {
           return fn({
-            workspaceMember: { deleteMany: vi.fn() },
-            user: { update: vi.fn() },
+            workspaceMember: {
+              deleteMany: vi.fn(),
+              findFirst: vi.fn().mockResolvedValue(null),
+            },
+            user: {
+              findUnique: vi
+                .fn()
+                .mockResolvedValue({ workspaceId: WORKSPACE_ID }),
+              update: vi.fn(),
+            },
           });
         }
       );

--- a/apps/api/src/trpc/routers/user.ts
+++ b/apps/api/src/trpc/routers/user.ts
@@ -2,6 +2,7 @@ import { SUPPORTED_LOCALES } from "@qarote/i18n";
 import { TRPCError } from "@trpc/server";
 
 import { getUserWorkspaceRole } from "@/core/workspace-access";
+import { canAssignRole } from "@/core/workspace-roles";
 
 import { EmailVerificationService } from "@/services/email/email-verification.service";
 
@@ -27,7 +28,7 @@ import {
   workspaceProcedure,
 } from "@/trpc/trpc";
 
-import { UserRole } from "@/generated/prisma/client";
+import { UserRole, WorkspaceRole } from "@/generated/prisma/client";
 import { te } from "@/i18n";
 
 /**
@@ -460,6 +461,14 @@ export const userRouter = router({
           });
         }
 
+        // Privilege escalation guard: cannot assign a role above your own
+        if (newRole && !canAssignRole(ctx.workspaceRole, newRole)) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: te(ctx.locale, "auth.cannotAssignHigherRole"),
+          });
+        }
+
         // Atomically update user profile and (optionally) workspace role
         const { user, workspaceMember } = await ctx.prisma.$transaction(
           async (tx) => {
@@ -624,7 +633,10 @@ export const userRouter = router({
         }
 
         // Prevent removing other admins (only workspace owner can remove admins)
-        if (workspaceRole === UserRole.ADMIN) {
+        if (
+          workspaceRole === WorkspaceRole.ADMIN ||
+          workspaceRole === WorkspaceRole.OWNER
+        ) {
           // Check if current user is the workspace owner
           const workspace = await ctx.prisma.workspace.findFirst({
             where: {

--- a/apps/api/src/trpc/routers/user.ts
+++ b/apps/api/src/trpc/routers/user.ts
@@ -426,13 +426,14 @@ export const userRouter = router({
   updateUser: workspaceAdminProcedure
     .input(UpdateUserWithIdSchema)
     .mutation(async ({ input, ctx }) => {
-      const {
-        id,
-        workspaceId,
-        role: newRole,
-        isActive: _isActive,
-        ...safeData
-      } = input;
+      const { id, workspaceId, role: newRole, isActive, ...safeData } = input;
+
+      if (isActive !== undefined) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: te(ctx.locale, "user.cannotUpdateIsActive"),
+        });
+      }
 
       try {
         // Check if user exists
@@ -459,41 +460,51 @@ export const userRouter = router({
           });
         }
 
-        // Update safe profile fields on the User record (never role/isActive)
-        const user = await ctx.prisma.user.update({
-          where: { id },
-          data: safeData,
-          select: {
-            id: true,
-            email: true,
-            firstName: true,
-            lastName: true,
-            role: true,
-            workspaceId: true,
-            isActive: true,
-            emailVerified: true,
-            lastLogin: true,
-            createdAt: true,
-            updatedAt: true,
-          },
-        });
-
-        // Apply role change to the workspace-scoped membership record
-        if (newRole) {
-          await ctx.prisma.workspaceMember.update({
-            where: {
-              userId_workspaceId: {
-                userId: id,
-                workspaceId,
+        // Atomically update user profile and (optionally) workspace role
+        const { user, workspaceMember } = await ctx.prisma.$transaction(
+          async (tx) => {
+            const updatedUser = await tx.user.update({
+              where: { id },
+              data: safeData,
+              select: {
+                id: true,
+                email: true,
+                firstName: true,
+                lastName: true,
+                role: true,
+                workspaceId: true,
+                isActive: true,
+                emailVerified: true,
+                lastLogin: true,
+                createdAt: true,
+                updatedAt: true,
               },
-            },
-            data: { role: newRole },
-          });
-        }
+            });
 
-        // Serialize date fields to ISO strings
+            let member = await tx.workspaceMember.findUnique({
+              where: { userId_workspaceId: { userId: id, workspaceId } },
+              select: { role: true },
+            });
+
+            if (newRole && member) {
+              member = await tx.workspaceMember.update({
+                where: { userId_workspaceId: { userId: id, workspaceId } },
+                data: { role: newRole },
+                select: { role: true },
+              });
+            }
+
+            return { user: updatedUser, workspaceMember: member };
+          }
+        );
+
+        // Return API response with workspace-scoped role instead of global role
+        const apiResponse = UserMapper.toApiResponse(user);
         return {
-          user: UserMapper.toApiResponse(user),
+          user: {
+            ...apiResponse,
+            role: workspaceMember?.role ?? apiResponse.role,
+          },
         };
       } catch (error) {
         if (error instanceof TRPCError) {
@@ -640,13 +651,26 @@ export const userRouter = router({
             },
           });
 
-          // Clear user's workspace association (leave global role untouched)
-          await tx.user.update({
+          // Only update active workspaceId if it matches the removed membership
+          const removedUser = await tx.user.findUnique({
             where: { id: userIdToRemove },
-            data: {
-              workspaceId: null,
-            },
+            select: { workspaceId: true },
           });
+
+          if (removedUser?.workspaceId === workspaceId) {
+            // Try to reassign to another remaining workspace
+            const nextMembership = await tx.workspaceMember.findFirst({
+              where: { userId: userIdToRemove },
+              select: { workspaceId: true },
+            });
+
+            await tx.user.update({
+              where: { id: userIdToRemove },
+              data: {
+                workspaceId: nextMembership?.workspaceId ?? null,
+              },
+            });
+          }
         });
 
         ctx.logger.info(

--- a/apps/api/src/trpc/routers/user.ts
+++ b/apps/api/src/trpc/routers/user.ts
@@ -21,9 +21,9 @@ import { UpdateWorkspaceSchema } from "@/schemas/workspace";
 import { UserMapper } from "@/mappers/auth";
 
 import {
-  authorize,
   rateLimitedProcedure,
   router,
+  workspaceAdminProcedure,
   workspaceProcedure,
 } from "@/trpc/trpc";
 
@@ -311,9 +311,9 @@ export const userRouter = router({
     }),
 
   /**
-   * Get pending invitations for a workspace (ADMIN ONLY)
+   * Get pending invitations for a workspace (WORKSPACE ADMIN ONLY)
    */
-  getInvitations: authorize([UserRole.ADMIN])
+  getInvitations: workspaceAdminProcedure
     .input(GetInvitationsSchema)
     .query(async ({ input, ctx }) => {
       const { workspaceId } = input;
@@ -421,9 +421,9 @@ export const userRouter = router({
     }),
 
   /**
-   * Update a user (ADMIN ONLY)
+   * Update a user (WORKSPACE ADMIN ONLY)
    */
-  updateUser: authorize([UserRole.ADMIN])
+  updateUser: workspaceAdminProcedure
     .input(UpdateUserWithIdSchema)
     .mutation(async ({ input, ctx }) => {
       const { id, workspaceId, ...data } = input;
@@ -488,9 +488,9 @@ export const userRouter = router({
     }),
 
   /**
-   * Update workspace information (ADMIN ONLY)
+   * Update workspace information (WORKSPACE ADMIN ONLY)
    */
-  updateWorkspace: authorize([UserRole.ADMIN])
+  updateWorkspace: workspaceAdminProcedure
     .input(UpdateWorkspaceSchema)
     .mutation(async ({ input, ctx }) => {
       const data = input;
@@ -543,9 +543,9 @@ export const userRouter = router({
     }),
 
   /**
-   * Remove user from workspace (ADMIN ONLY)
+   * Remove user from workspace (WORKSPACE ADMIN ONLY)
    */
-  removeFromWorkspace: authorize([UserRole.ADMIN])
+  removeFromWorkspace: workspaceAdminProcedure
     .input(RemoveUserFromWorkspaceSchema)
     .mutation(async ({ input, ctx }) => {
       const { userId: userIdToRemove, workspaceId } = input;

--- a/apps/api/src/trpc/routers/user.ts
+++ b/apps/api/src/trpc/routers/user.ts
@@ -426,7 +426,13 @@ export const userRouter = router({
   updateUser: workspaceAdminProcedure
     .input(UpdateUserWithIdSchema)
     .mutation(async ({ input, ctx }) => {
-      const { id, workspaceId, ...data } = input;
+      const {
+        id,
+        workspaceId,
+        role: newRole,
+        isActive: _isActive,
+        ...safeData
+      } = input;
 
       try {
         // Check if user exists
@@ -453,9 +459,10 @@ export const userRouter = router({
           });
         }
 
+        // Update safe profile fields on the User record (never role/isActive)
         const user = await ctx.prisma.user.update({
           where: { id },
-          data,
+          data: safeData,
           select: {
             id: true,
             email: true,
@@ -470,6 +477,19 @@ export const userRouter = router({
             updatedAt: true,
           },
         });
+
+        // Apply role change to the workspace-scoped membership record
+        if (newRole) {
+          await ctx.prisma.workspaceMember.update({
+            where: {
+              userId_workspaceId: {
+                userId: id,
+                workspaceId,
+              },
+            },
+            data: { role: newRole },
+          });
+        }
 
         // Serialize date fields to ISO strings
         return {
@@ -494,9 +514,8 @@ export const userRouter = router({
     .input(UpdateWorkspaceSchema)
     .mutation(async ({ input, ctx }) => {
       const data = input;
-      const user = ctx.user;
 
-      if (!user.workspaceId) {
+      if (!ctx.workspaceId) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: te(ctx.locale, "workspace.noWorkspaceAssigned"),
@@ -505,7 +524,7 @@ export const userRouter = router({
 
       try {
         const updatedWorkspace = await ctx.prisma.workspace.update({
-          where: { id: user.workspaceId },
+          where: { id: ctx.workspaceId },
           data,
           select: {
             id: true,
@@ -533,7 +552,7 @@ export const userRouter = router({
       } catch (error) {
         ctx.logger.error(
           { error },
-          `Error updating workspace ${user.workspaceId}`
+          `Error updating workspace ${ctx.workspaceId}`
         );
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
@@ -621,12 +640,11 @@ export const userRouter = router({
             },
           });
 
-          // Update user's workspaceId and reset role
+          // Clear user's workspace association (leave global role untouched)
           await tx.user.update({
             where: { id: userIdToRemove },
             data: {
               workspaceId: null,
-              role: UserRole.MEMBER, // Reset role to USER when removed from workspace
             },
           });
         });

--- a/apps/api/src/trpc/routers/workspace/__tests__/invitation-workspace-auth.test.ts
+++ b/apps/api/src/trpc/routers/workspace/__tests__/invitation-workspace-auth.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+// Mock workspace packages that aren't resolved in worktrees
+vi.mock("@qarote/i18n", () => ({
+  SUPPORTED_LOCALES: ["en", "fr", "es", "zh"],
+}));
+vi.mock("@qarote/i18n/server", () => ({
+  createServerI18nInstance: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockWorkspaceFindUnique = vi.fn();
+const mockWorkspaceMemberCount = vi.fn();
+const mockWorkspaceMemberFindFirst = vi.fn();
+const mockWorkspaceMemberFindUnique = vi.fn();
+const mockSubscriptionFindUnique = vi.fn();
+const mockUserFindUnique = vi.fn();
+const mockInvitationFindMany = vi.fn();
+const mockInvitationCreate = vi.fn();
+const mockInvitationFindFirst = vi.fn();
+const mockInvitationDelete = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    workspace: {
+      findUnique: (...args: unknown[]) => mockWorkspaceFindUnique(...args),
+    },
+    workspaceMember: {
+      count: (...args: unknown[]) => mockWorkspaceMemberCount(...args),
+      findFirst: (...args: unknown[]) => mockWorkspaceMemberFindFirst(...args),
+      findUnique: (...args: unknown[]) =>
+        mockWorkspaceMemberFindUnique(...args),
+    },
+    subscription: {
+      findUnique: (...args: unknown[]) => mockSubscriptionFindUnique(...args),
+    },
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+    },
+    invitation: {
+      findMany: (...args: unknown[]) => mockInvitationFindMany(...args),
+      create: (...args: unknown[]) => mockInvitationCreate(...args),
+      findFirst: (...args: unknown[]) => mockInvitationFindFirst(...args),
+      delete: (...args: unknown[]) => mockInvitationDelete(...args),
+    },
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock rate limiter to be a passthrough
+vi.mock("../../../middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+// Mock plan service
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  validateUserInvitation: vi.fn(), // no-op by default
+}));
+
+// Mock workspace middleware
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+// Mock workspace-access (getUserWorkspaceRole)
+const mockGetUserWorkspaceRole = vi.fn();
+vi.mock("@/core/workspace-access", () => ({
+  getUserWorkspaceRole: (...args: unknown[]) =>
+    mockGetUserWorkspaceRole(...args),
+}));
+
+// Mock utils
+vi.mock("@/core/utils", () => ({
+  formatInvitedBy: (u: Record<string, unknown>) =>
+    `${u.firstName} ${u.lastName}`,
+  getUserDisplayName: (u: Record<string, unknown>) =>
+    `${u.firstName} ${u.lastName}`,
+}));
+
+// Mock email and encryption services
+vi.mock("@/services/email/core-email.service", () => ({
+  CoreEmailService: {
+    loadEffectiveConfig: vi.fn().mockResolvedValue({ enabled: false }),
+  },
+}));
+vi.mock("@/services/email/email.service", () => ({
+  EmailService: { sendInvitationEmail: vi.fn() },
+}));
+vi.mock("@/services/encryption.service", () => ({
+  EncryptionService: {
+    generateEncryptionKey: () => "mock-token-123",
+  },
+}));
+vi.mock("@/config", () => ({
+  emailConfig: { frontendUrl: "http://localhost:8080" },
+}));
+
+// Import after mocks
+const { invitationRouter } = await import("../invitation");
+
+// --- Helpers ---
+
+const WORKSPACE_ID = "ws-1";
+
+function makeAdminCtx() {
+  return {
+    prisma: {
+      workspace: { findUnique: mockWorkspaceFindUnique },
+      workspaceMember: {
+        count: mockWorkspaceMemberCount,
+        findFirst: mockWorkspaceMemberFindFirst,
+        findUnique: mockWorkspaceMemberFindUnique,
+      },
+      subscription: { findUnique: mockSubscriptionFindUnique },
+      user: { findUnique: mockUserFindUnique },
+      invitation: {
+        findMany: mockInvitationFindMany,
+        create: mockInvitationCreate,
+        findFirst: mockInvitationFindFirst,
+        delete: mockInvitationDelete,
+      },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "admin-1",
+      role: "ADMIN",
+      isActive: true,
+      email: "admin@test.com",
+      firstName: "Admin",
+      lastName: "User",
+      workspaceId: WORKSPACE_ID,
+    },
+    workspaceId: WORKSPACE_ID,
+    req: {},
+  };
+}
+
+function makeMemberCtx() {
+  return {
+    ...makeAdminCtx(),
+    user: {
+      id: "member-1",
+      role: "MEMBER",
+      isActive: true,
+      email: "member@test.com",
+      firstName: "Member",
+      lastName: "User",
+      workspaceId: WORKSPACE_ID,
+    },
+  };
+}
+
+function makeReadonlyCtx() {
+  return {
+    ...makeAdminCtx(),
+    user: {
+      id: "readonly-1",
+      role: "READONLY",
+      isActive: true,
+      email: "readonly@test.com",
+      firstName: "Readonly",
+      lastName: "User",
+      workspaceId: WORKSPACE_ID,
+    },
+  };
+}
+
+// --- Tests ---
+
+describe("invitationRouter workspace-scoped authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getInvitations", () => {
+    it("allows workspace admin to list invitations", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("ADMIN");
+      mockInvitationFindMany.mockResolvedValue([]);
+
+      const caller = invitationRouter.createCaller(makeAdminCtx() as never);
+      const result = await caller.getInvitations();
+
+      expect(result.invitations).toEqual([]);
+    });
+
+    it("rejects workspace member from listing invitations", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+
+      const caller = invitationRouter.createCaller(makeMemberCtx() as never);
+      await expect(caller.getInvitations()).rejects.toThrow(
+        /workspaceAdminRequired/
+      );
+    });
+
+    it("rejects readonly user from listing invitations", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("READONLY");
+
+      const caller = invitationRouter.createCaller(makeReadonlyCtx() as never);
+      await expect(caller.getInvitations()).rejects.toThrow(
+        /workspaceAdminRequired/
+      );
+    });
+  });
+
+  describe("sendInvitation", () => {
+    it("allows workspace admin to send invitation", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("ADMIN");
+      mockWorkspaceFindUnique.mockResolvedValue({
+        id: WORKSPACE_ID,
+        name: "Test WS",
+        ownerId: "admin-1",
+      });
+      mockWorkspaceMemberCount.mockResolvedValue(1);
+      mockSubscriptionFindUnique.mockResolvedValue({ plan: "DEVELOPER" });
+      mockUserFindUnique.mockResolvedValue(null); // no existing user
+      mockInvitationCreate.mockResolvedValue({
+        id: "inv-1",
+        email: "new@test.com",
+        role: "MEMBER",
+        token: "mock-token-123",
+        expiresAt: new Date("2025-02-01"),
+        createdAt: new Date("2025-01-01"),
+        invitedBy: {
+          id: "admin-1",
+          email: "admin@test.com",
+          firstName: "Admin",
+          lastName: "User",
+        },
+      });
+
+      const caller = invitationRouter.createCaller(makeAdminCtx() as never);
+      const result = await caller.sendInvitation({
+        email: "new@test.com",
+        role: "MEMBER",
+      });
+
+      expect(result.message).toBe("Invitation sent successfully");
+      expect(result.inviteUrl).toContain("/invite/");
+    });
+
+    it("rejects workspace member from sending invitation", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+
+      const caller = invitationRouter.createCaller(makeMemberCtx() as never);
+      await expect(
+        caller.sendInvitation({ email: "new@test.com", role: "MEMBER" })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+
+    it("rejects readonly user from sending invitation", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("READONLY");
+
+      const caller = invitationRouter.createCaller(makeReadonlyCtx() as never);
+      await expect(
+        caller.sendInvitation({ email: "new@test.com", role: "MEMBER" })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+  });
+
+  describe("revokeInvitation", () => {
+    it("allows workspace admin to revoke invitation", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("ADMIN");
+      mockInvitationFindFirst.mockResolvedValue({
+        id: "inv-1",
+        workspaceId: WORKSPACE_ID,
+        status: "PENDING",
+      });
+      mockInvitationDelete.mockResolvedValue({});
+
+      const caller = invitationRouter.createCaller(makeAdminCtx() as never);
+      const result = await caller.revokeInvitation({
+        invitationId: "inv-1",
+      });
+
+      expect(result.message).toBe("Invitation revoked successfully");
+    });
+
+    it("rejects workspace member from revoking invitation", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+
+      const caller = invitationRouter.createCaller(makeMemberCtx() as never);
+      await expect(
+        caller.revokeInvitation({ invitationId: "inv-1" })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+
+    it("rejects readonly user from revoking invitation", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("READONLY");
+
+      const caller = invitationRouter.createCaller(makeReadonlyCtx() as never);
+      await expect(
+        caller.revokeInvitation({ invitationId: "inv-1" })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+  });
+
+  describe("cross-workspace isolation", () => {
+    it("rejects user who is globally ADMIN but not admin in target workspace", async () => {
+      // Global ADMIN, but workspace role is MEMBER
+      mockGetUserWorkspaceRole.mockResolvedValue("MEMBER");
+
+      const ctx = makeMemberCtx();
+      ctx.user.role = "ADMIN"; // Global admin
+
+      const caller = invitationRouter.createCaller(ctx as never);
+      await expect(
+        caller.sendInvitation({ email: "new@test.com", role: "MEMBER" })
+      ).rejects.toThrow(/workspaceAdminRequired/);
+    });
+
+    it("rejects user with no workspace from interacting with invitations", async () => {
+      const ctx = makeAdminCtx();
+      ctx.user.workspaceId = null as unknown as string;
+
+      const caller = invitationRouter.createCaller(ctx as never);
+      await expect(caller.getInvitations()).rejects.toThrow(
+        /userNotAuthenticatedOrNotInWorkspace/
+      );
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/workspace/__tests__/invitation-workspace-auth.test.ts
+++ b/apps/api/src/trpc/routers/workspace/__tests__/invitation-workspace-auth.test.ts
@@ -305,6 +305,51 @@ describe("invitationRouter workspace-scoped authorization", () => {
     });
   });
 
+  describe("privilege escalation guard", () => {
+    it("admin can invite another admin (at own level)", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("ADMIN");
+      mockWorkspaceFindUnique.mockResolvedValue({
+        id: WORKSPACE_ID,
+        name: "Test WS",
+        ownerId: "admin-1",
+      });
+      mockWorkspaceMemberCount.mockResolvedValue(1);
+      mockSubscriptionFindUnique.mockResolvedValue({ plan: "DEVELOPER" });
+      mockUserFindUnique.mockResolvedValue(null);
+      mockInvitationCreate.mockResolvedValue({
+        id: "inv-2",
+        email: "peer@test.com",
+        role: "ADMIN",
+        token: "mock-token-123",
+        expiresAt: new Date("2025-02-01"),
+        createdAt: new Date("2025-01-01"),
+        invitedBy: {
+          id: "admin-1",
+          email: "admin@test.com",
+          firstName: "Admin",
+          lastName: "User",
+        },
+      });
+
+      const caller = invitationRouter.createCaller(makeAdminCtx() as never);
+      const result = await caller.sendInvitation({
+        email: "peer@test.com",
+        role: "ADMIN",
+      });
+
+      expect(result.message).toBe("Invitation sent successfully");
+    });
+
+    it("rejects OWNER role in invitation (not in INVITABLE_ROLES)", async () => {
+      mockGetUserWorkspaceRole.mockResolvedValue("OWNER");
+
+      const caller = invitationRouter.createCaller(makeAdminCtx() as never);
+      await expect(
+        caller.sendInvitation({ email: "new@test.com", role: "OWNER" as never })
+      ).rejects.toThrow();
+    });
+  });
+
   describe("cross-workspace isolation", () => {
     it("rejects user who is globally ADMIN but not admin in target workspace", async () => {
       // Global ADMIN, but workspace role is MEMBER

--- a/apps/api/src/trpc/routers/workspace/invitation.ts
+++ b/apps/api/src/trpc/routers/workspace/invitation.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 
 import { formatInvitedBy, getUserDisplayName } from "@/core/utils";
+import { getUserWorkspaceRole } from "@/core/workspace-access";
 
 import { CoreEmailService } from "@/services/email/core-email.service";
 import { EmailService } from "@/services/email/email.service";
@@ -18,7 +19,11 @@ import {
   router,
 } from "@/trpc/trpc";
 
-import { InvitationStatus, UserPlan } from "@/generated/prisma/client";
+import {
+  InvitationStatus,
+  UserPlan,
+  UserRole,
+} from "@/generated/prisma/client";
 import { te } from "@/i18n";
 
 /**
@@ -27,7 +32,7 @@ import { te } from "@/i18n";
  */
 export const invitationRouter = router({
   /**
-   * Get all pending invitations for workspace (PROTECTED)
+   * Get all pending invitations for workspace (WORKSPACE ADMIN ONLY)
    */
   getInvitations: rateLimitedProcedure.query(async ({ ctx }) => {
     const user = ctx.user;
@@ -40,6 +45,15 @@ export const invitationRouter = router({
             ctx.locale,
             "workspace.userNotAuthenticatedOrNotInWorkspace"
           ),
+        });
+      }
+
+      // Verify the caller is a workspace admin
+      const callerRole = await getUserWorkspaceRole(user.id, user.workspaceId);
+      if (callerRole !== UserRole.ADMIN) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: te(ctx.locale, "auth.workspaceAdminRequired"),
         });
       }
 
@@ -92,7 +106,7 @@ export const invitationRouter = router({
   }),
 
   /**
-   * Send invitation (PROTECTED with plan validation)
+   * Send invitation (WORKSPACE ADMIN with plan validation)
    */
   sendInvitation: planValidationProcedure
     .input(inviteUserSchema)
@@ -108,6 +122,18 @@ export const invitationRouter = router({
               ctx.locale,
               "workspace.userNotAuthenticatedOrNotInWorkspace"
             ),
+          });
+        }
+
+        // Verify the caller is a workspace admin
+        const callerRole = await getUserWorkspaceRole(
+          user.id,
+          user.workspaceId
+        );
+        if (callerRole !== UserRole.ADMIN) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: te(ctx.locale, "auth.workspaceAdminRequired"),
           });
         }
 
@@ -268,7 +294,7 @@ export const invitationRouter = router({
     }),
 
   /**
-   * Revoke invitation (PROTECTED)
+   * Revoke invitation (WORKSPACE ADMIN ONLY)
    */
   revokeInvitation: rateLimitedProcedure
     .input(InvitationIdParamSchema)
@@ -284,6 +310,18 @@ export const invitationRouter = router({
               ctx.locale,
               "workspace.userNotAuthenticatedOrNotInWorkspace"
             ),
+          });
+        }
+
+        // Verify the caller is a workspace admin
+        const callerRole = await getUserWorkspaceRole(
+          user.id,
+          user.workspaceId
+        );
+        if (callerRole !== UserRole.ADMIN) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: te(ctx.locale, "auth.workspaceAdminRequired"),
           });
         }
 

--- a/apps/api/src/trpc/routers/workspace/invitation.ts
+++ b/apps/api/src/trpc/routers/workspace/invitation.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 
 import { formatInvitedBy, getUserDisplayName } from "@/core/utils";
 import { getUserWorkspaceRole } from "@/core/workspace-access";
+import { canAssignRole, hasMinimumWorkspaceRole } from "@/core/workspace-roles";
 
 import { CoreEmailService } from "@/services/email/core-email.service";
 import { EmailService } from "@/services/email/email.service";
@@ -22,7 +23,7 @@ import {
 import {
   InvitationStatus,
   UserPlan,
-  UserRole,
+  WorkspaceRole,
 } from "@/generated/prisma/client";
 import { te } from "@/i18n";
 
@@ -50,7 +51,10 @@ export const invitationRouter = router({
 
       // Verify the caller is a workspace admin
       const callerRole = await getUserWorkspaceRole(user.id, user.workspaceId);
-      if (callerRole !== UserRole.ADMIN) {
+      if (
+        !callerRole ||
+        !hasMinimumWorkspaceRole(callerRole, WorkspaceRole.ADMIN)
+      ) {
         throw new TRPCError({
           code: "FORBIDDEN",
           message: te(ctx.locale, "auth.workspaceAdminRequired"),
@@ -130,10 +134,21 @@ export const invitationRouter = router({
           user.id,
           user.workspaceId
         );
-        if (callerRole !== UserRole.ADMIN) {
+        if (
+          !callerRole ||
+          !hasMinimumWorkspaceRole(callerRole, WorkspaceRole.ADMIN)
+        ) {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: te(ctx.locale, "auth.workspaceAdminRequired"),
+          });
+        }
+
+        // Privilege escalation guard: cannot invite above own role
+        if (!canAssignRole(callerRole, role)) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: te(ctx.locale, "auth.cannotAssignHigherRole"),
           });
         }
 
@@ -318,7 +333,10 @@ export const invitationRouter = router({
           user.id,
           user.workspaceId
         );
-        if (callerRole !== UserRole.ADMIN) {
+        if (
+          !callerRole ||
+          !hasMinimumWorkspaceRole(callerRole, WorkspaceRole.ADMIN)
+        ) {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: te(ctx.locale, "auth.workspaceAdminRequired"),

--- a/apps/api/src/trpc/routers/workspace/management.ts
+++ b/apps/api/src/trpc/routers/workspace/management.ts
@@ -26,7 +26,7 @@ import {
   workspaceProcedure,
 } from "@/trpc/trpc";
 
-import { UserPlan, UserRole } from "@/generated/prisma/client";
+import { UserPlan, UserRole, WorkspaceRole } from "@/generated/prisma/client";
 import { te } from "@/i18n";
 
 /**
@@ -73,9 +73,9 @@ export const managementRouter = router({
         allUserWorkspaces.map(async (workspace) => {
           const isOwner = workspace.ownerId === user.id;
           const userRole = isOwner
-            ? UserRole.ADMIN
+            ? WorkspaceRole.OWNER
             : (await getUserWorkspaceRole(user.id, workspace.id)) ||
-              UserRole.MEMBER;
+              WorkspaceRole.MEMBER;
 
           const mappedWorkspace = WorkspaceMapper.toApiResponse(workspace);
           return {
@@ -228,7 +228,7 @@ export const managementRouter = router({
           await ensureWorkspaceMember(
             user.id,
             workspace.id,
-            UserRole.ADMIN,
+            WorkspaceRole.ADMIN,
             tx
           );
 
@@ -259,7 +259,7 @@ export const managementRouter = router({
           workspace: {
             ...WorkspaceMapper.toApiResponse(newWorkspace),
             isOwner: true,
-            userRole: UserRole.ADMIN,
+            userRole: WorkspaceRole.OWNER,
           },
         };
       } catch (error) {
@@ -344,7 +344,7 @@ export const managementRouter = router({
           workspace: {
             ...WorkspaceMapper.toApiResponse(updatedWorkspace),
             isOwner: true,
-            userRole: UserRole.ADMIN,
+            userRole: WorkspaceRole.OWNER,
           },
         };
       } catch (error) {

--- a/apps/api/src/trpc/trpc.ts
+++ b/apps/api/src/trpc/trpc.ts
@@ -1,6 +1,8 @@
 import { TRPCError } from "@trpc/server";
 import { initTRPC } from "@trpc/server";
 
+import { getUserWorkspaceRole } from "@/core/workspace-access";
+
 import {
   PlanErrorCode,
   PlanLimitExceededError,
@@ -197,6 +199,30 @@ export const workspaceProcedure = rateLimitedProcedure.use(async (opts) => {
       workspaceId,
     },
   });
+});
+
+/**
+ * Workspace-scoped admin procedure - requires ADMIN role in the specific workspace.
+ * Unlike `authorize([UserRole.ADMIN])` which checks the global User.role,
+ * this checks WorkspaceMember.role for the target workspace,
+ * preventing cross-workspace privilege escalation.
+ */
+export const workspaceAdminProcedure = workspaceProcedure.use(async (opts) => {
+  const { ctx } = opts;
+
+  const workspaceRole = await getUserWorkspaceRole(
+    ctx.user.id,
+    ctx.workspaceId
+  );
+
+  if (workspaceRole !== UserRole.ADMIN) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: te(ctx.locale, "auth.workspaceAdminRequired"),
+    });
+  }
+
+  return opts.next();
 });
 
 /**

--- a/apps/api/src/trpc/trpc.ts
+++ b/apps/api/src/trpc/trpc.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { initTRPC } from "@trpc/server";
 
 import { getUserWorkspaceRole } from "@/core/workspace-access";
+import { hasMinimumWorkspaceRole } from "@/core/workspace-roles";
 
 import {
   PlanErrorCode,
@@ -18,7 +19,7 @@ import {
   strictRateLimiter,
 } from "./middlewares/rateLimiter";
 
-import { UserRole } from "@/generated/prisma/client";
+import { UserRole, WorkspaceRole } from "@/generated/prisma/client";
 import { te } from "@/i18n";
 
 /**
@@ -215,14 +216,19 @@ export const workspaceAdminProcedure = workspaceProcedure.use(async (opts) => {
     ctx.workspaceId
   );
 
-  if (workspaceRole !== UserRole.ADMIN) {
+  if (
+    !workspaceRole ||
+    !hasMinimumWorkspaceRole(workspaceRole, WorkspaceRole.ADMIN)
+  ) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: te(ctx.locale, "auth.workspaceAdminRequired"),
     });
   }
 
-  return opts.next();
+  return opts.next({
+    ctx: { ...ctx, workspaceRole },
+  });
 });
 
 /**

--- a/apps/e2e/tests/settings/workspace-rbac.spec.ts
+++ b/apps/e2e/tests/settings/workspace-rbac.spec.ts
@@ -1,0 +1,246 @@
+import { test, expect } from "../../fixtures/test-base.js";
+import {
+  uniqueEmail,
+  createUser,
+} from "../../helpers/factories/user.factory.js";
+
+const apiUrl = process.env.API_URL || "http://localhost:3001";
+
+/**
+ * E2E tests for workspace-scoped RBAC enforcement (P0 security).
+ *
+ * Verifies that workspace-admin-only endpoints reject non-admin users
+ * and that the system checks the *workspace role* (WorkspaceMember.role),
+ * not the global User.role.
+ */
+test.describe("Workspace RBAC enforcement @p0", () => {
+  let adminToken: string;
+  let memberToken: string;
+  let readonlyToken: string;
+  let workspaceId: string;
+  let memberUserId: string;
+
+  test.beforeAll(async ({ api, db }) => {
+    const prisma = await db.getClient();
+
+    // Get workspace
+    const admin = await prisma.user.findUnique({
+      where: { email: "admin@e2e-test.local" },
+    });
+    expect(admin).toBeTruthy();
+    const workspace = await prisma.workspace.findFirst({
+      where: { ownerId: admin!.id },
+    });
+    expect(workspace).toBeTruthy();
+    workspaceId = workspace!.id;
+
+    // Login as admin
+    const adminLogin = await api.login(
+      "admin@e2e-test.local",
+      "TestPassword123!"
+    );
+    adminToken = adminLogin.token;
+
+    // Create a MEMBER user for this workspace
+    const memberEmail = uniqueEmail("rbac-member");
+    const { user: memberUser, password: memberPassword } = await createUser(
+      prisma,
+      {
+        email: memberEmail,
+        role: "MEMBER",
+        workspaceId: workspaceId,
+      }
+    );
+    memberUserId = memberUser.id;
+
+    // Add workspace membership
+    await prisma.workspaceMember.create({
+      data: {
+        userId: memberUser.id,
+        workspaceId,
+        role: "MEMBER",
+      },
+    });
+    db.track("WorkspaceMember", memberUser.id);
+    db.track("User", memberUser.id);
+
+    // Login as member
+    const memberLogin = await api.login(memberEmail, memberPassword);
+    memberToken = memberLogin.token;
+
+    // Login as readonly
+    const readonlyLogin = await api.login(
+      "readonly@e2e-test.local",
+      "TestPassword123!"
+    );
+    readonlyToken = readonlyLogin.token;
+  });
+
+  // --- Helper to make raw tRPC calls that don't throw on error ---
+  async function rawMutation(
+    token: string,
+    procedure: string,
+    input: Record<string, unknown>
+  ) {
+    const response = await fetch(`${apiUrl}/trpc/${procedure}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(input),
+    });
+    return {
+      status: response.status,
+      body: await response.json(),
+    };
+  }
+
+  async function rawQuery(
+    token: string,
+    procedure: string,
+    input?: Record<string, unknown>
+  ) {
+    const params = input
+      ? `?input=${encodeURIComponent(JSON.stringify(input))}`
+      : "";
+    const response = await fetch(`${apiUrl}/trpc/${procedure}${params}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return {
+      status: response.status,
+      body: await response.json(),
+    };
+  }
+
+  // --- Tests ---
+
+  test.describe("user.getInvitations", () => {
+    test("admin can fetch invitations", async () => {
+      const res = await rawQuery(adminToken, "user.getInvitations", {
+        workspaceId,
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.result?.data?.invitations).toBeDefined();
+    });
+
+    test("member is rejected from fetching invitations", async () => {
+      const res = await rawQuery(memberToken, "user.getInvitations", {
+        workspaceId,
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBeDefined();
+    });
+
+    test("readonly is rejected from fetching invitations", async () => {
+      const res = await rawQuery(readonlyToken, "user.getInvitations", {
+        workspaceId,
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  test.describe("user.updateWorkspace", () => {
+    test("admin can update workspace", async () => {
+      const res = await rawMutation(adminToken, "user.updateWorkspace", {
+        name: "E2E Test Workspace",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    test("member is rejected from updating workspace", async () => {
+      const res = await rawMutation(memberToken, "user.updateWorkspace", {
+        name: "Hacked Workspace",
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  test.describe("user.removeFromWorkspace", () => {
+    test("member cannot remove other users from workspace", async () => {
+      const res = await rawMutation(memberToken, "user.removeFromWorkspace", {
+        userId: "nonexistent-user",
+        workspaceId,
+      });
+      // Should be 403 (FORBIDDEN) not 404 — auth check must come first
+      expect(res.status).toBe(403);
+    });
+
+    test("readonly cannot remove users from workspace", async () => {
+      const res = await rawMutation(
+        readonlyToken,
+        "user.removeFromWorkspace",
+        {
+          userId: memberUserId,
+          workspaceId,
+        }
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  test.describe("workspace.invitation.sendInvitation", () => {
+    test("admin can send invitation @selfhosted", async ({}) => {
+      test.skip(
+        process.env.DEPLOYMENT_MODE === "cloud",
+        "Selfhosted mode only"
+      );
+
+      const authedApi = new (await import("../../helpers/api-client.js")).ApiClient(
+        apiUrl
+      ).withAuth(adminToken);
+
+      const inviteEmail = uniqueEmail("rbac-invite");
+      const result = await authedApi.mutation(
+        "workspace.invitation.sendInvitation",
+        { email: inviteEmail, role: "MEMBER" }
+      );
+      expect(result.inviteUrl).toBeDefined();
+    });
+
+    test("member is rejected from sending invitation", async () => {
+      const res = await rawMutation(
+        memberToken,
+        "workspace.invitation.sendInvitation",
+        { email: uniqueEmail("rbac-blocked"), role: "MEMBER" }
+      );
+      expect(res.status).toBe(403);
+    });
+
+    test("readonly is rejected from sending invitation", async () => {
+      const res = await rawMutation(
+        readonlyToken,
+        "workspace.invitation.sendInvitation",
+        { email: uniqueEmail("rbac-blocked-ro"), role: "MEMBER" }
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  test.describe("workspace.invitation.revokeInvitation", () => {
+    test("member cannot revoke invitations", async () => {
+      const res = await rawMutation(
+        memberToken,
+        "workspace.invitation.revokeInvitation",
+        { invitationId: "nonexistent" }
+      );
+      // Should be 403 (auth check) not 404
+      expect(res.status).toBe(403);
+    });
+  });
+
+  test.describe("workspace.invitation.getInvitations", () => {
+    test("member cannot list invitations via invitation router", async () => {
+      const res = await rawQuery(
+        memberToken,
+        "workspace.invitation.getInvitations"
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/apps/e2e/tests/settings/workspace-rbac.spec.ts
+++ b/apps/e2e/tests/settings/workspace-rbac.spec.ts
@@ -243,4 +243,15 @@ test.describe("Workspace RBAC enforcement @p0", () => {
       expect(res.status).toBe(403);
     });
   });
+
+  test.describe("privilege escalation guard", () => {
+    test("member cannot send invitation as ADMIN", async () => {
+      const res = await rawMutation(
+        memberToken,
+        "workspace.invitation.sendInvitation",
+        { email: uniqueEmail("rbac-escalate"), role: "ADMIN" }
+      );
+      expect(res.status).toBe(403);
+    });
+  });
 });

--- a/apps/e2e/tests/settings/workspace-rbac.spec.ts
+++ b/apps/e2e/tests/settings/workspace-rbac.spec.ts
@@ -185,7 +185,7 @@ test.describe("Workspace RBAC enforcement @p0", () => {
   });
 
   test.describe("workspace.invitation.sendInvitation", () => {
-    test("admin can send invitation @selfhosted", async ({}) => {
+    test("admin can send invitation @selfhosted", async () => {
       test.skip(
         process.env.DEPLOYMENT_MODE === "cloud",
         "Selfhosted mode only"


### PR DESCRIPTION
## Summary
- **Security fix**: Admin-only endpoints (`getInvitations`, `updateUser`, `updateWorkspace`, `removeFromWorkspace`, invitation CRUD) now check **workspace-scoped role** (`WorkspaceMember.role`) instead of the global `User.role`, preventing cross-workspace privilege escalation.
- Added `workspaceAdminProcedure` to the tRPC middleware chain that verifies workspace admin role via `getUserWorkspaceRole()`.
- Added inline workspace admin checks to the invitation router endpoints (`getInvitations`, `sendInvitation`, `revokeInvitation`).
- Added `auth.workspaceAdminRequired` i18n key in all 4 locales (en, fr, es, zh).

## Test plan
- [x] 13 unit tests for user router workspace auth (`user-workspace-auth.test.ts`)
- [x] 11 unit tests for invitation router workspace auth (`invitation-workspace-auth.test.ts`)
- [x] 12 E2E tests for API-level RBAC enforcement (`workspace-rbac.spec.ts`)
- [x] Cross-workspace isolation: global ADMIN with workspace MEMBER role is correctly rejected
- [x] Verify admin can still perform all admin operations
- [x] Verify MEMBER and READONLY users get 403 on admin-only endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced workspace-admin-only access for invitations, user removals, and workspace updates (scoped per workspace).
  * Workspace role model surfaced consistently in responses (OWNER, ADMIN, MEMBER, READONLY).
  * New localized error messages: workspace admin required, cannot assign higher role, and cannot update isActive.

* **Tests**
  * Added comprehensive unit and end-to-end tests validating workspace-scoped RBAC for user and invitation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->