### PR TITLE
feat(app): add role selector to workspace invite members

### DIFF
--- a/apps/api/src/core/better-auth.ts
+++ b/apps/api/src/core/better-auth.ts
@@ -306,19 +306,23 @@ export const auth = betterAuth({
         after: async (user) => {
           const baUser = user as Record<string, unknown>;
 
-          // Auto-start Enterprise trial for cloud users (fire-and-forget)
+          // Auto-start Enterprise trial for cloud users
+          // Awaited so the subscription exists before the auth callback returns
+          // and the frontend can fetch the correct plan on first load.
           if (isCloudMode()) {
-            StripeCustomerService.provisionTrialForNewUser({
-              userId: user.id,
-              email: user.email,
-              name: user.name || "",
-              prisma,
-            }).catch((error) => {
+            try {
+              await StripeCustomerService.provisionTrialForNewUser({
+                userId: user.id,
+                email: user.email,
+                name: user.name || "",
+                prisma,
+              });
+            } catch (error) {
               logger.warn(
                 { error, userId: user.id },
                 "Failed to auto-start trial at registration"
               );
-            });
+            }
           }
 
           // Auto-verify email when email service is disabled (self-hosted/binary)

--- a/apps/api/src/trpc/routers/workspace/plan.ts
+++ b/apps/api/src/trpc/routers/workspace/plan.ts
@@ -77,7 +77,10 @@ export const planRouter = router({
         });
       }
 
-      // Always use workspace owner's subscription plan for workspace features
+      // Always use workspace owner's subscription plan for workspace features.
+      // When no workspace exists yet (e.g. first signup), fall back to the
+      // user's own subscription so trial features are available during
+      // workspace creation.
       let workspacePlan: UserPlan = UserPlan.FREE;
       const currentWorkspace = userWithSubscription.workspace;
 
@@ -93,6 +96,9 @@ export const planRouter = router({
         if (ownerSubscription) {
           workspacePlan = ownerSubscription.plan;
         }
+      } else if (userWithSubscription.subscription) {
+        // No workspace yet — use the user's own subscription (e.g. trial)
+        workspacePlan = userWithSubscription.subscription.plan;
       }
 
       // Self-hosted fallback: if no Stripe subscription exists, use the license JWT tier

--- a/apps/app/public/locales/en/workspace.json
+++ b/apps/app/public/locales/en/workspace.json
@@ -15,7 +15,11 @@
     "invitePlaceholder": "Type an email and press Enter to add",
     "inviteHintWithLimit": "You can invite up to {{count}} members on your current plan",
     "upgradeToInvite": "Upgrade to the Developer or Enterprise plan to invite team members.",
-    "invalidEmail": "Please enter a valid email address"
+    "invalidEmail": "Please enter a valid email address",
+    "role": "Role",
+    "selectRole": "Select a role",
+    "roleMember": "Member",
+    "roleAdmin": "Admin"
   },
   "createForm": {
     "title": "Create New Workspace",
@@ -30,6 +34,10 @@
     "invitePlaceholder": "Type an email and press Enter to add",
     "inviteHintWithLimit": "You can invite up to {{count}} members on your current plan",
     "upgradeToInvite": "Upgrade to the Developer or Enterprise plan to invite team members.",
+    "role": "Role",
+    "selectRole": "Select a role",
+    "roleMember": "Member",
+    "roleAdmin": "Admin",
     "cancel": "Cancel",
     "creating": "Creating...",
     "submit": "Create Workspace"

--- a/apps/app/public/locales/es/workspace.json
+++ b/apps/app/public/locales/es/workspace.json
@@ -15,7 +15,11 @@
     "invitePlaceholder": "Escribe un correo y presiona Enter para agregar",
     "inviteHintWithLimit": "Puedes invitar hasta {{count}} miembros con tu plan actual",
     "upgradeToInvite": "Actualiza al plan Developer o Enterprise para invitar miembros del equipo.",
-    "invalidEmail": "Por favor ingresa una dirección de correo válida"
+    "invalidEmail": "Por favor ingresa una dirección de correo válida",
+    "role": "Rol",
+    "selectRole": "Seleccionar un rol",
+    "roleMember": "Miembro",
+    "roleAdmin": "Admin"
   },
   "createForm": {
     "title": "Crear nuevo espacio de trabajo",
@@ -30,6 +34,10 @@
     "invitePlaceholder": "Escribe un correo y presiona Enter para agregar",
     "inviteHintWithLimit": "Puedes invitar hasta {{count}} miembros con tu plan actual",
     "upgradeToInvite": "Actualiza al plan Developer o Enterprise para invitar miembros del equipo.",
+    "role": "Rol",
+    "selectRole": "Seleccionar un rol",
+    "roleMember": "Miembro",
+    "roleAdmin": "Admin",
     "cancel": "Cancelar",
     "creating": "Creando...",
     "submit": "Crear espacio de trabajo"

--- a/apps/app/public/locales/fr/workspace.json
+++ b/apps/app/public/locales/fr/workspace.json
@@ -15,7 +15,11 @@
     "invitePlaceholder": "Saisissez un e-mail et appuyez sur Entrée",
     "inviteHintWithLimit": "Vous pouvez inviter jusqu'à {{count}} membres avec votre forfait actuel",
     "upgradeToInvite": "Passez au forfait Developer ou Enterprise pour inviter des membres.",
-    "invalidEmail": "Veuillez saisir une adresse e-mail valide"
+    "invalidEmail": "Veuillez saisir une adresse e-mail valide",
+    "role": "Rôle",
+    "selectRole": "Sélectionner un rôle",
+    "roleMember": "Membre",
+    "roleAdmin": "Admin"
   },
   "createForm": {
     "title": "Créer un nouvel espace de travail",
@@ -30,6 +34,10 @@
     "invitePlaceholder": "Saisissez un e-mail et appuyez sur Entrée",
     "inviteHintWithLimit": "Vous pouvez inviter jusqu'à {{count}} membres avec votre forfait actuel",
     "upgradeToInvite": "Passez au forfait Developer ou Enterprise pour inviter des membres.",
+    "role": "Rôle",
+    "selectRole": "Sélectionner un rôle",
+    "roleMember": "Membre",
+    "roleAdmin": "Admin",
     "cancel": "Annuler",
     "creating": "Création...",
     "submit": "Créer l'espace de travail"

--- a/apps/app/public/locales/zh/workspace.json
+++ b/apps/app/public/locales/zh/workspace.json
@@ -15,7 +15,11 @@
     "invitePlaceholder": "输入邮箱地址并按回车添加",
     "inviteHintWithLimit": "您当前的计划最多可邀请 {{count}} 名成员",
     "upgradeToInvite": "升级到 Developer 或 Enterprise 计划以邀请团队成员。",
-    "invalidEmail": "请输入有效的邮箱地址"
+    "invalidEmail": "请输入有效的邮箱地址",
+    "role": "角色",
+    "selectRole": "选择角色",
+    "roleMember": "成员",
+    "roleAdmin": "管理员"
   },
   "createForm": {
     "title": "创建新工作区",
@@ -30,6 +34,10 @@
     "invitePlaceholder": "输入邮箱地址并按回车添加",
     "inviteHintWithLimit": "您当前的计划最多可邀请 {{count}} 名成员",
     "upgradeToInvite": "升级到 Developer 或 Enterprise 计划以邀请团队成员。",
+    "role": "角色",
+    "selectRole": "选择角色",
+    "roleMember": "成员",
+    "roleAdmin": "管理员",
     "cancel": "取消",
     "creating": "创建中...",
     "submit": "创建工作区"

--- a/apps/app/src/components/AddServerFormComponent/RabbitMqVersionInfo.tsx
+++ b/apps/app/src/components/AddServerFormComponent/RabbitMqVersionInfo.tsx
@@ -70,9 +70,9 @@ export const RabbitMqVersionInfo = ({
     <div className={className}>
       {/* Management Plugin Requirement Notice */}
       {!isManagementAlertDismissed && (
-        <Alert className="mb-4 border-blue-200 bg-blue-50 relative">
-          <InfoIcon className="h-4 w-4 text-blue-600" />
-          <AlertDescription className="text-blue-800 pr-8">
+        <Alert className="mb-4 border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950 relative">
+          <InfoIcon className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+          <AlertDescription className="text-blue-800 dark:text-blue-200 pr-8">
             <div className="font-medium mb-1">
               RabbitMQ Management Plugin Required
             </div>
@@ -85,7 +85,7 @@ export const RabbitMqVersionInfo = ({
             </p>
             <p className="text-xs mt-2 opacity-90">
               To enable:{" "}
-              <span className="bg-blue-100 px-1 py-0.5 rounded text-xs font-mono">
+              <span className="bg-blue-100 dark:bg-blue-900 px-1 py-0.5 rounded text-xs font-mono">
                 rabbitmq-plugins enable rabbitmq_management
               </span>
             </p>
@@ -94,7 +94,7 @@ export const RabbitMqVersionInfo = ({
             variant="ghost"
             size="sm"
             onClick={() => setIsManagementAlertDismissed(true)}
-            className="absolute top-2 right-6 h-5 w-5 p-0"
+            className="absolute top-2 right-6 h-5 w-5 p-0 hover:bg-blue-200 dark:hover:bg-blue-800 text-blue-600 dark:text-blue-400"
           >
             <X
               className="h-3 w-3 cursor-pointer"
@@ -116,7 +116,7 @@ export const RabbitMqVersionInfo = ({
               variant="ghost"
               size="sm"
               onClick={() => setIsExpanded(!isExpanded)}
-              className="h-6 w-6 p-0 hover:bg-gray-100"
+              className="h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-800"
             >
               {isExpanded ? (
                 <ChevronUp className="h-4 w-4" />

--- a/apps/app/src/components/CreateWorkspaceForm.tsx
+++ b/apps/app/src/components/CreateWorkspaceForm.tsx
@@ -51,6 +51,8 @@ export function CreateWorkspaceForm({
   const {
     inviteEmails,
     setInviteEmails,
+    inviteRole,
+    setInviteRole,
     inviteLinks,
     canInviteUsers,
     maxInvites,
@@ -192,6 +194,8 @@ export function CreateWorkspaceForm({
               <InviteMembersSection
                 inviteEmails={inviteEmails}
                 setInviteEmails={setInviteEmails}
+                inviteRole={inviteRole}
+                setInviteRole={setInviteRole}
                 canInviteUsers={canInviteUsers}
                 maxInvites={maxInvites}
                 disabled={createWorkspaceMutation.isPending}

--- a/apps/app/src/components/CreateWorkspaceForm.tsx
+++ b/apps/app/src/components/CreateWorkspaceForm.tsx
@@ -86,6 +86,7 @@ export function CreateWorkspaceForm({
           queryClient.invalidateQueries({ queryKey: ["workspaces"] });
           refreshWorkspace();
           setInviteEmails([]);
+          setInviteRole("MEMBER");
           onClose();
           form.reset();
         },

--- a/apps/app/src/components/InviteMembersSection.tsx
+++ b/apps/app/src/components/InviteMembersSection.tsx
@@ -3,11 +3,21 @@ import { useTranslation } from "react-i18next";
 import { Info, UserPlus } from "lucide-react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { TagsInput } from "@/components/ui/tags-input";
 
 interface InviteMembersSectionProps {
   inviteEmails: string[];
   setInviteEmails: (emails: string[]) => void;
+  inviteRole: "ADMIN" | "MEMBER";
+  setInviteRole: (role: "ADMIN" | "MEMBER") => void;
   canInviteUsers: boolean;
   maxInvites?: number;
   disabled?: boolean;
@@ -18,6 +28,8 @@ interface InviteMembersSectionProps {
 export function InviteMembersSection({
   inviteEmails,
   setInviteEmails,
+  inviteRole,
+  setInviteRole,
   canInviteUsers,
   maxInvites,
   disabled,
@@ -44,6 +56,30 @@ export function InviteMembersSection({
             maxTagLength={100}
             disabled={disabled}
           />
+
+          <div className="space-y-1">
+            <Label className="text-sm">{t(`${i18nPrefix}.role`)}</Label>
+            <Select
+              value={inviteRole}
+              onValueChange={(value) =>
+                setInviteRole(value as "ADMIN" | "MEMBER")
+              }
+              disabled={disabled}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder={t(`${i18nPrefix}.selectRole`)} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="MEMBER">
+                  {t(`${i18nPrefix}.roleMember`)}
+                </SelectItem>
+                <SelectItem value="ADMIN">
+                  {t(`${i18nPrefix}.roleAdmin`)}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
           {maxInvites && (
             <p className="text-xs text-muted-foreground">
               {t(`${i18nPrefix}.inviteHintWithLimit`, { count: maxInvites })}

--- a/apps/app/src/components/InviteMembersSection.tsx
+++ b/apps/app/src/components/InviteMembersSection.tsx
@@ -13,6 +13,14 @@ import {
 } from "@/components/ui/select";
 import { TagsInput } from "@/components/ui/tags-input";
 
+export interface InviteFieldsLabels {
+  emailPlaceholder: string;
+  role: string;
+  selectRole: string;
+  roleMember: string;
+  roleAdmin: string;
+}
+
 interface InviteMembersSectionProps {
   inviteEmails: string[];
   setInviteEmails: (emails: string[]) => void;
@@ -23,8 +31,18 @@ interface InviteMembersSectionProps {
   disabled?: boolean;
   /** i18n key prefix — "create" for Workspace page, "createForm" for the modal */
   i18nPrefix?: "create" | "createForm";
+  /** Override labels (when used outside the workspace i18n namespace) */
+  labels?: InviteFieldsLabels;
+  /** Hide the header with icon + "Invite Members (Optional)" */
+  hideHeader?: boolean;
+  /** Show email label above input */
+  emailLabel?: string;
 }
 
+/**
+ * Shared email + role invite fields.
+ * Used in workspace creation (modal & post-signup) and team settings invite dialog.
+ */
 export function InviteMembersSection({
   inviteEmails,
   setInviteEmails,
@@ -34,31 +52,48 @@ export function InviteMembersSection({
   maxInvites,
   disabled,
   i18nPrefix = "create",
+  labels,
+  hideHeader,
+  emailLabel,
 }: InviteMembersSectionProps) {
   const { t } = useTranslation("workspace");
 
+  // Use explicit labels if provided, otherwise derive from workspace i18n prefix
+  const l: InviteFieldsLabels = labels ?? {
+    emailPlaceholder: t(`${i18nPrefix}.invitePlaceholder`),
+    role: t(`${i18nPrefix}.role`),
+    selectRole: t(`${i18nPrefix}.selectRole`),
+    roleMember: t(`${i18nPrefix}.roleMember`),
+    roleAdmin: t(`${i18nPrefix}.roleAdmin`),
+  };
+
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <UserPlus className="h-4 w-4 text-muted-foreground" />
-        <span className="text-sm font-medium">
-          {t(`${i18nPrefix}.inviteMembers`)} ({t(`${i18nPrefix}.optional`)})
-        </span>
-      </div>
+      {!hideHeader && (
+        <div className="flex items-center gap-2">
+          <UserPlus className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium">
+            {t(`${i18nPrefix}.inviteMembers`)} ({t(`${i18nPrefix}.optional`)})
+          </span>
+        </div>
+      )}
 
       {canInviteUsers ? (
-        <>
-          <TagsInput
-            value={inviteEmails}
-            onChange={setInviteEmails}
-            placeholder={t(`${i18nPrefix}.invitePlaceholder`)}
-            maxTags={maxInvites}
-            maxTagLength={100}
-            disabled={disabled}
-          />
+        <div className="space-y-4">
+          <div className="space-y-2">
+            {emailLabel && <Label>{emailLabel}</Label>}
+            <TagsInput
+              value={inviteEmails}
+              onChange={setInviteEmails}
+              placeholder={l.emailPlaceholder}
+              maxTags={maxInvites}
+              maxTagLength={100}
+              disabled={disabled}
+            />
+          </div>
 
-          <div className="space-y-1">
-            <Label className="text-sm">{t(`${i18nPrefix}.role`)}</Label>
+          <div className="space-y-2">
+            <Label className="text-sm">{l.role}</Label>
             <Select
               value={inviteRole}
               onValueChange={(value) =>
@@ -67,15 +102,11 @@ export function InviteMembersSection({
               disabled={disabled}
             >
               <SelectTrigger>
-                <SelectValue placeholder={t(`${i18nPrefix}.selectRole`)} />
+                <SelectValue placeholder={l.selectRole} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="MEMBER">
-                  {t(`${i18nPrefix}.roleMember`)}
-                </SelectItem>
-                <SelectItem value="ADMIN">
-                  {t(`${i18nPrefix}.roleAdmin`)}
-                </SelectItem>
+                <SelectItem value="MEMBER">{l.roleMember}</SelectItem>
+                <SelectItem value="ADMIN">{l.roleAdmin}</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -85,7 +116,7 @@ export function InviteMembersSection({
               {t(`${i18nPrefix}.inviteHintWithLimit`, { count: maxInvites })}
             </p>
           )}
-        </>
+        </div>
       ) : (
         <Alert>
           <Info className="h-4 w-4" />

--- a/apps/app/src/components/profile/InviteUserDialogEnhanced.tsx
+++ b/apps/app/src/components/profile/InviteUserDialogEnhanced.tsx
@@ -3,6 +3,10 @@ import { useTranslation } from "react-i18next";
 import { AlertTriangle, Info } from "lucide-react";
 import { toast } from "sonner";
 
+import {
+  InviteFieldsLabels,
+  InviteMembersSection,
+} from "@/components/InviteMembersSection";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,15 +16,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { TagsInput } from "@/components/ui/tags-input";
 
 import { InviteFormState } from "./profileUtils";
 
@@ -65,6 +60,14 @@ export const InviteUserDialog = ({
     }
   };
 
+  const labels: InviteFieldsLabels = {
+    emailPlaceholder: t("invite.emailPlaceholder"),
+    role: t("invite.role"),
+    selectRole: t("invite.selectRole"),
+    roleMember: t("invite.member"),
+    roleAdmin: t("invite.admin"),
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -104,39 +107,18 @@ export const InviteUserDialog = ({
         )}
 
         <div className="space-y-4">
-          <div className="space-y-2">
-            <Label>{t("invite.emailAddress")}</Label>
-            <TagsInput
-              value={inviteForm.emails}
-              onChange={handleEmailsChange}
-              placeholder={t("invite.emailPlaceholder")}
-              maxTags={remainingSlots}
-              maxTagLength={100}
-              disabled={isInviting || !canInvite}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="role">{t("invite.role")}</Label>
-            <Select
-              value={inviteForm.role}
-              onValueChange={(value) =>
-                setInviteForm({
-                  ...inviteForm,
-                  role: value as "ADMIN" | "MEMBER",
-                })
-              }
-              disabled={isInviting || !canInvite}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder={t("invite.selectRole")} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="MEMBER">{t("invite.member")}</SelectItem>
-                <SelectItem value="ADMIN">{t("invite.admin")}</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          <InviteMembersSection
+            inviteEmails={inviteForm.emails}
+            setInviteEmails={handleEmailsChange}
+            inviteRole={inviteForm.role}
+            setInviteRole={(role) => setInviteForm({ ...inviteForm, role })}
+            canInviteUsers={canInvite}
+            maxInvites={remainingSlots}
+            disabled={isInviting || !canInvite}
+            labels={labels}
+            hideHeader
+            emailLabel={t("invite.emailAddress")}
+          />
 
           <div className="flex justify-end space-x-2">
             <Button

--- a/apps/app/src/hooks/ui/useWorkspaceInvites.ts
+++ b/apps/app/src/hooks/ui/useWorkspaceInvites.ts
@@ -18,8 +18,10 @@ export function useWorkspaceInvites() {
   const { planData } = useUser();
   const sendInvitationMutation = useSendInvitation();
   const [inviteEmails, setInviteEmails] = useState<string[]>([]);
+  const [inviteRole, setInviteRole] = useState<"ADMIN" | "MEMBER">("MEMBER");
   const [inviteLinks, setInviteLinks] = useState<InviteLink[]>([]);
   const pendingInvites = useRef<string[]>([]);
+  const pendingRole = useRef<"ADMIN" | "MEMBER">("MEMBER");
   const pendingCount = useRef(0);
   const batchIdRef = useRef(0);
 
@@ -41,7 +43,8 @@ export function useWorkspaceInvites() {
 
   const storePendingInvites = useCallback(() => {
     pendingInvites.current = [...inviteEmails];
-  }, [inviteEmails]);
+    pendingRole.current = inviteRole;
+  }, [inviteEmails, inviteRole]);
 
   const sendPendingInvites = useCallback((): Promise<InviteLink[]> => {
     const emails = pendingInvites.current;
@@ -68,7 +71,7 @@ export function useWorkspaceInvites() {
 
       emails.forEach((email) => {
         sendInvitationMutation.mutate(
-          { email, role: "MEMBER" },
+          { email, role: pendingRole.current },
           {
             onSuccess: (data) => {
               if (currentBatchId !== batchIdRef.current) return;
@@ -105,14 +108,18 @@ export function useWorkspaceInvites() {
   const reset = useCallback(() => {
     batchIdRef.current++;
     setInviteEmails([]);
+    setInviteRole("MEMBER");
     setInviteLinks([]);
     pendingInvites.current = [];
+    pendingRole.current = "MEMBER";
     pendingCount.current = 0;
   }, []);
 
   return {
     inviteEmails,
     setInviteEmails: handleInviteEmailsChange,
+    inviteRole,
+    setInviteRole,
     inviteLinks,
     canInviteUsers,
     maxInvites,

--- a/apps/app/src/pages/Workspace.tsx
+++ b/apps/app/src/pages/Workspace.tsx
@@ -47,6 +47,8 @@ const Workspace = () => {
   const {
     inviteEmails,
     setInviteEmails,
+    inviteRole,
+    setInviteRole,
     inviteLinks,
     canInviteUsers,
     maxInvites,
@@ -269,6 +271,8 @@ const Workspace = () => {
                       <InviteMembersSection
                         inviteEmails={inviteEmails}
                         setInviteEmails={setInviteEmails}
+                        inviteRole={inviteRole}
+                        setInviteRole={setInviteRole}
                         canInviteUsers={canInviteUsers}
                         maxInvites={maxInvites}
                         disabled={createWorkspaceMutation.isPending}

--- a/apps/app/src/pages/Workspace.tsx
+++ b/apps/app/src/pages/Workspace.tsx
@@ -32,7 +32,6 @@ import {
   useCreateWorkspace,
   useUserWorkspaces,
 } from "@/hooks/queries/useWorkspaceApi";
-import { useUser } from "@/hooks/ui/useUser";
 import { useWorkspaceInvites } from "@/hooks/ui/useWorkspaceInvites";
 
 import { WorkspaceFormData, workspaceSchema } from "@/schemas";
@@ -41,7 +40,6 @@ const Workspace = () => {
   const { t } = useTranslation("workspace");
   const navigate = useNavigate();
   const { user, updateUser } = useAuth();
-  const { refetchPlan } = useUser();
   const queryClient = useQueryClient();
   const [showSuccess, setShowSuccess] = useState(false);
   const isCreatingRef = useRef(false);
@@ -58,18 +56,6 @@ const Workspace = () => {
     sendPendingInvites,
     reset: resetInvites,
   } = useWorkspaceInvites();
-
-  // Trial provisioning happens async after OAuth callback — the initial
-  // plan fetch may return FREE before the subscription is created.
-  // Retry once after a short delay so the invite section appears.
-  const hasRetried = useRef(false);
-  useEffect(() => {
-    if (!canInviteUsers && !hasRetried.current) {
-      hasRetried.current = true;
-      const timer = setTimeout(() => refetchPlan(), 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [canInviteUsers, refetchPlan]);
 
   // Check if user already has workspaces
   const { data: workspacesData, isLoading: workspacesLoading } =

--- a/apps/app/src/pages/Workspace.tsx
+++ b/apps/app/src/pages/Workspace.tsx
@@ -32,6 +32,7 @@ import {
   useCreateWorkspace,
   useUserWorkspaces,
 } from "@/hooks/queries/useWorkspaceApi";
+import { useUser } from "@/hooks/ui/useUser";
 import { useWorkspaceInvites } from "@/hooks/ui/useWorkspaceInvites";
 
 import { WorkspaceFormData, workspaceSchema } from "@/schemas";
@@ -40,6 +41,7 @@ const Workspace = () => {
   const { t } = useTranslation("workspace");
   const navigate = useNavigate();
   const { user, updateUser } = useAuth();
+  const { refetchPlan } = useUser();
   const queryClient = useQueryClient();
   const [showSuccess, setShowSuccess] = useState(false);
   const isCreatingRef = useRef(false);
@@ -56,6 +58,18 @@ const Workspace = () => {
     sendPendingInvites,
     reset: resetInvites,
   } = useWorkspaceInvites();
+
+  // Trial provisioning happens async after OAuth callback — the initial
+  // plan fetch may return FREE before the subscription is created.
+  // Retry once after a short delay so the invite section appears.
+  const hasRetried = useRef(false);
+  useEffect(() => {
+    if (!canInviteUsers && !hasRetried.current) {
+      hasRetried.current = true;
+      const timer = setTimeout(() => refetchPlan(), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [canInviteUsers, refetchPlan]);
 
   // Check if user already has workspaces
   const { data: workspacesData, isLoading: workspacesLoading } =

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -314,7 +314,7 @@
 
     /* Orange primary theme for dark mode */
     --primary: 25 95% 53%;
-    --primary-foreground: 20 14.3% 4.1%;
+    --primary-foreground: 0 0% 98%;
 
     --secondary: 25 14% 12%;
     --secondary-foreground: 0 0% 95%;


### PR DESCRIPTION
## Summary
- Added a role dropdown (Member/Admin) to the invite members section in both the workspace creation modal and the post-signup workspace page
- Previously, all invited users were hardcoded as `MEMBER` — now workspace creators can choose the role at invite time
- Consistent with the existing role selector in the team settings invite dialog (`/settings/team`)

## Test plan
- [ ] Open the workspace creation modal (click "Créer un nouvel espace de travail" from the workspace selector) and verify the role dropdown appears below the email input
- [ ] Navigate to `/workspace` (post-signup page) and verify the role dropdown appears
- [ ] Invite a user as Admin and verify the invitation is created with the Admin role
- [ ] Invite a user as Member (default) and verify the invitation is created with the Member role
- [ ] Verify translations render correctly in all 4 locales (en, fr, es, zh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role selection (Admin/Member) added to invite UI and persisted through the invite flow; workspace creation uses this selection.

* **Localization**
  * Added role-selection strings in English, Spanish, French, and Chinese.

* **Style**
  * Improved dark-mode visuals and color contrast for workspace management UI.

* **Refactor**
  * Unified invite UI by replacing local invite controls with a shared InviteMembersSection.

* **Bug Fixes**
  * Ensure enterprise trial provisioning is awaited so plan state is accurate on first load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->