### PR TITLE
chore: use jwt_secret directly and add google_client_secret to workflows

### DIFF
--- a/.github/workflows/deploy-api-production.yml
+++ b/.github/workflows/deploy-api-production.yml
@@ -145,6 +145,7 @@ jobs:
             SENTRY_DSN=${{ vars.SENTRY_DSN }} \
             SENTRY_ENABLED=${{ vars.SENTRY_ENABLED }} \
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} \
+            GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }} \
             NOTION_API_KEY=${{ secrets.NOTION_API_KEY }} \
             NOTION_DATABASE_ID=${{ vars.NOTION_DATABASE_ID }} \
             NOTION_SYNC_ENABLED=${{ vars.NOTION_SYNC_ENABLED }} \

--- a/.github/workflows/deploy-api-staging.yml
+++ b/.github/workflows/deploy-api-staging.yml
@@ -114,6 +114,7 @@ jobs:
             SENTRY_DSN=${{ vars.SENTRY_DSN }} \
             SENTRY_ENABLED=${{ vars.SENTRY_ENABLED }} \
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} \
+            GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }} \
             NOTION_API_KEY=${{ secrets.NOTION_API_KEY }} \
             NOTION_DATABASE_ID=${{ vars.NOTION_DATABASE_ID }} \
             NOTION_SYNC_ENABLED=${{ vars.NOTION_SYNC_ENABLED }} \

--- a/.github/workflows/deploy-worker-production.yml
+++ b/.github/workflows/deploy-worker-production.yml
@@ -116,6 +116,7 @@ jobs:
             SENTRY_DSN=${{ vars.SENTRY_DSN }} \
             SENTRY_ENABLED=${{ vars.SENTRY_ENABLED }} \
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} \
+            GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }} \
             NOTION_API_KEY=${{ secrets.NOTION_API_KEY }} \
             NOTION_DATABASE_ID=${{ vars.NOTION_DATABASE_ID }} \
             NOTION_SYNC_ENABLED=${{ vars.NOTION_SYNC_ENABLED }} \

--- a/.github/workflows/deploy-worker-staging.yml
+++ b/.github/workflows/deploy-worker-staging.yml
@@ -121,6 +121,7 @@ jobs:
             SENTRY_DSN=${{ vars.SENTRY_DSN }} \
             SENTRY_ENABLED=${{ vars.SENTRY_ENABLED }} \
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} \
+            GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }} \
             NOTION_API_KEY=${{ secrets.NOTION_API_KEY }} \
             NOTION_DATABASE_ID=${{ vars.NOTION_DATABASE_ID }} \
             NOTION_SYNC_ENABLED=${{ vars.NOTION_SYNC_ENABLED }} \

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -58,15 +58,6 @@ function parseConfig(): Config {
         break;
     }
 
-    // Cross-field validation: the effective auth secret must be >= 32 chars
-    const effectiveSecret = config.BETTER_AUTH_SECRET ?? config.JWT_SECRET;
-    if (effectiveSecret.length < 32) {
-      throw new Error(
-        "The effective auth secret (BETTER_AUTH_SECRET ?? JWT_SECRET) must be at least 32 characters. " +
-          "Set BETTER_AUTH_SECRET or use a longer JWT_SECRET."
-      );
-    }
-
     // Cross-field validation: OAuth credentials required when ENABLE_OAUTH is true
     if (config.ENABLE_OAUTH) {
       const missing: string[] = [];
@@ -115,7 +106,6 @@ export const serverConfig = {
 
 export const authConfig = {
   jwtSecret: config.JWT_SECRET,
-  betterAuthSecret: config.BETTER_AUTH_SECRET || config.JWT_SECRET,
   encryptionKey: config.ENCRYPTION_KEY,
 } as const;
 

--- a/apps/api/src/config/schemas/base.ts
+++ b/apps/api/src/config/schemas/base.ts
@@ -14,11 +14,7 @@ export const baseSchema = z.object({
   LOG_LEVEL: z.enum(["error", "warn", "info", "debug"]).default("info"),
 
   // Security - ALWAYS required
-  JWT_SECRET: z.string().min(1, "JWT_SECRET is required"),
-  BETTER_AUTH_SECRET: z
-    .string()
-    .min(32, "BETTER_AUTH_SECRET must be at least 32 characters")
-    .optional(),
+  JWT_SECRET: z.string().min(32, "JWT_SECRET must be at least 32 characters"),
   ENCRYPTION_KEY: z
     .string()
     .min(32, "ENCRYPTION_KEY must be at least 32 characters"),

--- a/apps/api/src/core/better-auth.ts
+++ b/apps/api/src/core/better-auth.ts
@@ -13,7 +13,7 @@ import { authConfig, config, emailConfig, googleConfig } from "@/config";
 import { isCloudMode } from "@/config/deployment";
 
 export const auth = betterAuth({
-  secret: authConfig.betterAuthSecret,
+  secret: authConfig.jwtSecret,
   baseURL: config.API_URL,
   basePath: "/api/auth",
   trustedOrigins: [config.FRONTEND_URL, config.CORS_ORIGIN].filter(Boolean),


### PR DESCRIPTION
## Summary
- Remove `BETTER_AUTH_SECRET` env var — use `JWT_SECRET` directly (with `min(32)` validation)
- Add `GOOGLE_CLIENT_SECRET` to all 4 deploy workflows (api + worker, staging + production)

## Test plan
- [ ] Staging deploy works with existing `JWT_SECRET`
- [ ] Google OAuth works with `GOOGLE_CLIENT_SECRET` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)