### PR TITLE
fix: resolve known issues in alert notification service

### DIFF
--- a/.claude/skills/alerts-notification-workflow.md
+++ b/.claude/skills/alerts-notification-workflow.md
@@ -1,0 +1,215 @@
+# Alerts Notification Workflow
+
+**Part:** apps/api/
+**Last Updated:** 2026-03-11
+**Domain:** Alert monitoring, tracking, and multi-channel notifications
+
+## Overview
+
+The alert notification system monitors all RabbitMQ servers on a scheduled interval, analyzes their health against configurable thresholds, tracks alert state in the database, and sends notifications via Email, Slack, and Webhooks. Notifications are feature-gated (Enterprise/licensed only).
+
+---
+
+## End-to-End Flow
+
+```
+[alert-monitor worker]
+        ↓
+[RabbitMQAlertsCronService]   (cron/rabbitmq-alerts.cron.ts)
+  → runs on configurable interval (alertConfig.checkIntervalMs)
+  → sliding-window concurrency (alertConfig.concurrency)
+  → 30s per-server timeout
+        ↓
+[AlertService.getServerAlerts]   (services/alerts/alert.service.ts)
+  → fetches workspace thresholds (WorkspaceAlertThresholds or defaults)
+  → analyzeNodeHealth() for each node
+  → analyzeQueueHealth() for each queue (optionally filtered by vhost)
+  → sorts alerts: critical > warning > info, then by timestamp
+        ↓
+[AlertNotificationService.trackAndNotifyNewAlerts]   (services/alerts/alert.notification.ts)
+  → checks ALERTING feature flag
+  → loads workspace settings (contactEmail, emailNotificationsEnabled, notificationSeverities, notificationServerIds)
+  → tracks all alerts in SeenAlert table (regardless of feature flag)
+  → determines which alerts should send notifications
+  → [if feature enabled] sends Email / Webhook / Slack
+```
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/workers/alert-monitor.ts` | Worker entry point - runs the cron service as a separate process |
+| `src/cron/rabbitmq-alerts.cron.ts` | `RabbitMQAlertsCronService` - scheduler with sliding-window concurrency |
+| `src/services/alerts/alert.service.ts` | `AlertService` - orchestrates health analysis + notification |
+| `src/services/alerts/alert.notification.ts` | `AlertNotificationService` - tracking, deduplication, multi-channel dispatch |
+| `src/services/alerts/alert.analyzer.ts` | `analyzeNodeHealth`, `analyzeQueueHealth` - threshold evaluation |
+| `src/services/alerts/alert.fingerprint.ts` | `generateAlertFingerprint` - stable deduplication key |
+| `src/services/alerts/alert.thresholds.ts` | `AlertThresholdsService` - workspace-specific or default thresholds |
+| `src/services/alerts/alert.health.ts` | `AlertHealthService` - cluster health summaries |
+| `src/services/alerts/alert.interfaces.ts` | `RabbitMQAlert`, `AlertThresholds`, `AlertSeverity`, `AlertCategory` types |
+| `src/services/email/templates/alert-notification-email.tsx` | React Email template for alert emails |
+| `src/services/slack/slack.service.ts` | `SlackService.sendAlertNotifications` |
+| `src/services/webhook/webhook.service.ts` | `WebhookService.sendAlertNotification` |
+
+---
+
+## Alert Fingerprinting
+
+Fingerprints are stable identifiers used to deduplicate alerts across check cycles.
+
+**Format:**
+- Node/cluster alerts: `${serverId}-${category}-${sourceType}-${sourceName}`
+- Queue alerts (with vhost): `${serverId}-${category}-${sourceType}-${vhost}-${sourceName}`
+
+**Example:** `server-abc123-memory-node-rabbit@node1`
+
+Vhost is included for queue alerts so the same queue name in different vhosts is tracked separately.
+
+---
+
+## Database Models
+
+### `SeenAlert`
+Tracks currently active and recently resolved alerts.
+
+| Field | Purpose |
+|-------|---------|
+| `fingerprint` | Unique stable identifier |
+| `serverId` / `workspaceId` | Scope |
+| `severity` / `category` / `sourceType` / `sourceName` | Alert metadata |
+| `firstSeenAt` | When first detected |
+| `lastSeenAt` | Most recent detection |
+| `resolvedAt` | Set when alert disappears; cleared when it returns |
+| `emailSentAt` | When notification was last sent (drives cooldown) |
+
+### `ResolvedAlert`
+Immutable historical record created when an alert resolves.
+
+| Field | Purpose |
+|-------|---------|
+| `fingerprint` | Matches `SeenAlert.fingerprint` |
+| `title` / `description` / `details` | Reconstructed from category + source |
+| `firstSeenAt` / `resolvedAt` | Alert lifetime |
+| `duration` | Milliseconds from first seen to resolved |
+| `serverName` | Snapshot of server name at resolution time |
+
+---
+
+## Notification Decision Logic
+
+An alert triggers a notification when **all** of the following are true:
+
+1. `ALERTING` feature flag is enabled
+2. `workspace.emailNotificationsEnabled === true` AND `workspace.contactEmail` is set
+3. `serverId` is in `workspace.notificationServerIds` (or the list is empty/null = notify all)
+4. Alert severity is in `workspace.notificationSeverities`
+5. One of:
+   - Alert is **brand new** (no SeenAlert record)
+   - Alert was **previously resolved** (`resolvedAt` was set, now cleared)
+   - **Cooldown period expired**: 7 days since `emailSentAt` (or `firstSeenAt` if never emailed)
+
+**Notifications are NOT sent when:**
+- Alert is ongoing and within the 7-day cooldown
+- Feature flag is disabled (community mode) — alerts still tracked
+- Email notifications are disabled or no contact email configured
+- Server is excluded from `notificationServerIds`
+
+---
+
+## Notification Channels
+
+All channels fire for the same set of `alertsToNotify`:
+
+| Channel | Feature Flag | Config |
+|---------|-------------|--------|
+| Email | `ALERTING` | `workspace.emailNotificationsEnabled` + `contactEmail` |
+| Webhook | `WEBHOOK_INTEGRATION` | `Webhook` record with `enabled: true` |
+| Slack | `SLACK_INTEGRATION` | `SlackConfig` record with `enabled: true` |
+
+After email is sent, `SeenAlert.emailSentAt` is updated. Slack and Webhook delivery is not tracked in the DB.
+
+---
+
+## Auto-Resolution
+
+After processing active alerts, the system resolves any `SeenAlert` records for alerts that are no longer present in the current check:
+
+1. Fetches all unresolved `SeenAlert` records for the server
+2. For each one not in the current active fingerprints set → sets `resolvedAt = now`
+3. Creates a `ResolvedAlert` record with duration
+
+**Vhost scoping:** If a `vhost` is provided to the check, only queue alerts matching that vhost's fingerprint pattern are considered for resolution. Node and cluster alerts are always evaluated. This prevents incorrectly resolving alerts from other vhosts.
+
+---
+
+## Severity & Categories
+
+**Severities:** `critical` | `warning` | `info`
+
+**Categories:**
+
+| Category | Source Types | Thresholds |
+|----------|-------------|------------|
+| `memory` | node | mem_alarm or > 80%/95% |
+| `disk` | node | disk_free_alarm or < 15%/10% free |
+| `connection` | node | fd_used, sockets_used, connections |
+| `node` | node | node running, net partitions, proc_used |
+| `queue` | queue | messages, unacked, consumer_utilisation |
+| `performance` | node/queue | run_queue, message rates |
+
+Default thresholds are in `alert.thresholds.ts`. Workspaces can override via `WorkspaceAlertThresholds`.
+
+---
+
+## Workspace Notification Settings
+
+Stored on the `Workspace` model:
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `emailNotificationsEnabled` | boolean | false | Master email toggle |
+| `contactEmail` | string? | null | Recipient address |
+| `notificationSeverities` | string[] | `["critical", "warning"]` | Which severities trigger notifications |
+| `notificationServerIds` | string[] | [] (= all) | Per-server notification filter |
+
+---
+
+## Known Issues (as of 2026-03-11)
+
+1. **`serverName` variable shadowing** — `alert.notification.ts:475` creates a local `serverName` from `alertsToNotify[0]?.serverName || "Unknown Server"`, shadowing the function parameter. Webhook and Slack calls use the local var, risking `"Unknown Server"` if the alert object lacks this field. Should use the function parameter directly.
+
+2. **Duplicate notification logic** — `shouldNotify` is computed twice (lines 272–299 for `newAlerts`, then lines 443–472 for `alertsToNotify` filter). Both use the same `seenAlerts` snapshot so results match, but creates maintenance risk.
+
+3. **`notificationSeverities` default includes `"info"`** — The in-code default at line 199 is `["critical", "warning", "info"]` but the module documentation states "Only WARNING and CRITICAL alerts are tracked and can trigger emails." The default should exclude `"info"`.
+
+4. **Fragile vhost auto-resolution pattern** — Uses `fingerprint CONTAINS "-queue-${vhost}-"` which could have false positives if vhost names overlap.
+
+5. **N+1 queries in tracking loop** — Each alert in the loop triggers an individual `create` or `updateMany`. Could be batched.
+
+6. **Slack/Webhook not tracked** — Unlike email (`emailSentAt`), Slack and webhook sends are not recorded. The cooldown period only applies to email.
+
+---
+
+## tRPC Routers
+
+Alert-related API endpoints are in `src/trpc/routers/alerts/`:
+- `index.ts` — main alerts router (get alerts, resolved alerts, cluster health, thresholds)
+- `rules.ts` — alert rules management
+- `webhook.ts` — webhook integration CRUD
+- `slack.ts` — Slack integration CRUD
+
+---
+
+## Example Scenarios
+
+| Scenario | Outcome |
+|----------|---------|
+| New alert detected | SeenAlert created → notification sent → `emailSentAt` set |
+| Same alert still active (< 7 days) | `lastSeenAt` updated → no notification (cooldown) |
+| Same alert still active (> 7 days) | `lastSeenAt` updated → notification sent → `emailSentAt` updated |
+| Alert disappears | `resolvedAt` set → `ResolvedAlert` record created |
+| Resolved alert returns | `resolvedAt` cleared → notification sent (treated as new) |
+| Community mode (no license) | Alerts tracked, no notifications sent |
+| Email disabled in workspace | Alerts tracked, no email sent (Slack/Webhook still fire if configured) |

--- a/.claude/skills/alerts-notification-workflow.md
+++ b/.claude/skills/alerts-notification-workflow.md
@@ -102,19 +102,23 @@ Immutable historical record created when an alert resolves.
 An alert triggers a notification when **all** of the following are true:
 
 1. `ALERTING` feature flag is enabled
-2. `workspace.emailNotificationsEnabled === true` AND `workspace.contactEmail` is set
-3. `serverId` is in `workspace.notificationServerIds` (or the list is empty/null = notify all)
-4. Alert severity is in `workspace.notificationSeverities`
-5. One of:
+2. `serverId` is in `workspace.notificationServerIds` (or the list is empty/null = notify all)
+3. Alert severity is in `workspace.notificationSeverities`
+4. One of:
    - Alert is **brand new** (no SeenAlert record)
    - Alert was **previously resolved** (`resolvedAt` was set, now cleared)
    - **Cooldown period expired**: 7 days since `emailSentAt` (or `firstSeenAt` if never emailed)
 
+Each channel then applies its own gate independently:
+- **Email**: requires `workspace.emailNotificationsEnabled === true` AND `workspace.contactEmail` set
+- **Webhook**: requires `WEBHOOK_INTEGRATION` feature flag + an enabled `Webhook` record
+- **Slack**: requires `SLACK_INTEGRATION` feature flag + an enabled `SlackConfig` record
+
 **Notifications are NOT sent when:**
 - Alert is ongoing and within the 7-day cooldown
-- Feature flag is disabled (community mode) — alerts still tracked
-- Email notifications are disabled or no contact email configured
+- Feature flag (`ALERTING`) is disabled (community mode) — alerts still tracked
 - Server is excluded from `notificationServerIds`
+- Per-channel gate fails (e.g. email disabled only suppresses email, not Slack/Webhook)
 
 ---
 
@@ -178,17 +182,9 @@ Stored on the `Workspace` model:
 
 ## Known Issues (as of 2026-03-11)
 
-1. **`serverName` variable shadowing** — `alert.notification.ts:475` creates a local `serverName` from `alertsToNotify[0]?.serverName || "Unknown Server"`, shadowing the function parameter. Webhook and Slack calls use the local var, risking `"Unknown Server"` if the alert object lacks this field. Should use the function parameter directly.
+1. **N+1 queries in tracking loop** — Each alert in the loop triggers an individual `upsert`. Could be batched with a true bulk upsert for very high alert volumes.
 
-2. **Duplicate notification logic** — `shouldNotify` is computed twice (lines 272–299 for `newAlerts`, then lines 443–472 for `alertsToNotify` filter). Both use the same `seenAlerts` snapshot so results match, but creates maintenance risk.
-
-3. **`notificationSeverities` default includes `"info"`** — The in-code default at line 199 is `["critical", "warning", "info"]` but the module documentation states "Only WARNING and CRITICAL alerts are tracked and can trigger emails." The default should exclude `"info"`.
-
-4. **Fragile vhost auto-resolution pattern** — Uses `fingerprint CONTAINS "-queue-${vhost}-"` which could have false positives if vhost names overlap.
-
-5. **N+1 queries in tracking loop** — Each alert in the loop triggers an individual `create` or `updateMany`. Could be batched.
-
-6. **Slack/Webhook not tracked** — Unlike email (`emailSentAt`), Slack and webhook sends are not recorded. The cooldown period only applies to email.
+2. **Slack/Webhook not tracked** — Unlike email (`emailSentAt`), Slack and webhook sends are not recorded. The cooldown period only applies to email.
 
 ---
 

--- a/.claude/skills/alerts-notification-workflow.md
+++ b/.claude/skills/alerts-notification-workflow.md
@@ -124,7 +124,7 @@ Each channel then applies its own gate independently:
 
 ## Notification Channels
 
-All channels fire for the same set of `alertsToNotify`:
+All channels fire for the same pre-computed `alertsToNotify` set, which means Webhook and Slack inherit the same cooldown gate as email (`SeenAlert.emailSentAt` / `firstSeenAt`). The gate runs once, then all three channels dispatch to that filtered list.
 
 | Channel | Feature Flag | Config |
 |---------|-------------|--------|
@@ -132,7 +132,7 @@ All channels fire for the same set of `alertsToNotify`:
 | Webhook | `WEBHOOK_INTEGRATION` | `Webhook` record with `enabled: true` |
 | Slack | `SLACK_INTEGRATION` | `SlackConfig` record with `enabled: true` |
 
-After email is sent, `SeenAlert.emailSentAt` is updated. Slack and Webhook delivery is not tracked in the DB.
+After email is sent, `SeenAlert.emailSentAt` is updated (drives cooldown for all channels on the next cycle). Webhook and Slack dispatch results are not persisted to the DB — only email tracks a send timestamp.
 
 ---
 
@@ -185,6 +185,8 @@ Stored on the `Workspace` model:
 1. **N+1 queries in tracking loop** — Each alert in the loop triggers an individual `upsert`. Could be batched with a true bulk upsert for very high alert volumes.
 
 2. **Slack/Webhook not tracked** — Unlike email (`emailSentAt`), Slack and webhook sends are not recorded. The cooldown period only applies to email.
+
+3. **No atomic notification claim** — The notification decision uses the pre-loaded `seenAlerts` snapshot, so two overlapping cron runs for the same server could both decide to notify before either sets `emailSentAt`. In practice this is rare (sliding-window concurrency serialises per-server runs), but a fully safe implementation would need a conditional DB claim (set `emailSentAt = now WHERE emailSentAt IS NULL OR emailSentAt < cooldown`) before dispatching, treating a 0-row update as "already claimed".
 
 ---
 

--- a/.claude/skills/index.md
+++ b/.claude/skills/index.md
@@ -44,6 +44,7 @@
 - **[Architecture - API](./architecture-api.md)** - Technical architecture and design
 - **[API Contracts](./api-contracts-api.md)** - tRPC endpoints and integration points
 - **[Data Models](./data-models-api.md)** - PostgreSQL schema (21 models)
+- **[Alerts Notification Workflow](./alerts-notification-workflow.md)** - Alert monitoring, tracking, deduplication, and multi-channel notifications
 
 **Key Information:**
 - **Framework:** Hono.js with tRPC for type-safe APIs

--- a/apps/api/src/services/alerts/__tests__/alert.notification.test.ts
+++ b/apps/api/src/services/alerts/__tests__/alert.notification.test.ts
@@ -945,6 +945,171 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Vhost-scoped auto-resolution
+  // -------------------------------------------------------------------------
+
+  describe("vhost-scoped auto-resolution", () => {
+    function makeQueueSeenAlert(
+      vhost: string,
+      overrides: Record<string, unknown> = {}
+    ) {
+      // Fingerprint format: ${serverId}-${category}-queue-${vhost}-${sourceName}
+      return {
+        fingerprint: `${SERVER_ID}-memory-queue-${vhost}-myqueue`,
+        severity: "warning",
+        category: "memory",
+        sourceType: "queue",
+        sourceName: "myqueue",
+        firstSeenAt: new Date(Date.now() - 30 * 60 * 1000),
+        ...overrides,
+      };
+    }
+
+    it("resolves queue alerts that match the specified vhost", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [makeQueueSeenAlert("default")],
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME,
+        "default"
+      );
+
+      expect(mockPrisma.seenAlert.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ resolvedAt: expect.any(Date) }),
+        })
+      );
+    });
+
+    it("does NOT resolve queue alerts that belong to a different vhost", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [makeQueueSeenAlert("other")],
+      });
+
+      // Checking vhost "default" — alert for "other" vhost must be skipped
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME,
+        "default"
+      );
+
+      const resolveUpdate = mockPrisma.seenAlert.updateMany.mock.calls.find(
+        (call: unknown[]) => {
+          const data = (call[0] as { data: { resolvedAt?: unknown } }).data;
+          return data?.resolvedAt instanceof Date;
+        }
+      );
+      expect(resolveUpdate).toBeUndefined();
+    });
+
+    it("always resolves node alerts regardless of the vhost filter", async () => {
+      const nodeAlert = {
+        fingerprint: `${SERVER_ID}-memory-node-rabbit@node1`,
+        severity: "warning",
+        category: "memory",
+        sourceType: "node",
+        sourceName: "rabbit@node1",
+        firstSeenAt: new Date(Date.now() - 30 * 60 * 1000),
+      };
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [nodeAlert],
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME,
+        "default" // vhost filter specified, but node alerts are always evaluated
+      );
+
+      expect(mockPrisma.seenAlert.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ resolvedAt: expect.any(Date) }),
+        })
+      );
+    });
+
+    it("is position-safe: vhost 'foo' does not match a fingerprint whose actual vhost is 'foo-bar' (when category is 'queue')", async () => {
+      // category="queue" means indexOf("-queue-") hits the category segment first,
+      // exposing "queue-foo-bar-myqueue" which does NOT start with "foo-".
+      // This is the scenario where the old DB `contains` approach had a false positive.
+      const fooBarAlert = {
+        fingerprint: `${SERVER_ID}-queue-queue-foo-bar-myqueue`,
+        severity: "warning",
+        category: "queue",
+        sourceType: "queue",
+        sourceName: "myqueue",
+        firstSeenAt: new Date(Date.now() - 30 * 60 * 1000),
+      };
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [fooBarAlert],
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME,
+        "foo" // checking vhost "foo" — should NOT resolve vhost "foo-bar"
+      );
+
+      const resolveUpdate = mockPrisma.seenAlert.updateMany.mock.calls.find(
+        (call: unknown[]) => {
+          const data = (call[0] as { data: { resolvedAt?: unknown } }).data;
+          return data?.resolvedAt instanceof Date;
+        }
+      );
+      expect(resolveUpdate).toBeUndefined();
+    });
+
+    it("resolves both matching-vhost queue alerts and node alerts when vhost is specified", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [
+          makeQueueSeenAlert("default"), // matches → resolve
+          makeQueueSeenAlert("other"), // different vhost → skip
+          {
+            fingerprint: `${SERVER_ID}-memory-node-rabbit@node1`,
+            severity: "warning",
+            category: "memory",
+            sourceType: "node",
+            sourceName: "rabbit@node1",
+            firstSeenAt: new Date(Date.now() - 30 * 60 * 1000),
+          }, // node → always resolve
+        ],
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME,
+        "default"
+      );
+
+      const resolveUpdates = mockPrisma.seenAlert.updateMany.mock.calls.filter(
+        (call: unknown[]) => {
+          const data = (call[0] as { data: { resolvedAt?: unknown } }).data;
+          return data?.resolvedAt instanceof Date;
+        }
+      );
+      // "default" queue alert + node alert = 2 resolved, "other" queue alert skipped
+      expect(resolveUpdates).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Default severity filter (fix 3)
   // -------------------------------------------------------------------------
 

--- a/apps/api/src/services/alerts/__tests__/alert.notification.test.ts
+++ b/apps/api/src/services/alerts/__tests__/alert.notification.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/core/prisma", () => ({
     workspace: { findUnique: vi.fn() },
     seenAlert: {
       findMany: vi.fn(),
-      create: vi.fn(),
+      upsert: vi.fn(),
       updateMany: vi.fn(),
     },
     resolvedAlert: { create: vi.fn() },
@@ -122,7 +122,7 @@ const mockPrisma = prisma as unknown as {
   workspace: { findUnique: MockInstance };
   seenAlert: {
     findMany: MockInstance;
-    create: MockInstance;
+    upsert: MockInstance;
     updateMany: MockInstance;
   };
   resolvedAlert: { create: MockInstance };
@@ -165,7 +165,7 @@ function setupDefaults({
     .mockResolvedValueOnce(seenAlerts)
     .mockResolvedValueOnce(unresolvedSeenAlerts);
 
-  mockPrisma.seenAlert.create.mockResolvedValue({});
+  mockPrisma.seenAlert.upsert.mockResolvedValue({});
   mockPrisma.seenAlert.updateMany.mockResolvedValue({ count: 1 });
   mockPrisma.resolvedAlert.create.mockResolvedValue({});
   mockPrisma.webhook.findFirst.mockResolvedValue(null);
@@ -203,7 +203,7 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
       );
 
       expect(mockPrisma.seenAlert.findMany).not.toHaveBeenCalled();
-      expect(mockPrisma.seenAlert.create).not.toHaveBeenCalled();
+      expect(mockPrisma.seenAlert.upsert).not.toHaveBeenCalled();
     });
   });
 
@@ -222,8 +222,8 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
         SERVER_NAME
       );
 
-      expect(mockPrisma.seenAlert.create).toHaveBeenCalledOnce();
-      const created = mockPrisma.seenAlert.create.mock.calls[0][0].data;
+      expect(mockPrisma.seenAlert.upsert).toHaveBeenCalledOnce();
+      const created = mockPrisma.seenAlert.upsert.mock.calls[0][0].create;
       expect(created.serverId).toBe(SERVER_ID);
       expect(created.workspaceId).toBe(WORKSPACE_ID);
       expect(created.category).toBe(AlertCategory.MEMORY);
@@ -249,10 +249,9 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
         SERVER_NAME
       );
 
-      expect(mockPrisma.seenAlert.create).not.toHaveBeenCalled();
-      expect(mockPrisma.seenAlert.updateMany).toHaveBeenCalledWith(
+      expect(mockPrisma.seenAlert.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ resolvedAt: null }),
+          update: expect.objectContaining({ resolvedAt: null }),
         })
       );
     });
@@ -267,7 +266,7 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
         SERVER_NAME
       );
 
-      expect(mockPrisma.seenAlert.create).toHaveBeenCalledOnce();
+      expect(mockPrisma.seenAlert.upsert).toHaveBeenCalledOnce();
     });
 
     it("tracks info alerts in the database even though they are excluded from notifications by default", async () => {
@@ -281,7 +280,7 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
         SERVER_NAME
       );
 
-      expect(mockPrisma.seenAlert.create).toHaveBeenCalledOnce();
+      expect(mockPrisma.seenAlert.upsert).toHaveBeenCalledOnce();
     });
   });
 
@@ -460,10 +459,10 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
         SERVER_NAME
       );
 
-      // resolvedAt is cleared in DB
-      expect(mockPrisma.seenAlert.updateMany).toHaveBeenCalledWith(
+      // resolvedAt is cleared in DB via upsert
+      expect(mockPrisma.seenAlert.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ resolvedAt: null }),
+          update: expect.objectContaining({ resolvedAt: null }),
         })
       );
       // Email should be sent
@@ -556,6 +555,52 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
       );
 
       expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+
+    it("sends webhook even when email notifications are disabled", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        webhookEnabled: true,
+        workspace: makeWorkspace({ emailNotificationsEnabled: false }),
+      });
+      mockPrisma.webhook.findFirst.mockResolvedValue({
+        id: "wh-1",
+        url: "https://example.com/hook",
+        secret: null,
+        version: "v1",
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(mockSendWebhook).toHaveBeenCalledOnce();
+    });
+
+    it("sends Slack even when email notifications are disabled", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        slackEnabled: true,
+        workspace: makeWorkspace({ emailNotificationsEnabled: false }),
+      });
+      mockPrisma.slackConfig.findFirst.mockResolvedValue({
+        id: "slack-1",
+        webhookUrl: "https://hooks.slack.com/test",
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(mockSendSlack).toHaveBeenCalledOnce();
     });
   });
 

--- a/apps/api/src/services/alerts/__tests__/alert.notification.test.ts
+++ b/apps/api/src/services/alerts/__tests__/alert.notification.test.ts
@@ -1,0 +1,1108 @@
+import { afterEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+import {
+  AlertCategory,
+  AlertSeverity,
+  RabbitMQAlert,
+} from "../alert.interfaces";
+
+// ---------------------------------------------------------------------------
+// Module mocks (hoisted so imports in alert.notification resolve to stubs)
+// ---------------------------------------------------------------------------
+
+vi.mock("@/core/feature-flags", () => ({
+  isFeatureEnabled: vi.fn(),
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    workspace: { findUnique: vi.fn() },
+    seenAlert: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    resolvedAlert: { create: vi.fn() },
+    webhook: { findFirst: vi.fn() },
+    slackConfig: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("@/services/email/notification-email.service", () => ({
+  NotificationEmailService: {
+    sendAlertNotificationEmail: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/slack/slack.service", () => ({
+  SlackService: {
+    sendAlertNotifications: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/webhook/webhook.service", () => ({
+  WebhookService: {
+    sendAlertNotification: vi.fn(),
+  },
+}));
+
+vi.mock("@/config", () => ({
+  emailConfig: { frontendUrl: "http://localhost:3000" },
+}));
+
+vi.mock("@/config/features", () => ({
+  FEATURES: {
+    ALERTING: "alerting",
+    WEBHOOK_INTEGRATION: "webhook_integration",
+    SLACK_INTEGRATION: "slack_integration",
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import SUT + mocked modules after mocks are set up
+// ---------------------------------------------------------------------------
+
+import { isFeatureEnabled } from "@/core/feature-flags";
+import { prisma } from "@/core/prisma";
+
+import { NotificationEmailService } from "@/services/email/notification-email.service";
+import { SlackService } from "@/services/slack/slack.service";
+import { WebhookService } from "@/services/webhook/webhook.service";
+
+// Import the service last so it picks up the mocked dependencies
+import { alertNotificationService } from "../alert.notification";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_ID = "ws-1";
+const SERVER_ID = "server-1";
+const SERVER_NAME = "My RabbitMQ Server";
+
+function makeAlert(overrides: Partial<RabbitMQAlert> = {}): RabbitMQAlert {
+  return {
+    id: "alert-id-1",
+    serverId: SERVER_ID,
+    serverName: SERVER_NAME,
+    severity: AlertSeverity.WARNING,
+    category: AlertCategory.MEMORY,
+    title: "High Memory Usage",
+    description: "Memory usage is high",
+    details: { current: 85, threshold: 80 },
+    timestamp: new Date().toISOString(),
+    resolved: false,
+    source: { type: "node", name: "rabbit@node1" },
+    ...overrides,
+  };
+}
+
+function makeWorkspace(overrides: Record<string, unknown> = {}) {
+  return {
+    contactEmail: "admin@example.com",
+    name: "My Workspace",
+    emailNotificationsEnabled: true,
+    notificationSeverities: null, // null = use default ["critical", "warning"]
+    notificationServerIds: null, // null = notify all servers
+    ...overrides,
+  };
+}
+
+// Shorthand to cast prisma mock fields
+const mockPrisma = prisma as unknown as {
+  workspace: { findUnique: MockInstance };
+  seenAlert: {
+    findMany: MockInstance;
+    create: MockInstance;
+    updateMany: MockInstance;
+  };
+  resolvedAlert: { create: MockInstance };
+  webhook: { findFirst: MockInstance };
+  slackConfig: { findFirst: MockInstance };
+};
+
+const mockIsFeatureEnabled = isFeatureEnabled as unknown as MockInstance;
+const mockSendEmail =
+  NotificationEmailService.sendAlertNotificationEmail as unknown as MockInstance;
+const mockSendSlack =
+  SlackService.sendAlertNotifications as unknown as MockInstance;
+const mockSendWebhook =
+  WebhookService.sendAlertNotification as unknown as MockInstance;
+
+// ---------------------------------------------------------------------------
+// Default mock setup helpers
+// ---------------------------------------------------------------------------
+
+function setupDefaults({
+  alertingEnabled = true,
+  webhookEnabled = false,
+  slackEnabled = false,
+  workspace = makeWorkspace(),
+  seenAlerts = [] as unknown[],
+  unresolvedSeenAlerts = [] as unknown[],
+} = {}) {
+  mockIsFeatureEnabled.mockImplementation((feature: string) => {
+    if (feature === "alerting") return Promise.resolve(alertingEnabled);
+    if (feature === "webhook_integration")
+      return Promise.resolve(webhookEnabled);
+    if (feature === "slack_integration") return Promise.resolve(slackEnabled);
+    return Promise.resolve(false);
+  });
+
+  mockPrisma.workspace.findUnique.mockResolvedValue(workspace);
+
+  // First call: seenAlerts for tracking; second call: unresolvedSeenAlerts for auto-resolution
+  mockPrisma.seenAlert.findMany
+    .mockResolvedValueOnce(seenAlerts)
+    .mockResolvedValueOnce(unresolvedSeenAlerts);
+
+  mockPrisma.seenAlert.create.mockResolvedValue({});
+  mockPrisma.seenAlert.updateMany.mockResolvedValue({ count: 1 });
+  mockPrisma.resolvedAlert.create.mockResolvedValue({});
+  mockPrisma.webhook.findFirst.mockResolvedValue(null);
+  mockPrisma.slackConfig.findFirst.mockResolvedValue(null);
+  mockSendEmail.mockResolvedValue(undefined);
+  mockSendSlack.mockResolvedValue([{ result: { success: true } }]);
+  mockSendWebhook.mockResolvedValue([
+    { webhookId: "wh-1", result: { success: true } },
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Workspace guard
+  // -------------------------------------------------------------------------
+
+  describe("workspace guard", () => {
+    it("returns early without tracking when workspace is not found", async () => {
+      mockIsFeatureEnabled.mockResolvedValue(false);
+      mockPrisma.workspace.findUnique.mockResolvedValue(null);
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockPrisma.seenAlert.findMany).not.toHaveBeenCalled();
+      expect(mockPrisma.seenAlert.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Alert tracking (always, regardless of feature flags)
+  // -------------------------------------------------------------------------
+
+  describe("alert tracking", () => {
+    it("creates a SeenAlert record for a brand-new alert", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockPrisma.seenAlert.create).toHaveBeenCalledOnce();
+      const created = mockPrisma.seenAlert.create.mock.calls[0][0].data;
+      expect(created.serverId).toBe(SERVER_ID);
+      expect(created.workspaceId).toBe(WORKSPACE_ID);
+      expect(created.category).toBe(AlertCategory.MEMORY);
+      expect(created.sourceType).toBe("node");
+      expect(created.sourceName).toBe("rabbit@node1");
+      expect(created.resolvedAt).toBeNull();
+    });
+
+    it("updates lastSeenAt for an existing alert and clears resolvedAt", async () => {
+      const existingSeenAlert = {
+        fingerprint: `${SERVER_ID}-memory-node-rabbit@node1`,
+        emailSentAt: new Date(),
+        resolvedAt: null,
+        lastSeenAt: new Date(),
+        firstSeenAt: new Date(),
+      };
+      setupDefaults({ seenAlerts: [existingSeenAlert] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockPrisma.seenAlert.create).not.toHaveBeenCalled();
+      expect(mockPrisma.seenAlert.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ resolvedAt: null }),
+        })
+      );
+    });
+
+    it("tracks alerts even when alerting feature is disabled (community mode)", async () => {
+      setupDefaults({ alertingEnabled: false, seenAlerts: [] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockPrisma.seenAlert.create).toHaveBeenCalledOnce();
+    });
+
+    it("tracks info alerts in the database even though they are excluded from notifications by default", async () => {
+      setupDefaults({ seenAlerts: [] });
+      const infoAlert = makeAlert({ severity: AlertSeverity.INFO });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [infoAlert],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockPrisma.seenAlert.create).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Notification decision — new alert
+  // -------------------------------------------------------------------------
+
+  describe("new alert notification", () => {
+    it("sends email for a brand-new critical alert", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert({ severity: AlertSeverity.CRITICAL })],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+
+    it("sends email for a brand-new warning alert", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert({ severity: AlertSeverity.WARNING })],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+
+    it("does NOT send email for a brand-new info alert (excluded by default severity filter)", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert({ severity: AlertSeverity.INFO })],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("sends email for info alerts when workspace explicitly enables info severity", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        workspace: makeWorkspace({
+          notificationSeverities: ["critical", "warning", "info"],
+        }),
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert({ severity: AlertSeverity.INFO })],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Notification decision — cooldown
+  // -------------------------------------------------------------------------
+
+  describe("cooldown period", () => {
+    it("does NOT send email for an ongoing alert within the 7-day cooldown", async () => {
+      const recentlySeen = {
+        fingerprint: `${SERVER_ID}-memory-node-rabbit@node1`,
+        emailSentAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), // 1 day ago
+        resolvedAt: null,
+        lastSeenAt: new Date(),
+        firstSeenAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+      };
+      setupDefaults({ seenAlerts: [recentlySeen] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("sends email again after the 7-day cooldown expires", async () => {
+      const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+      const oldSeenAlert = {
+        fingerprint: `${SERVER_ID}-memory-node-rabbit@node1`,
+        emailSentAt: eightDaysAgo,
+        resolvedAt: null,
+        lastSeenAt: new Date(),
+        firstSeenAt: eightDaysAgo,
+      };
+      setupDefaults({ seenAlerts: [oldSeenAlert] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+
+    it("uses firstSeenAt as the cooldown reference when emailSentAt is null", async () => {
+      // Alert was seen 8 days ago but no email was ever sent (e.g. notifications were off)
+      const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+      const seenNoEmail = {
+        fingerprint: `${SERVER_ID}-memory-node-rabbit@node1`,
+        emailSentAt: null,
+        resolvedAt: null,
+        lastSeenAt: new Date(),
+        firstSeenAt: eightDaysAgo,
+      };
+      setupDefaults({ seenAlerts: [seenNoEmail] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+
+    it("does NOT send when firstSeenAt is recent and emailSentAt is null", async () => {
+      const oneDayAgo = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000);
+      const seenNoEmail = {
+        fingerprint: `${SERVER_ID}-memory-node-rabbit@node1`,
+        emailSentAt: null,
+        resolvedAt: null,
+        lastSeenAt: new Date(),
+        firstSeenAt: oneDayAgo,
+      };
+      setupDefaults({ seenAlerts: [seenNoEmail] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Notification decision — resolved and returned
+  // -------------------------------------------------------------------------
+
+  describe("resolved alert returning", () => {
+    it("sends email when a previously resolved alert comes back", async () => {
+      const resolvedAlert = {
+        fingerprint: `${SERVER_ID}-memory-node-rabbit@node1`,
+        emailSentAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), // within cooldown
+        resolvedAt: new Date(Date.now() - 12 * 60 * 60 * 1000), // was resolved 12h ago
+        lastSeenAt: new Date(Date.now() - 12 * 60 * 60 * 1000),
+        firstSeenAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+      };
+      setupDefaults({ seenAlerts: [resolvedAlert] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      // resolvedAt is cleared in DB
+      expect(mockPrisma.seenAlert.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ resolvedAt: null }),
+        })
+      );
+      // Email should be sent
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Workspace notification settings
+  // -------------------------------------------------------------------------
+
+  describe("workspace notification settings", () => {
+    it("does NOT send email when emailNotificationsEnabled is false", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        workspace: makeWorkspace({ emailNotificationsEnabled: false }),
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("does NOT send email when contactEmail is null", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        workspace: makeWorkspace({ contactEmail: null }),
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("does NOT send email when serverId is not in notificationServerIds", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        workspace: makeWorkspace({ notificationServerIds: ["server-other"] }),
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("sends email when notificationServerIds is an empty array (notify all servers)", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        workspace: makeWorkspace({ notificationServerIds: [] }),
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+
+    it("sends email when serverId is in notificationServerIds", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        workspace: makeWorkspace({
+          notificationServerIds: [SERVER_ID, "server-other"],
+        }),
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Feature flag gating
+  // -------------------------------------------------------------------------
+
+  describe("feature flag gating", () => {
+    it("does NOT send any notifications when ALERTING feature is disabled", async () => {
+      setupDefaults({ alertingEnabled: false, seenAlerts: [] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(mockSendWebhook).not.toHaveBeenCalled();
+      expect(mockSendSlack).not.toHaveBeenCalled();
+    });
+
+    it("does NOT send webhook when WEBHOOK_INTEGRATION feature is disabled", async () => {
+      setupDefaults({ seenAlerts: [], webhookEnabled: false });
+      mockPrisma.webhook.findFirst.mockResolvedValue({
+        id: "wh-1",
+        url: "https://example.com/hook",
+        secret: null,
+        version: "v1",
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendWebhook).not.toHaveBeenCalled();
+    });
+
+    it("sends webhook when WEBHOOK_INTEGRATION feature is enabled and webhook exists", async () => {
+      setupDefaults({ seenAlerts: [], webhookEnabled: true });
+      mockPrisma.webhook.findFirst.mockResolvedValue({
+        id: "wh-1",
+        url: "https://example.com/hook",
+        secret: null,
+        version: "v1",
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendWebhook).toHaveBeenCalledOnce();
+    });
+
+    it("does NOT send Slack when SLACK_INTEGRATION feature is disabled", async () => {
+      setupDefaults({ seenAlerts: [], slackEnabled: false });
+      mockPrisma.slackConfig.findFirst.mockResolvedValue({
+        id: "slack-1",
+        webhookUrl: "https://hooks.slack.com/test",
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendSlack).not.toHaveBeenCalled();
+    });
+
+    it("sends Slack when SLACK_INTEGRATION feature is enabled and config exists", async () => {
+      setupDefaults({ seenAlerts: [], slackEnabled: true });
+      mockPrisma.slackConfig.findFirst.mockResolvedValue({
+        id: "slack-1",
+        webhookUrl: "https://hooks.slack.com/test",
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendSlack).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // serverName param correctness (fix for shadowing bug)
+  // -------------------------------------------------------------------------
+
+  describe("serverName parameter usage", () => {
+    it("passes the serverName function parameter to the email service", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        "Explicitly Provided Server Name"
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: "Explicitly Provided Server Name",
+        })
+      );
+    });
+
+    it("passes the serverName function parameter to the webhook service", async () => {
+      setupDefaults({ seenAlerts: [], webhookEnabled: true });
+      mockPrisma.webhook.findFirst.mockResolvedValue({
+        id: "wh-1",
+        url: "https://example.com/hook",
+        secret: null,
+        version: "v1",
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        "Webhook Server Name"
+      );
+
+      expect(mockSendWebhook).toHaveBeenCalledWith(
+        expect.anything(),
+        WORKSPACE_ID,
+        expect.anything(),
+        SERVER_ID,
+        "Webhook Server Name",
+        expect.anything()
+      );
+    });
+
+    it("passes the serverName function parameter to the Slack service", async () => {
+      setupDefaults({ seenAlerts: [], slackEnabled: true });
+      mockPrisma.slackConfig.findFirst.mockResolvedValue({
+        id: "slack-1",
+        webhookUrl: "https://hooks.slack.com/test",
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        "Slack Server Name"
+      );
+
+      expect(mockSendSlack).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        "Slack Server Name",
+        SERVER_ID,
+        expect.anything()
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // emailSentAt marking
+  // -------------------------------------------------------------------------
+
+  describe("emailSentAt tracking", () => {
+    it("marks alerts as emailSentAt after a successful email send", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      const emailSentUpdate = mockPrisma.seenAlert.updateMany.mock.calls.find(
+        (call: unknown[]) =>
+          (call[0] as { data: { emailSentAt?: unknown } }).data?.emailSentAt !==
+          undefined
+      );
+      expect(emailSentUpdate).toBeDefined();
+    });
+
+    it("does NOT update emailSentAt when email send fails", async () => {
+      setupDefaults({ seenAlerts: [] });
+      mockSendEmail.mockRejectedValue(new Error("SMTP error"));
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      const emailSentUpdate = mockPrisma.seenAlert.updateMany.mock.calls.find(
+        (call: unknown[]) =>
+          (call[0] as { data: { emailSentAt?: unknown } }).data?.emailSentAt !==
+          undefined
+      );
+      expect(emailSentUpdate).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Auto-resolution
+  // -------------------------------------------------------------------------
+
+  describe("auto-resolution", () => {
+    it("marks an alert as resolved when it disappears from the active list", async () => {
+      const fingerprint = `${SERVER_ID}-memory-node-rabbit@node1`;
+      const unresolvedSeen = {
+        fingerprint,
+        severity: "warning",
+        category: "memory",
+        sourceType: "node",
+        sourceName: "rabbit@node1",
+        firstSeenAt: new Date(Date.now() - 30 * 60 * 1000),
+      };
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [unresolvedSeen],
+      });
+
+      // Pass an empty alerts array — nothing active, so the seen alert should resolve
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockPrisma.seenAlert.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ resolvedAt: expect.any(Date) }),
+        })
+      );
+    });
+
+    it("creates a ResolvedAlert record with correct serverName when an alert resolves", async () => {
+      const fingerprint = `${SERVER_ID}-memory-node-rabbit@node1`;
+      const unresolvedSeen = {
+        fingerprint,
+        severity: "critical",
+        category: "memory",
+        sourceType: "node",
+        sourceName: "rabbit@node1",
+        firstSeenAt: new Date(Date.now() - 60 * 60 * 1000),
+      };
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [unresolvedSeen],
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [],
+        WORKSPACE_ID,
+        SERVER_ID,
+        "Resolution Server Name"
+      );
+
+      expect(mockPrisma.resolvedAlert.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            serverName: "Resolution Server Name",
+            serverId: SERVER_ID,
+            workspaceId: WORKSPACE_ID,
+            severity: "critical",
+            category: "memory",
+          }),
+        })
+      );
+    });
+
+    it("does NOT resolve an alert that is still active", async () => {
+      const fingerprint = `${SERVER_ID}-memory-node-rabbit@node1`;
+      const unresolvedSeen = {
+        fingerprint,
+        severity: "warning",
+        category: "memory",
+        sourceType: "node",
+        sourceName: "rabbit@node1",
+        firstSeenAt: new Date(Date.now() - 10 * 60 * 1000),
+      };
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [unresolvedSeen],
+      });
+
+      // The alert IS still active in the current list
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert()],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      // resolvedAt should only have been set to null (clearing), not to a date value
+      const resolveUpdate = mockPrisma.seenAlert.updateMany.mock.calls.find(
+        (call: unknown[]) => {
+          const data = (call[0] as { data: { resolvedAt?: unknown } }).data;
+          return data?.resolvedAt instanceof Date;
+        }
+      );
+      expect(resolveUpdate).toBeUndefined();
+    });
+
+    it("calculates a positive duration for the ResolvedAlert record", async () => {
+      const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
+      const fingerprint = `${SERVER_ID}-memory-node-rabbit@node1`;
+      const unresolvedSeen = {
+        fingerprint,
+        severity: "warning",
+        category: "memory",
+        sourceType: "node",
+        sourceName: "rabbit@node1",
+        firstSeenAt: tenMinutesAgo,
+      };
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [unresolvedSeen],
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      const createCall = mockPrisma.resolvedAlert.create.mock.calls[0][0];
+      expect(createCall.data.duration).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Default severity filter (fix 3)
+  // -------------------------------------------------------------------------
+
+  describe("default notificationSeverities", () => {
+    it("defaults to ['critical', 'warning'] when workspace has no severity config", async () => {
+      // workspace.notificationSeverities = null → default
+      setupDefaults({
+        seenAlerts: [],
+        workspace: makeWorkspace({ notificationSeverities: null }),
+      });
+
+      // Warning alert → should notify
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert({ severity: AlertSeverity.WARNING })],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+    });
+
+    it("does NOT notify for info alerts when workspace uses the default severity config", async () => {
+      setupDefaults({
+        seenAlerts: [],
+        workspace: makeWorkspace({ notificationSeverities: null }),
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [makeAlert({ severity: AlertSeverity.INFO })],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple alerts in a single call
+  // -------------------------------------------------------------------------
+
+  describe("multiple alerts", () => {
+    it("sends a single email containing all notifiable alerts", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      const alerts = [
+        makeAlert({
+          category: AlertCategory.MEMORY,
+          source: { type: "node", name: "rabbit@node1" },
+        }),
+        makeAlert({
+          category: AlertCategory.DISK,
+          source: { type: "node", name: "rabbit@node1" },
+        }),
+        makeAlert({
+          severity: AlertSeverity.CRITICAL,
+          category: AlertCategory.NODE,
+          source: { type: "node", name: "rabbit@node1" },
+        }),
+      ];
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        alerts,
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+      const emailArgs = mockSendEmail.mock.calls[0][0];
+      expect(emailArgs.alerts).toHaveLength(3);
+    });
+
+    it("only sends email for notifiable alerts when some are within cooldown", async () => {
+      const fingerprint = `${SERVER_ID}-memory-node-rabbit@node1`;
+      const recentlySeen = {
+        fingerprint,
+        emailSentAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), // within cooldown
+        resolvedAt: null,
+        lastSeenAt: new Date(),
+        firstSeenAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+      };
+      setupDefaults({ seenAlerts: [recentlySeen] });
+
+      const alerts = [
+        makeAlert({
+          category: AlertCategory.MEMORY,
+          source: { type: "node", name: "rabbit@node1" },
+        }), // cooldown → skip
+        makeAlert({
+          category: AlertCategory.DISK,
+          source: { type: "node", name: "rabbit@node2" },
+        }), // new → notify
+      ];
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        alerts,
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+      const emailArgs = mockSendEmail.mock.calls[0][0];
+      expect(emailArgs.alerts).toHaveLength(1);
+      expect(emailArgs.alerts[0].category).toBe(AlertCategory.DISK);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error resilience
+  // -------------------------------------------------------------------------
+
+  describe("error resilience", () => {
+    it("does not throw when email service fails", async () => {
+      setupDefaults({ seenAlerts: [] });
+      mockSendEmail.mockRejectedValue(new Error("SMTP failure"));
+
+      await expect(
+        alertNotificationService.trackAndNotifyNewAlerts(
+          [makeAlert()],
+          WORKSPACE_ID,
+          SERVER_ID,
+          SERVER_NAME
+        )
+      ).resolves.not.toThrow();
+    });
+
+    it("does not throw when webhook service fails", async () => {
+      setupDefaults({ seenAlerts: [], webhookEnabled: true });
+      mockPrisma.webhook.findFirst.mockResolvedValue({
+        id: "wh-1",
+        url: "https://example.com",
+        secret: null,
+        version: "v1",
+      });
+      mockSendWebhook.mockRejectedValue(new Error("Webhook timeout"));
+
+      await expect(
+        alertNotificationService.trackAndNotifyNewAlerts(
+          [makeAlert()],
+          WORKSPACE_ID,
+          SERVER_ID,
+          SERVER_NAME
+        )
+      ).resolves.not.toThrow();
+    });
+
+    it("does not throw when Slack service fails", async () => {
+      setupDefaults({ seenAlerts: [], slackEnabled: true });
+      mockPrisma.slackConfig.findFirst.mockResolvedValue({
+        id: "slack-1",
+        webhookUrl: "https://hooks.slack.com/test",
+      });
+      mockSendSlack.mockRejectedValue(new Error("Slack unreachable"));
+
+      await expect(
+        alertNotificationService.trackAndNotifyNewAlerts(
+          [makeAlert()],
+          WORKSPACE_ID,
+          SERVER_ID,
+          SERVER_NAME
+        )
+      ).resolves.not.toThrow();
+    });
+
+    it("continues processing when resolvedAlert.create fails for one alert", async () => {
+      const firstResolved = {
+        fingerprint: `${SERVER_ID}-memory-node-rabbit@node1`,
+        severity: "warning",
+        category: "memory",
+        sourceType: "node",
+        sourceName: "rabbit@node1",
+        firstSeenAt: new Date(Date.now() - 30 * 60 * 1000),
+      };
+      const secondResolved = {
+        fingerprint: `${SERVER_ID}-disk-node-rabbit@node1`,
+        severity: "critical",
+        category: "disk",
+        sourceType: "node",
+        sourceName: "rabbit@node1",
+        firstSeenAt: new Date(Date.now() - 60 * 60 * 1000),
+      };
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [firstResolved, secondResolved],
+      });
+
+      // First resolvedAlert.create fails, second should still be attempted
+      mockPrisma.resolvedAlert.create
+        .mockRejectedValueOnce(new Error("DB constraint"))
+        .mockResolvedValueOnce({});
+
+      await expect(
+        alertNotificationService.trackAndNotifyNewAlerts(
+          [],
+          WORKSPACE_ID,
+          SERVER_ID,
+          SERVER_NAME
+        )
+      ).resolves.not.toThrow();
+
+      expect(mockPrisma.resolvedAlert.create).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/api/src/services/alerts/__tests__/alert.notification.test.ts
+++ b/apps/api/src/services/alerts/__tests__/alert.notification.test.ts
@@ -1039,10 +1039,10 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
       );
     });
 
-    it("is position-safe: vhost 'foo' does not match a fingerprint whose actual vhost is 'foo-bar' (when category is 'queue')", async () => {
-      // category="queue" means indexOf("-queue-") hits the category segment first,
-      // exposing "queue-foo-bar-myqueue" which does NOT start with "foo-".
-      // This is the scenario where the old DB `contains` approach had a false positive.
+    it("is exact-boundary-safe: vhost 'foo' does not match a fingerprint whose actual vhost is 'foo-bar' (category='queue')", async () => {
+      // Fingerprint: server-1-queue-queue-foo-bar-myqueue
+      // Strip sourceName "myqueue" → server-1-queue-queue-foo-bar
+      // Check endsWith("-queue-foo") → FALSE ✓
       const fooBarAlert = {
         fingerprint: `${SERVER_ID}-queue-queue-foo-bar-myqueue`,
         severity: "warning",
@@ -1061,7 +1061,44 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
         WORKSPACE_ID,
         SERVER_ID,
         SERVER_NAME,
-        "foo" // checking vhost "foo" — should NOT resolve vhost "foo-bar"
+        "foo"
+      );
+
+      const resolveUpdate = mockPrisma.seenAlert.updateMany.mock.calls.find(
+        (call: unknown[]) => {
+          const data = (call[0] as { data: { resolvedAt?: unknown } }).data;
+          return data?.resolvedAt instanceof Date;
+        }
+      );
+      expect(resolveUpdate).toBeUndefined();
+    });
+
+    it("is exact-boundary-safe: vhost 'foo' does not match a fingerprint whose actual vhost is 'foo-bar' (category='memory')", async () => {
+      // This was the false positive in the old indexOf/startsWith approach:
+      // indexOf("-queue-") found the sourceType segment, then startsWith("foo-")
+      // matched "foo-bar-myqueue". The endsWith approach correctly returns FALSE.
+      // Fingerprint: server-1-memory-queue-foo-bar-myqueue
+      // Strip sourceName "myqueue" → server-1-memory-queue-foo-bar
+      // Check endsWith("-queue-foo") → FALSE ✓
+      const fooBarMemoryAlert = {
+        fingerprint: `${SERVER_ID}-memory-queue-foo-bar-myqueue`,
+        severity: "warning",
+        category: "memory",
+        sourceType: "queue",
+        sourceName: "myqueue",
+        firstSeenAt: new Date(Date.now() - 30 * 60 * 1000),
+      };
+      setupDefaults({
+        seenAlerts: [],
+        unresolvedSeenAlerts: [fooBarMemoryAlert],
+      });
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME,
+        "foo"
       );
 
       const resolveUpdate = mockPrisma.seenAlert.updateMany.mock.calls.find(
@@ -1106,6 +1143,69 @@ describe("AlertNotificationService.trackAndNotifyNewAlerts", () => {
       );
       // "default" queue alert + node alert = 2 resolved, "other" queue alert skipped
       expect(resolveUpdates).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Batch deduplication
+  // -------------------------------------------------------------------------
+
+  describe("batch deduplication", () => {
+    it("processes each fingerprint only once when the same alert appears twice in the batch", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      const alert = makeAlert();
+      // Pass the same alert twice — same fingerprint
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [alert, alert],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      // upsert should be called once, not twice
+      expect(mockPrisma.seenAlert.upsert).toHaveBeenCalledOnce();
+    });
+
+    it("sends only one notification when the same alert appears twice in the batch", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      const alert = makeAlert();
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        [alert, alert],
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      // Email should be sent once with 1 alert, not twice
+      expect(mockSendEmail).toHaveBeenCalledOnce();
+      const emailArgs = mockSendEmail.mock.calls[0][0];
+      expect(emailArgs.alerts).toHaveLength(1);
+    });
+
+    it("keeps distinct alerts when fingerprints are different", async () => {
+      setupDefaults({ seenAlerts: [] });
+
+      const alerts = [
+        makeAlert({
+          category: AlertCategory.MEMORY,
+          source: { type: "node", name: "rabbit@node1" },
+        }),
+        makeAlert({
+          category: AlertCategory.DISK,
+          source: { type: "node", name: "rabbit@node1" },
+        }),
+      ];
+
+      await alertNotificationService.trackAndNotifyNewAlerts(
+        alerts,
+        WORKSPACE_ID,
+        SERVER_ID,
+        SERVER_NAME
+      );
+
+      expect(mockPrisma.seenAlert.upsert).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/api/src/services/alerts/__tests__/alert.service.getResolvedAlerts.test.ts
+++ b/apps/api/src/services/alerts/__tests__/alert.service.getResolvedAlerts.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    seenAlert: { findMany: vi.fn() },
+    resolvedAlert: { findMany: vi.fn() },
+  },
+}));
+
+// alertService also imports createRabbitMQClient transitively — stub it out
+vi.mock("@/trpc/routers/rabbitmq/shared", () => ({
+  createRabbitMQClient: vi.fn(),
+}));
+
+vi.mock("@/services/alerts/alert.analyzer", () => ({
+  analyzeNodeHealth: vi.fn(() => []),
+  analyzeQueueHealth: vi.fn(() => []),
+}));
+
+vi.mock("@/services/alerts/alert.notification", () => ({
+  alertNotificationService: { trackAndNotifyNewAlerts: vi.fn() },
+}));
+
+vi.mock("@/services/alerts/alert.thresholds", () => ({
+  alertThresholdsService: { getWorkspaceThresholds: vi.fn() },
+}));
+
+vi.mock("@/services/alerts/alert.health", () => ({
+  alertHealthService: {
+    getClusterHealthSummary: vi.fn(),
+    getHealthCheck: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import { prisma } from "@/core/prisma";
+
+import { alertService } from "../alert.service";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SERVER_ID = "server-1";
+const WORKSPACE_ID = "ws-1";
+
+const mockPrisma = prisma as unknown as {
+  seenAlert: { findMany: MockInstance };
+  resolvedAlert: { findMany: MockInstance };
+};
+
+function makeResolvedAlert(
+  fingerprint: string,
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    id: `ra-${fingerprint}`,
+    serverId: SERVER_ID,
+    serverName: "Test Server",
+    severity: "warning",
+    category: "memory",
+    title: "High Memory Usage",
+    description: "Memory issue on node rabbit@node1",
+    details: {
+      sourceType: "node",
+      sourceName: "rabbit@node1",
+      category: "memory",
+    },
+    sourceType: "node",
+    sourceName: "rabbit@node1",
+    fingerprint,
+    firstSeenAt: new Date("2026-01-01T00:00:00Z"),
+    resolvedAt: new Date("2026-01-01T01:00:00Z"),
+    duration: 3_600_000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AlertService.getResolvedAlerts", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns resolved alerts that are not currently active", async () => {
+    const fp = `${SERVER_ID}-memory-node-rabbit@node1`;
+
+    mockPrisma.seenAlert.findMany.mockResolvedValue([]); // nothing active
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([
+      makeResolvedAlert(fp),
+    ]);
+
+    const result = await alertService.getResolvedAlerts(
+      SERVER_ID,
+      WORKSPACE_ID
+    );
+
+    expect(result.alerts).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.alerts[0].source.type).toBe("node");
+  });
+
+  it("excludes resolved alert records whose fingerprint is currently active", async () => {
+    const activeFp = `${SERVER_ID}-memory-node-rabbit@node1`;
+    const resolvedFp = `${SERVER_ID}-disk-node-rabbit@node1`;
+
+    // activeFp has resolvedAt: null in SeenAlert → currently active
+    mockPrisma.seenAlert.findMany.mockResolvedValue([
+      { fingerprint: activeFp },
+    ]);
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([
+      makeResolvedAlert(activeFp), // should be excluded
+      makeResolvedAlert(resolvedFp), // should be included
+    ]);
+
+    const result = await alertService.getResolvedAlerts(
+      SERVER_ID,
+      WORKSPACE_ID
+    );
+
+    expect(result.alerts).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.alerts[0].id).toBe(`ra-${resolvedFp}`);
+  });
+
+  it("returns empty list when all resolved alert fingerprints are currently active", async () => {
+    const fp1 = `${SERVER_ID}-memory-node-rabbit@node1`;
+    const fp2 = `${SERVER_ID}-disk-node-rabbit@node1`;
+
+    mockPrisma.seenAlert.findMany.mockResolvedValue([
+      { fingerprint: fp1 },
+      { fingerprint: fp2 },
+    ]);
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([
+      makeResolvedAlert(fp1),
+      makeResolvedAlert(fp2),
+    ]);
+
+    const result = await alertService.getResolvedAlerts(
+      SERVER_ID,
+      WORKSPACE_ID
+    );
+
+    expect(result.alerts).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it("returns all resolved alerts when there are no active alerts", async () => {
+    mockPrisma.seenAlert.findMany.mockResolvedValue([]);
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([
+      makeResolvedAlert(`${SERVER_ID}-memory-node-rabbit@node1`),
+      makeResolvedAlert(`${SERVER_ID}-disk-node-rabbit@node1`),
+    ]);
+
+    const result = await alertService.getResolvedAlerts(
+      SERVER_ID,
+      WORKSPACE_ID
+    );
+
+    expect(result.alerts).toHaveLength(2);
+    expect(result.total).toBe(2);
+  });
+
+  it("returns empty list when both resolved and active alert tables are empty", async () => {
+    mockPrisma.seenAlert.findMany.mockResolvedValue([]);
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([]);
+
+    const result = await alertService.getResolvedAlerts(
+      SERVER_ID,
+      WORKSPACE_ID
+    );
+
+    expect(result.alerts).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it("maps resolved alert fields correctly", async () => {
+    const fp = `${SERVER_ID}-memory-node-rabbit@node1`;
+    mockPrisma.seenAlert.findMany.mockResolvedValue([]);
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([
+      makeResolvedAlert(fp),
+    ]);
+
+    const result = await alertService.getResolvedAlerts(
+      SERVER_ID,
+      WORKSPACE_ID
+    );
+    const alert = result.alerts[0];
+
+    expect(alert.id).toBe(`ra-${fp}`);
+    expect(alert.serverId).toBe(SERVER_ID);
+    expect(alert.serverName).toBe("Test Server");
+    expect(alert.severity).toBe("warning");
+    expect(alert.category).toBe("memory");
+    expect(alert.source).toEqual({ type: "node", name: "rabbit@node1" });
+    expect(alert.firstSeenAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(alert.resolvedAt).toBe("2026-01-01T01:00:00.000Z");
+    expect(alert.duration).toBe(3_600_000);
+    // fingerprint is internal — should NOT be exposed on the response shape
+    expect(Object.keys(alert)).not.toContain("fingerprint");
+  });
+
+  it("queries SeenAlert with resolvedAt: null to identify active fingerprints", async () => {
+    mockPrisma.seenAlert.findMany.mockResolvedValue([]);
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([]);
+
+    await alertService.getResolvedAlerts(SERVER_ID, WORKSPACE_ID);
+
+    expect(mockPrisma.seenAlert.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          serverId: SERVER_ID,
+          workspaceId: WORKSPACE_ID,
+          resolvedAt: null,
+        }),
+      })
+    );
+  });
+
+  describe("a recurring alert is not simultaneously in both lists", () => {
+    it("alert that recurred (came back) is excluded from resolved list", async () => {
+      // Scenario: alert fired, was resolved (ResolvedAlert created), then came back
+      // → SeenAlert.resolvedAt is now null again (active)
+      // → The old ResolvedAlert record is still in the DB
+      const fp = `${SERVER_ID}-memory-node-rabbit@node1`;
+
+      // SeenAlert shows alert is currently active
+      mockPrisma.seenAlert.findMany.mockResolvedValue([{ fingerprint: fp }]);
+      // ResolvedAlert has a historical record from the previous occurrence
+      mockPrisma.resolvedAlert.findMany.mockResolvedValue([
+        makeResolvedAlert(fp),
+      ]);
+
+      const result = await alertService.getResolvedAlerts(
+        SERVER_ID,
+        WORKSPACE_ID
+      );
+
+      // The historical record must not appear because the alert is active again
+      expect(result.alerts).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it("alert that has truly resolved (not active) appears in resolved list", async () => {
+      const fp = `${SERVER_ID}-memory-node-rabbit@node1`;
+
+      // No active SeenAlert for this fingerprint
+      mockPrisma.seenAlert.findMany.mockResolvedValue([]);
+      mockPrisma.resolvedAlert.findMany.mockResolvedValue([
+        makeResolvedAlert(fp),
+      ]);
+
+      const result = await alertService.getResolvedAlerts(
+        SERVER_ID,
+        WORKSPACE_ID
+      );
+
+      expect(result.alerts).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+  });
+});

--- a/apps/api/src/services/alerts/__tests__/alert.service.getResolvedAlerts.test.ts
+++ b/apps/api/src/services/alerts/__tests__/alert.service.getResolvedAlerts.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, type MockInstance, vi } from "vitest";
 vi.mock("@/core/prisma", () => ({
   prisma: {
     seenAlert: { findMany: vi.fn() },
-    resolvedAlert: { findMany: vi.fn() },
+    resolvedAlert: { findMany: vi.fn(), count: vi.fn() },
   },
 }));
 
@@ -53,7 +53,7 @@ const WORKSPACE_ID = "ws-1";
 
 const mockPrisma = prisma as unknown as {
   seenAlert: { findMany: MockInstance };
-  resolvedAlert: { findMany: MockInstance };
+  resolvedAlert: { findMany: MockInstance; count: MockInstance };
 };
 
 function makeResolvedAlert(
@@ -99,6 +99,7 @@ describe("AlertService.getResolvedAlerts", () => {
     mockPrisma.resolvedAlert.findMany.mockResolvedValue([
       makeResolvedAlert(fp),
     ]);
+    mockPrisma.resolvedAlert.count.mockResolvedValue(1);
 
     const result = await alertService.getResolvedAlerts(
       SERVER_ID,
@@ -110,18 +111,18 @@ describe("AlertService.getResolvedAlerts", () => {
     expect(result.alerts[0].source.type).toBe("node");
   });
 
-  it("excludes resolved alert records whose fingerprint is currently active", async () => {
+  it("passes active fingerprints as notIn to the resolvedAlert query", async () => {
     const activeFp = `${SERVER_ID}-memory-node-rabbit@node1`;
     const resolvedFp = `${SERVER_ID}-disk-node-rabbit@node1`;
 
-    // activeFp has resolvedAt: null in SeenAlert → currently active
     mockPrisma.seenAlert.findMany.mockResolvedValue([
       { fingerprint: activeFp },
     ]);
+    // DB has already excluded the activeFp record via the notIn clause
     mockPrisma.resolvedAlert.findMany.mockResolvedValue([
-      makeResolvedAlert(activeFp), // should be excluded
-      makeResolvedAlert(resolvedFp), // should be included
+      makeResolvedAlert(resolvedFp),
     ]);
+    mockPrisma.resolvedAlert.count.mockResolvedValue(1);
 
     const result = await alertService.getResolvedAlerts(
       SERVER_ID,
@@ -131,6 +132,31 @@ describe("AlertService.getResolvedAlerts", () => {
     expect(result.alerts).toHaveLength(1);
     expect(result.total).toBe(1);
     expect(result.alerts[0].id).toBe(`ra-${resolvedFp}`);
+
+    // The DB query must include the notIn exclusion
+    expect(mockPrisma.resolvedAlert.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          fingerprint: { notIn: [activeFp] },
+        }),
+      })
+    );
+  });
+
+  it("does not add fingerprint notIn clause when there are no active alerts", async () => {
+    mockPrisma.seenAlert.findMany.mockResolvedValue([]);
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([
+      makeResolvedAlert(`${SERVER_ID}-memory-node-rabbit@node1`),
+    ]);
+    mockPrisma.resolvedAlert.count.mockResolvedValue(1);
+
+    await alertService.getResolvedAlerts(SERVER_ID, WORKSPACE_ID);
+
+    expect(mockPrisma.resolvedAlert.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.not.objectContaining({ fingerprint: expect.anything() }),
+      })
+    );
   });
 
   it("returns empty list when all resolved alert fingerprints are currently active", async () => {
@@ -141,10 +167,9 @@ describe("AlertService.getResolvedAlerts", () => {
       { fingerprint: fp1 },
       { fingerprint: fp2 },
     ]);
-    mockPrisma.resolvedAlert.findMany.mockResolvedValue([
-      makeResolvedAlert(fp1),
-      makeResolvedAlert(fp2),
-    ]);
+    // DB returns nothing because all fingerprints are excluded via notIn
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([]);
+    mockPrisma.resolvedAlert.count.mockResolvedValue(0);
 
     const result = await alertService.getResolvedAlerts(
       SERVER_ID,
@@ -161,6 +186,7 @@ describe("AlertService.getResolvedAlerts", () => {
       makeResolvedAlert(`${SERVER_ID}-memory-node-rabbit@node1`),
       makeResolvedAlert(`${SERVER_ID}-disk-node-rabbit@node1`),
     ]);
+    mockPrisma.resolvedAlert.count.mockResolvedValue(2);
 
     const result = await alertService.getResolvedAlerts(
       SERVER_ID,
@@ -174,6 +200,7 @@ describe("AlertService.getResolvedAlerts", () => {
   it("returns empty list when both resolved and active alert tables are empty", async () => {
     mockPrisma.seenAlert.findMany.mockResolvedValue([]);
     mockPrisma.resolvedAlert.findMany.mockResolvedValue([]);
+    mockPrisma.resolvedAlert.count.mockResolvedValue(0);
 
     const result = await alertService.getResolvedAlerts(
       SERVER_ID,
@@ -184,12 +211,31 @@ describe("AlertService.getResolvedAlerts", () => {
     expect(result.total).toBe(0);
   });
 
+  it("total comes from count query, not the length of the current page", async () => {
+    // Simulates a paginated response: page returns 2 items but total is 50
+    mockPrisma.seenAlert.findMany.mockResolvedValue([]);
+    mockPrisma.resolvedAlert.findMany.mockResolvedValue([
+      makeResolvedAlert(`${SERVER_ID}-memory-node-rabbit@node1`),
+      makeResolvedAlert(`${SERVER_ID}-disk-node-rabbit@node1`),
+    ]);
+    mockPrisma.resolvedAlert.count.mockResolvedValue(50);
+
+    const result = await alertService.getResolvedAlerts(
+      SERVER_ID,
+      WORKSPACE_ID
+    );
+
+    expect(result.alerts).toHaveLength(2);
+    expect(result.total).toBe(50); // reflects count, not current page length
+  });
+
   it("maps resolved alert fields correctly", async () => {
     const fp = `${SERVER_ID}-memory-node-rabbit@node1`;
     mockPrisma.seenAlert.findMany.mockResolvedValue([]);
     mockPrisma.resolvedAlert.findMany.mockResolvedValue([
       makeResolvedAlert(fp),
     ]);
+    mockPrisma.resolvedAlert.count.mockResolvedValue(1);
 
     const result = await alertService.getResolvedAlerts(
       SERVER_ID,
@@ -213,6 +259,7 @@ describe("AlertService.getResolvedAlerts", () => {
   it("queries SeenAlert with resolvedAt: null to identify active fingerprints", async () => {
     mockPrisma.seenAlert.findMany.mockResolvedValue([]);
     mockPrisma.resolvedAlert.findMany.mockResolvedValue([]);
+    mockPrisma.resolvedAlert.count.mockResolvedValue(0);
 
     await alertService.getResolvedAlerts(SERVER_ID, WORKSPACE_ID);
 
@@ -234,12 +281,10 @@ describe("AlertService.getResolvedAlerts", () => {
       // → The old ResolvedAlert record is still in the DB
       const fp = `${SERVER_ID}-memory-node-rabbit@node1`;
 
-      // SeenAlert shows alert is currently active
+      // SeenAlert shows alert is currently active → notIn clause excludes it from DB query
       mockPrisma.seenAlert.findMany.mockResolvedValue([{ fingerprint: fp }]);
-      // ResolvedAlert has a historical record from the previous occurrence
-      mockPrisma.resolvedAlert.findMany.mockResolvedValue([
-        makeResolvedAlert(fp),
-      ]);
+      mockPrisma.resolvedAlert.findMany.mockResolvedValue([]); // excluded by DB notIn
+      mockPrisma.resolvedAlert.count.mockResolvedValue(0);
 
       const result = await alertService.getResolvedAlerts(
         SERVER_ID,
@@ -249,16 +294,26 @@ describe("AlertService.getResolvedAlerts", () => {
       // The historical record must not appear because the alert is active again
       expect(result.alerts).toHaveLength(0);
       expect(result.total).toBe(0);
+
+      // Verify the exclusion is enforced at the DB level
+      expect(mockPrisma.resolvedAlert.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            fingerprint: { notIn: [fp] },
+          }),
+        })
+      );
     });
 
     it("alert that has truly resolved (not active) appears in resolved list", async () => {
       const fp = `${SERVER_ID}-memory-node-rabbit@node1`;
 
-      // No active SeenAlert for this fingerprint
+      // No active SeenAlert for this fingerprint → no notIn clause added
       mockPrisma.seenAlert.findMany.mockResolvedValue([]);
       mockPrisma.resolvedAlert.findMany.mockResolvedValue([
         makeResolvedAlert(fp),
       ]);
+      mockPrisma.resolvedAlert.count.mockResolvedValue(1);
 
       const result = await alertService.getResolvedAlerts(
         SERVER_ID,

--- a/apps/api/src/services/alerts/alert.notification.ts
+++ b/apps/api/src/services/alerts/alert.notification.ts
@@ -215,9 +215,29 @@ class AlertNotificationService {
       const newAlerts: RabbitMQAlert[] = [];
       const now = new Date();
 
+      // Deduplicate alerts by fingerprint before processing.
+      // If the same fingerprint appears more than once in the batch (e.g. from
+      // duplicate entries in the source data) only the first occurrence is kept,
+      // preventing duplicate SeenAlert writes and double notification sends.
+      const dedupedAlerts: RabbitMQAlert[] = [];
+      const seenInBatch = new Set<string>();
+      for (const alert of alerts) {
+        const fp = generateAlertFingerprint(
+          serverId,
+          alert.category,
+          alert.source.type,
+          alert.source.name,
+          alert.vhost
+        );
+        if (!seenInBatch.has(fp)) {
+          seenInBatch.add(fp);
+          dedupedAlerts.push(alert);
+        }
+      }
+
       // Process each alert - ALWAYS track alerts regardless of notification settings
       // Severity preferences only affect notifications, not tracking
-      for (const alert of alerts) {
+      for (const alert of dedupedAlerts) {
         const fingerprint = generateAlertFingerprint(
           serverId,
           alert.category,
@@ -313,16 +333,18 @@ class AlertNotificationService {
       });
 
       // If vhost is specified, exclude queue alerts that belong to a different vhost.
-      // Position-safe: after the "-queue-" segment the next part must start with
-      // `${vhost}-`, preventing false positives from overlapping vhost name prefixes.
+      // Exact boundary match: strip the known sourceName suffix, then verify the
+      // remainder ends with `-queue-${vhost}` exactly. This avoids false positives
+      // when one vhost name is a prefix of another (e.g. "foo" vs "foo-bar") and
+      // works correctly regardless of category (fixes the indexOf approach which
+      // could hit the category segment before the sourceType segment).
       const alertsToResolve = vhost
         ? unresolvedSeenAlerts.filter((a) => {
             if (a.sourceType !== "queue") return true;
-            const idx = a.fingerprint.indexOf("-queue-");
-            if (idx === -1) return false;
-            return a.fingerprint
-              .slice(idx + "-queue-".length)
-              .startsWith(`${vhost}-`);
+            const suffix = `-${a.sourceName}`;
+            if (!a.fingerprint.endsWith(suffix)) return false;
+            const withoutSource = a.fingerprint.slice(0, -suffix.length);
+            return withoutSource.endsWith(`-queue-${vhost}`);
           })
         : unresolvedSeenAlerts;
 

--- a/apps/api/src/services/alerts/alert.notification.ts
+++ b/apps/api/src/services/alerts/alert.notification.ts
@@ -193,10 +193,10 @@ class AlertNotificationService {
         return;
       }
 
-      // Get notification severity preferences (default to all if not set)
+      // Get notification severity preferences (default to critical + warning per documented scope)
       const notificationSeverities = workspace.notificationSeverities
         ? (workspace.notificationSeverities as string[])
-        : ["critical", "warning", "info"];
+        : ["critical", "warning"];
 
       // Get all existing seen alerts for this workspace and server
       const seenAlerts = await prisma.seenAlert.findMany({
@@ -234,6 +234,10 @@ class AlertNotificationService {
         const isNew = !existingAlert;
 
         // Always track alerts in database, regardless of severity preferences
+        // NOTE: This loop issues one DB write per alert (N+1 pattern).
+        // A batch upsert would be more efficient but is intentionally avoided here
+        // to preserve correct per-alert create-vs-update semantics and avoid
+        // race conditions when alerts transition state mid-batch.
         if (isNew) {
           // Brand new alert - create SeenAlert record
           await prisma.seenAlert.create({
@@ -320,6 +324,10 @@ class AlertNotificationService {
       // If vhost is specified, only auto-resolve alerts for that vhost (or node/cluster alerts)
       // This prevents resolving alerts from other vhosts when viewing a specific vhost
       if (vhost) {
+        // Fingerprint format for queue alerts: `${serverId}-${category}-queue-${vhost}-${sourceName}`
+        // We use `contains` because Prisma does not support regex. This is safe because the
+        // `sourceType: "queue"` condition in the OR clause constrains the match, and the
+        // `-queue-${vhost}-` segment is position-stable in the format.
         const vhostPattern = `-queue-${vhost}-`;
         unresolvedSeenAlertsWhere.OR = [
           // Include queue alerts that match the vhost
@@ -349,9 +357,6 @@ class AlertNotificationService {
         },
       });
 
-      // Use provided server name (always available from caller)
-      const resolvedServerName = serverName;
-
       for (const seenAlert of unresolvedSeenAlerts) {
         if (!activeFingerprints.has(seenAlert.fingerprint)) {
           // Alert is no longer active, mark as resolved
@@ -380,7 +385,7 @@ class AlertNotificationService {
             await prisma.resolvedAlert.create({
               data: {
                 serverId,
-                serverName: resolvedServerName,
+                serverName,
                 severity: seenAlert.severity,
                 category: seenAlert.category,
                 title,
@@ -439,205 +444,165 @@ class AlertNotificationService {
         shouldSendNotifications &&
         serverNotificationsEnabled
       ) {
-        // Filter to only alerts that should actually get notifications
-        const alertsToNotify = newAlerts.filter((alert) => {
-          const fingerprint = generateAlertFingerprint(
-            serverId,
-            alert.category,
-            alert.source.type,
-            alert.source.name,
-            alert.vhost
-          );
-          const existing = seenAlerts.find(
-            (a) => a.fingerprint === fingerprint
-          );
+        const alertsToNotify = newAlerts;
 
-          // Send notification if:
-          // 1. Never sent email before, OR
-          // 2. Alert was resolved (came back), OR
-          // 3. Past cooldown period
-          if (!existing || !existing.emailSentAt) {
-            return true;
+        // Send email notification (if enabled)
+        if (workspace.emailNotificationsEnabled && workspace.contactEmail) {
+          try {
+            await NotificationEmailService.sendAlertNotificationEmail({
+              to: workspace.contactEmail,
+              workspaceName: workspace.name,
+              workspaceId,
+              alerts: alertsToNotify,
+              serverName,
+              serverId,
+            });
+
+            // Mark alerts as email sent
+            for (const alert of alertsToNotify) {
+              const fingerprint = generateAlertFingerprint(
+                serverId,
+                alert.category,
+                alert.source.type,
+                alert.source.name,
+                alert.vhost
+              );
+              await prisma.seenAlert.updateMany({
+                where: { fingerprint },
+                data: { emailSentAt: now },
+              });
+            }
+
+            logger.info(
+              `Sent alert notification email for ${alertsToNotify.length} new/recurring alerts to ${workspace.contactEmail}`
+            );
+          } catch (error) {
+            logger.error({ error }, "Failed to send alert notification email");
           }
+        }
 
-          const wasResolved = !!existing.resolvedAt;
-          const referenceTime = existing.emailSentAt || existing.firstSeenAt;
-          const timeSinceLastNotification = referenceTime
-            ? now.getTime() - referenceTime.getTime()
-            : 0;
-          const isPastCooldown =
-            timeSinceLastNotification > this.COOLDOWN_PERIOD;
-
-          return wasResolved || isPastCooldown;
-        });
-
-        if (alertsToNotify.length > 0) {
-          const serverName = alertsToNotify[0]?.serverName || "Unknown Server";
-
-          // Send email notification (if enabled)
-          if (workspace.emailNotificationsEnabled && workspace.contactEmail) {
-            try {
-              await NotificationEmailService.sendAlertNotificationEmail({
-                to: workspace.contactEmail,
-                workspaceName: workspace.name,
+        // Send webhook notifications (only if webhook integration is enabled)
+        const webhookEnabled = await isFeatureEnabled(
+          FEATURES.WEBHOOK_INTEGRATION
+        );
+        if (webhookEnabled) {
+          try {
+            const webhook = await prisma.webhook.findFirst({
+              where: {
                 workspaceId,
-                alerts: alertsToNotify,
+                enabled: true,
+              },
+              select: {
+                id: true,
+                url: true,
+                secret: true,
+                version: true,
+              },
+            });
+
+            if (webhook) {
+              const webhookResults = await WebhookService.sendAlertNotification(
+                [webhook],
+                workspaceId,
+                workspace.name,
+                serverId,
+                serverName,
+                alertsToNotify
+              );
+
+              // Log webhook results
+              const successful = webhookResults.filter(
+                (r) => r.result.success
+              ).length;
+              const failed = webhookResults.filter(
+                (r) => !r.result.success
+              ).length;
+
+              if (successful > 0) {
+                logger.info(
+                  {
+                    successful,
+                    failed,
+                    alertsToNotifyLength: alertsToNotify.length,
+                  },
+                  "Sent alert notification to webhook(s)"
+                );
+              }
+
+              if (failed > 0) {
+                logger.warn(
+                  {
+                    failures: webhookResults
+                      .filter((r) => !r.result.success)
+                      .map((r) => ({
+                        webhookId: r.webhookId,
+                        error: r.result.error,
+                      })),
+                  },
+                  "Failed to send alert notification to webhook(s)"
+                );
+              }
+            }
+          } catch (error) {
+            logger.error({ error }, "Failed to send webhook notifications");
+          }
+        }
+
+        // Send Slack notifications (only if Slack integration is enabled)
+        const slackEnabled = await isFeatureEnabled(FEATURES.SLACK_INTEGRATION);
+        if (slackEnabled) {
+          try {
+            const slackConfig = await prisma.slackConfig.findFirst({
+              where: {
+                workspaceId,
+                enabled: true,
+              },
+              select: {
+                id: true,
+                webhookUrl: true,
+              },
+            });
+
+            if (slackConfig) {
+              const slackResults = await SlackService.sendAlertNotifications(
+                [slackConfig],
+                alertsToNotify,
+                workspace.name,
                 serverName,
                 serverId,
-              });
-
-              // Mark alerts as email sent
-              for (const alert of alertsToNotify) {
-                const fingerprint = generateAlertFingerprint(
-                  serverId,
-                  alert.category,
-                  alert.source.type,
-                  alert.source.name,
-                  alert.vhost
-                );
-                await prisma.seenAlert.updateMany({
-                  where: { fingerprint },
-                  data: { emailSentAt: now },
-                });
-              }
-
-              logger.info(
-                `Sent alert notification email for ${alertsToNotify.length} new/recurring alerts to ${workspace.contactEmail}`
+                emailConfig.frontendUrl
               );
-            } catch (error) {
-              logger.error(
-                { error },
-                "Failed to send alert notification email"
-              );
-            }
-          }
 
-          // Send webhook notifications (only if webhook integration is enabled)
-          const webhookEnabled = await isFeatureEnabled(
-            FEATURES.WEBHOOK_INTEGRATION
-          );
-          if (webhookEnabled) {
-            try {
-              const webhook = await prisma.webhook.findFirst({
-                where: {
-                  workspaceId,
-                  enabled: true,
-                },
-                select: {
-                  id: true,
-                  url: true,
-                  secret: true,
-                  version: true,
-                },
-              });
+              // Log Slack results
+              const successful = slackResults.filter(
+                (r) => r.result.success
+              ).length;
+              const failed = slackResults.filter(
+                (r) => !r.result.success
+              ).length;
 
-              if (webhook) {
-                const webhookResults =
-                  await WebhookService.sendAlertNotification(
-                    [webhook],
-                    workspaceId,
-                    workspace.name,
-                    serverId,
-                    serverName,
-                    alertsToNotify
-                  );
-
-                // Log webhook results
-                const successful = webhookResults.filter(
-                  (r) => r.result.success
-                ).length;
-                const failed = webhookResults.filter(
-                  (r) => !r.result.success
-                ).length;
-
-                if (successful > 0) {
-                  logger.info(
-                    {
-                      successful,
-                      failed,
-                      alertsToNotifyLength: alertsToNotify.length,
-                    },
-                    "Sent alert notification to webhook(s)"
-                  );
-                }
-
-                if (failed > 0) {
-                  logger.warn(
-                    {
-                      failures: webhookResults
-                        .filter((r) => !r.result.success)
-                        .map((r) => ({
-                          webhookId: r.webhookId,
-                          error: r.result.error,
-                        })),
-                    },
-                    "Failed to send alert notification to webhook(s)"
-                  );
-                }
-              }
-            } catch (error) {
-              logger.error({ error }, "Failed to send webhook notifications");
-            }
-          }
-
-          // Send Slack notifications (only if Slack integration is enabled)
-          const slackEnabled = await isFeatureEnabled(
-            FEATURES.SLACK_INTEGRATION
-          );
-          if (slackEnabled) {
-            try {
-              const slackConfig = await prisma.slackConfig.findFirst({
-                where: {
-                  workspaceId,
-                  enabled: true,
-                },
-                select: {
-                  id: true,
-                  webhookUrl: true,
-                },
-              });
-
-              if (slackConfig) {
-                const slackResults = await SlackService.sendAlertNotifications(
-                  [slackConfig],
-                  alertsToNotify,
-                  workspace.name,
-                  serverName,
-                  serverId,
-                  emailConfig.frontendUrl
+              if (successful > 0) {
+                logger.info(
+                  `Sent alert notification to ${successful} Slack channel(s) for ${alertsToNotify.length} alerts`
                 );
-
-                // Log Slack results
-                const successful = slackResults.filter(
-                  (r) => r.result.success
-                ).length;
-                const failed = slackResults.filter(
-                  (r) => !r.result.success
-                ).length;
-
-                if (successful > 0) {
-                  logger.info(
-                    `Sent alert notification to ${successful} Slack channel(s) for ${alertsToNotify.length} alerts`
-                  );
-                }
-
-                if (failed > 0) {
-                  logger.warn(
-                    {
-                      failures: slackResults
-                        .filter((r) => !r.result.success)
-                        .map((r) => ({
-                          slackConfigId: r.slackConfigId,
-                          error: r.result.error,
-                        })),
-                    },
-                    `Failed to send alert notification to ${failed} Slack channel(s)`
-                  );
-                }
               }
-            } catch (error) {
-              logger.error({ error }, "Failed to send Slack notifications");
+
+              if (failed > 0) {
+                logger.warn(
+                  {
+                    failures: slackResults
+                      .filter((r) => !r.result.success)
+                      .map((r) => ({
+                        slackConfigId: r.slackConfigId,
+                        error: r.result.error,
+                      })),
+                  },
+                  `Failed to send alert notification to ${failed} Slack channel(s)`
+                );
+              }
             }
+          } catch (error) {
+            logger.error({ error }, "Failed to send Slack notifications");
           }
         }
       } else if (newAlerts.length > 0) {

--- a/apps/api/src/services/alerts/alert.notification.ts
+++ b/apps/api/src/services/alerts/alert.notification.ts
@@ -235,36 +235,29 @@ class AlertNotificationService {
 
         // Always track alerts in database, regardless of severity preferences
         // NOTE: This loop issues one DB write per alert (N+1 pattern).
-        // A batch upsert would be more efficient but is intentionally avoided here
-        // to preserve correct per-alert create-vs-update semantics and avoid
-        // race conditions when alerts transition state mid-batch.
-        if (isNew) {
-          // Brand new alert - create SeenAlert record
-          await prisma.seenAlert.create({
-            data: {
-              fingerprint,
-              serverId,
-              workspaceId,
-              severity: alert.severity,
-              category: alert.category,
-              sourceType: alert.source.type,
-              sourceName: alert.source.name,
-              firstSeenAt: now,
-              lastSeenAt: now,
-              resolvedAt: null, // Not resolved
-            },
-          });
-        } else {
-          // Existing alert - update last seen time and clear resolution if alert is active again
-          await prisma.seenAlert.updateMany({
-            where: { fingerprint },
-            data: {
-              lastSeenAt: now,
-              resolvedAt: null, // Clear resolution since alert is active again
-              severity: alert.severity, // Update severity in case it changed
-            },
-          });
-        }
+        // Using upsert for idempotency: concurrent cron runs can race on
+        // fingerprint creation, so we atomically create-or-update rather than
+        // branching on the isNew snapshot.
+        await prisma.seenAlert.upsert({
+          where: { fingerprint },
+          create: {
+            fingerprint,
+            serverId,
+            workspaceId,
+            severity: alert.severity,
+            category: alert.category,
+            sourceType: alert.source.type,
+            sourceName: alert.source.name,
+            firstSeenAt: now,
+            lastSeenAt: now,
+            resolvedAt: null,
+          },
+          update: {
+            lastSeenAt: now,
+            resolvedAt: null, // Clear resolution since alert is active again
+            severity: alert.severity, // Update severity in case it changed
+          },
+        });
 
         // Check if alert should trigger notification
         // Only send notifications for alerts that match severity preferences
@@ -303,50 +296,12 @@ class AlertNotificationService {
         }
       }
 
-      // Auto-resolve alerts that are no longer active
-      // Find all seen alerts for this server that are not in current alerts
-      // IMPORTANT: If vhost is specified, only check alerts for that vhost (or node/cluster alerts)
-      // This prevents incorrectly resolving alerts from other vhosts when viewing a specific vhost
-      const unresolvedSeenAlertsWhere: {
-        workspaceId: string;
-        serverId: string;
-        resolvedAt: null;
-        OR?: Array<{
-          sourceType: string;
-          fingerprint?: { contains: string };
-        }>;
-      } = {
-        workspaceId,
-        serverId,
-        resolvedAt: null, // Only unresolved ones
-      };
-
-      // If vhost is specified, only auto-resolve alerts for that vhost (or node/cluster alerts)
-      // This prevents resolving alerts from other vhosts when viewing a specific vhost
-      if (vhost) {
-        // Fingerprint format for queue alerts: `${serverId}-${category}-queue-${vhost}-${sourceName}`
-        // We use `contains` because Prisma does not support regex. This is safe because the
-        // `sourceType: "queue"` condition in the OR clause constrains the match, and the
-        // `-queue-${vhost}-` segment is position-stable in the format.
-        const vhostPattern = `-queue-${vhost}-`;
-        unresolvedSeenAlertsWhere.OR = [
-          // Include queue alerts that match the vhost
-          {
-            sourceType: "queue",
-            fingerprint: { contains: vhostPattern },
-          },
-          // Include all node and cluster alerts (not vhost-specific)
-          {
-            sourceType: "node",
-          },
-          {
-            sourceType: "cluster",
-          },
-        ];
-      }
-
+      // Auto-resolve alerts that are no longer active.
+      // Fetch all unresolved SeenAlerts for this server; vhost scoping is applied
+      // in-memory below to avoid false positives from a substring `contains` match
+      // (e.g. vhost "foo" incorrectly matching fingerprints for vhost "foo-bar").
       const unresolvedSeenAlerts = await prisma.seenAlert.findMany({
-        where: unresolvedSeenAlertsWhere,
+        where: { workspaceId, serverId, resolvedAt: null },
         select: {
           fingerprint: true,
           severity: true,
@@ -357,7 +312,21 @@ class AlertNotificationService {
         },
       });
 
-      for (const seenAlert of unresolvedSeenAlerts) {
+      // If vhost is specified, exclude queue alerts that belong to a different vhost.
+      // Position-safe: after the "-queue-" segment the next part must start with
+      // `${vhost}-`, preventing false positives from overlapping vhost name prefixes.
+      const alertsToResolve = vhost
+        ? unresolvedSeenAlerts.filter((a) => {
+            if (a.sourceType !== "queue") return true;
+            const idx = a.fingerprint.indexOf("-queue-");
+            if (idx === -1) return false;
+            return a.fingerprint
+              .slice(idx + "-queue-".length)
+              .startsWith(`${vhost}-`);
+          })
+        : unresolvedSeenAlerts;
+
+      for (const seenAlert of alertsToResolve) {
         if (!activeFingerprints.has(seenAlert.fingerprint)) {
           // Alert is no longer active, mark as resolved
           await prisma.seenAlert.updateMany({
@@ -426,8 +395,8 @@ class AlertNotificationService {
         return;
       }
 
-      // Only send if email notifications are enabled and contact email is set
-      const shouldSendNotifications =
+      // Email-specific gate — webhook and Slack have their own independent feature flags
+      const shouldSendEmail =
         workspace.emailNotificationsEnabled && !!workspace.contactEmail;
 
       // Check if notifications are enabled for this server
@@ -439,18 +408,14 @@ class AlertNotificationService {
         notificationServerIds.length === 0 ||
         notificationServerIds.includes(serverId);
 
-      if (
-        newAlerts.length > 0 &&
-        shouldSendNotifications &&
-        serverNotificationsEnabled
-      ) {
+      if (newAlerts.length > 0 && serverNotificationsEnabled) {
         const alertsToNotify = newAlerts;
 
         // Send email notification (if enabled)
-        if (workspace.emailNotificationsEnabled && workspace.contactEmail) {
+        if (shouldSendEmail) {
           try {
             await NotificationEmailService.sendAlertNotificationEmail({
-              to: workspace.contactEmail,
+              to: workspace.contactEmail!,
               workspaceName: workspace.name,
               workspaceId,
               alerts: alertsToNotify,
@@ -477,7 +442,10 @@ class AlertNotificationService {
               `Sent alert notification email for ${alertsToNotify.length} new/recurring alerts to ${workspace.contactEmail}`
             );
           } catch (error) {
-            logger.error({ error }, "Failed to send alert notification email");
+            logger.error(
+              { error, workspaceId, serverId },
+              "Failed to send alert notification email"
+            );
           }
         }
 
@@ -544,7 +512,10 @@ class AlertNotificationService {
               }
             }
           } catch (error) {
-            logger.error({ error }, "Failed to send webhook notifications");
+            logger.error(
+              { error, workspaceId, serverId },
+              "Failed to send webhook notifications"
+            );
           }
         }
 
@@ -602,20 +573,16 @@ class AlertNotificationService {
               }
             }
           } catch (error) {
-            logger.error({ error }, "Failed to send Slack notifications");
+            logger.error(
+              { error, workspaceId, serverId },
+              "Failed to send Slack notifications"
+            );
           }
         }
       } else if (newAlerts.length > 0) {
-        // Log why notifications weren't sent (for debugging)
-        if (!shouldSendNotifications) {
-          logger.debug(
-            `Skipping notifications for ${newAlerts.length} alerts: email notifications disabled or no contact email`
-          );
-        } else if (!serverNotificationsEnabled) {
-          logger.debug(
-            `Skipping notifications for ${newAlerts.length} alerts: server ${serverId} not in notification server list`
-          );
-        }
+        logger.debug(
+          `Skipping notifications for ${newAlerts.length} alerts: server ${serverId} not in notification server list`
+        );
       }
     } catch (error) {
       logger.error({ error }, "Error tracking and notifying new alerts");

--- a/apps/api/src/services/alerts/alert.service.ts
+++ b/apps/api/src/services/alerts/alert.service.ts
@@ -230,33 +230,46 @@ class AlertService {
       ];
     }
 
-    const [resolvedAlerts, total] = await Promise.all([
-      prisma.resolvedAlert.findMany({
-        where,
-        orderBy: { resolvedAt: "desc" },
-        take: options?.limit,
-        skip: options?.offset,
-        select: {
-          id: true,
-          serverId: true,
-          serverName: true,
-          severity: true,
-          category: true,
-          title: true,
-          description: true,
-          details: true,
-          sourceType: true,
-          sourceName: true,
-          firstSeenAt: true,
-          resolvedAt: true,
-          duration: true,
-        },
-      }),
-      prisma.resolvedAlert.count({ where }),
-    ]);
+    // Exclude fingerprints that are currently active (SeenAlert with resolvedAt: null).
+    // This prevents the same alert from appearing in both the active alerts list and
+    // the resolved alerts history when an alert recurs after being resolved.
+    const activeSeenAlerts = await prisma.seenAlert.findMany({
+      where: { serverId, workspaceId, resolvedAt: null },
+      select: { fingerprint: true },
+    });
+    const activeFingerprintSet = new Set(
+      activeSeenAlerts.map((a) => a.fingerprint)
+    );
+
+    const resolvedAlerts = await prisma.resolvedAlert.findMany({
+      where,
+      orderBy: { resolvedAt: "desc" },
+      take: options?.limit,
+      skip: options?.offset,
+      select: {
+        id: true,
+        serverId: true,
+        serverName: true,
+        severity: true,
+        category: true,
+        title: true,
+        description: true,
+        details: true,
+        sourceType: true,
+        sourceName: true,
+        fingerprint: true,
+        firstSeenAt: true,
+        resolvedAt: true,
+        duration: true,
+      },
+    });
+
+    const nonActiveResolved = resolvedAlerts.filter(
+      (alert) => !activeFingerprintSet.has(alert.fingerprint)
+    );
 
     return {
-      alerts: resolvedAlerts.map((alert) => ({
+      alerts: nonActiveResolved.map((alert) => ({
         id: alert.id,
         serverId: alert.serverId,
         serverName: alert.serverName,
@@ -273,7 +286,7 @@ class AlertService {
         resolvedAt: alert.resolvedAt.toISOString(),
         duration: alert.duration,
       })),
-      total,
+      total: nonActiveResolved.length,
     };
   }
 }

--- a/apps/api/src/services/alerts/alert.service.ts
+++ b/apps/api/src/services/alerts/alert.service.ts
@@ -194,6 +194,7 @@ class AlertService {
       workspaceId: string;
       severity?: string;
       category?: string;
+      fingerprint?: { notIn: string[] };
       OR?: Array<{
         sourceType: string;
         fingerprint?: { contains: string };
@@ -231,45 +232,44 @@ class AlertService {
     }
 
     // Exclude fingerprints that are currently active (SeenAlert with resolvedAt: null).
-    // This prevents the same alert from appearing in both the active alerts list and
-    // the resolved alerts history when an alert recurs after being resolved.
+    // Pushing this into the DB query (rather than filtering in-memory) ensures that
+    // take/skip pagination and the total count remain correct.
     const activeSeenAlerts = await prisma.seenAlert.findMany({
       where: { serverId, workspaceId, resolvedAt: null },
       select: { fingerprint: true },
     });
-    const activeFingerprintSet = new Set(
-      activeSeenAlerts.map((a) => a.fingerprint)
-    );
+    const activeFingerprints = activeSeenAlerts.map((a) => a.fingerprint);
+    if (activeFingerprints.length > 0) {
+      where.fingerprint = { notIn: activeFingerprints };
+    }
 
-    const resolvedAlerts = await prisma.resolvedAlert.findMany({
-      where,
-      orderBy: { resolvedAt: "desc" },
-      take: options?.limit,
-      skip: options?.offset,
-      select: {
-        id: true,
-        serverId: true,
-        serverName: true,
-        severity: true,
-        category: true,
-        title: true,
-        description: true,
-        details: true,
-        sourceType: true,
-        sourceName: true,
-        fingerprint: true,
-        firstSeenAt: true,
-        resolvedAt: true,
-        duration: true,
-      },
-    });
-
-    const nonActiveResolved = resolvedAlerts.filter(
-      (alert) => !activeFingerprintSet.has(alert.fingerprint)
-    );
+    const [resolvedAlerts, total] = await Promise.all([
+      prisma.resolvedAlert.findMany({
+        where,
+        orderBy: { resolvedAt: "desc" },
+        take: options?.limit,
+        skip: options?.offset,
+        select: {
+          id: true,
+          serverId: true,
+          serverName: true,
+          severity: true,
+          category: true,
+          title: true,
+          description: true,
+          details: true,
+          sourceType: true,
+          sourceName: true,
+          firstSeenAt: true,
+          resolvedAt: true,
+          duration: true,
+        },
+      }),
+      prisma.resolvedAlert.count({ where }),
+    ]);
 
     return {
-      alerts: nonActiveResolved.map((alert) => ({
+      alerts: resolvedAlerts.map((alert) => ({
         id: alert.id,
         serverId: alert.serverId,
         serverName: alert.serverName,
@@ -286,7 +286,7 @@ class AlertService {
         resolvedAt: alert.resolvedAt.toISOString(),
         duration: alert.duration,
       })),
-      total: nonActiveResolved.length,
+      total,
     };
   }
 }


### PR DESCRIPTION
## Summary

- **Fix `serverName` shadowing (HIGH)** — A local `const serverName` on line 475 shadowed the function parameter, risking `"Unknown Server"` being passed to webhook and Slack services. Now uses the guaranteed function parameter throughout.
- **Remove redundant `alertsToNotify` filter (MEDIUM)** — The 30-line `newAlerts.filter(...)` block re-computed the exact same `shouldNotify` logic against the same `seenAlerts` snapshot already used to build `newAlerts`. Replaced with a direct alias.
- **Fix default `notificationSeverities` (MEDIUM)** — Default was `["critical", "warning", "info"]` but the module docs explicitly state info alerts are excluded from notifications. Changed to `["critical", "warning"]`.
- **Remove unused `resolvedServerName` alias** — Was a no-op `const resolvedServerName = serverName`.
- **Document intentional patterns** — Added comments explaining the N+1 DB write loop and the vhost `contains` fingerprint pattern.

## Tests

Adds `alert.notification.test.ts` — 46 tests covering:
- Alert tracking (new, existing, info, community mode)
- Notification decision: new alert, cooldown (within / expired), `firstSeenAt` fallback, resolved-and-returned
- Workspace settings: `emailNotificationsEnabled`, `contactEmail`, `notificationServerIds`
- Feature flag gating: `ALERTING`, `WEBHOOK_INTEGRATION`, `SLACK_INTEGRATION`
- `serverName` parameter correctness for email, webhook, and Slack
- `emailSentAt` marking and failure case
- Auto-resolution: marking resolved, `ResolvedAlert` creation with correct `serverName`, duration, no-op when still active
- Multiple alerts: single email batch, partial cooldown filtering
- Error resilience: email, webhook, Slack, and `resolvedAlert.create` failures

## Test plan

- [x] `pnpm run test:run` in `apps/api` — 624 passed, 1 skipped (pre-existing)
- [ ] Verify in staging that alert emails still fire correctly for new critical/warning alerts
- [ ] Verify info alerts do not trigger emails on workspaces without explicit info severity config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Alerts Notification Workflow reference.

* **New Features**
  * Multi-channel notifications: Email, webhook, and Slack with per-channel gating and aggregated multi-alert emails.
  * Notification status tracking (email send timestamps) and server name propagation.

* **Bug Fixes**
  * Default notifications exclude INFO-level alerts.
  * Improved vhost-scoped auto-resolution and resolved-alert listings now omit currently active alerts.

* **Tests**
  * Added extensive unit tests covering notification flows and resolved-alert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->