### PR TITLE
fix: use absolute callback url for google oauth to prevent redirect to api server

### DIFF
--- a/apps/app/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/app/src/components/auth/GoogleLoginButton.tsx
@@ -28,7 +28,7 @@ export const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({
     try {
       await authClient.signIn.social({
         provider: "google",
-        callbackURL: "/workspace",
+        callbackURL: `${window.location.origin}/workspace`,
       });
     } catch (error) {
       logger.error("Google login failed:", error);


### PR DESCRIPTION
## Summary

- `callbackURL: "/workspace"` was a relative path that better-auth resolved against the API base URL (`localhost:3000`), redirecting users to the API server after Google sign-in instead of the frontend
- Changed to `window.location.origin + "/workspace"` so the redirect always targets the correct frontend origin in all environments

## Test plan

- [ ] Click "Sign in with Google" on the login page
- [ ] Complete Google OAuth flow
- [ ] Verify redirect lands on the frontend `/workspace` page, not a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Google login redirect handling to work correctly across different deployment environments by using dynamic origin-based configuration instead of static paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->