### PR TITLE
fix(app): improve ui resilience during transient backend failures

### DIFF
--- a/apps/app/src/hooks/queries/usePlans.ts
+++ b/apps/app/src/hooks/queries/usePlans.ts
@@ -1,3 +1,5 @@
+import { keepPreviousData } from "@tanstack/react-query";
+
 import { trpc } from "@/lib/trpc/client";
 
 import { useAuth } from "@/contexts/AuthContextDefinition";
@@ -24,5 +26,6 @@ export const useCurrentPlan = () => {
   return trpc.workspace.plan.getCurrentPlan.useQuery(undefined, {
     enabled: isAuthenticated,
     staleTime: 30000, // 30 seconds
+    placeholderData: keepPreviousData,
   });
 };

--- a/apps/app/src/hooks/queries/useProfile.ts
+++ b/apps/app/src/hooks/queries/useProfile.ts
@@ -1,4 +1,4 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useQueryClient } from "@tanstack/react-query";
 
 import { trpc } from "@/lib/trpc/client";
 
@@ -17,6 +17,7 @@ export const useProfile = () => {
   const query = trpc.auth.session.getSession.useQuery(undefined, {
     enabled: isAuthenticated && !!workspace?.id,
     staleTime: 30000, // 30 seconds
+    placeholderData: keepPreviousData,
   });
 
   return query;

--- a/apps/app/src/hooks/queries/useWorkspaceApi.ts
+++ b/apps/app/src/hooks/queries/useWorkspaceApi.ts
@@ -1,3 +1,5 @@
+import { keepPreviousData } from "@tanstack/react-query";
+
 import { trpc } from "@/lib/trpc/client";
 
 import { useAuth } from "@/contexts/AuthContextDefinition";
@@ -95,6 +97,7 @@ export const useUserWorkspaces = () => {
   return trpc.workspace.management.getUserWorkspaces.useQuery(undefined, {
     enabled: isAuthenticated,
     staleTime: 30000, // 30 seconds
+    placeholderData: keepPreviousData,
   });
 };
 
@@ -105,6 +108,7 @@ export const useCurrentWorkspace = () => {
   return trpc.workspace.core.getCurrent.useQuery(undefined, {
     enabled: isAuthenticated,
     staleTime: 30000, // 30 seconds
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/apps/app/src/lib/queryClient.ts
+++ b/apps/app/src/lib/queryClient.ts
@@ -32,6 +32,7 @@ export const queryClient = new QueryClient({
       },
       retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
       staleTime: 5 * 60 * 1000, // 5 minutes
+      gcTime: 30 * 60 * 1000, // 30 minutes — keep cached data longer for resilience
       refetchOnWindowFocus: false,
     },
     mutations: {


### PR DESCRIPTION
## Summary
- Increase `gcTime` from default (5min) to 30 minutes — cached data survives longer during transient backend outages
- Add `placeholderData: keepPreviousData` to critical queries (`getSession`, `getCurrentPlan`, `getCurrent`, `getUserWorkspaces`) so the UI shows last known good data instead of error/loading states when background refetches fail

## Context
During the staging 500 outage (database connection exhaustion), the UI showed broken states because React Query's cached data expired and failed refetches had nothing to fall back to. These changes ensure the dashboard remains usable with stale-but-valid data during transient backend issues.

## Test plan
- [ ] Verify app loads normally with no regressions
- [ ] Simulate a backend error (e.g., stop API) — cached data should persist in the UI instead of showing error states
- [ ] Verify workspace switching still works correctly with `keepPreviousData` (previous workspace data shown briefly while new data loads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)