### PR TITLE
fix(api): add missing user image column for google oauth signup

### DIFF
--- a/apps/api/prisma/migrations/20260313233237_add_user_image_field/migration.sql
+++ b/apps/api/prisma/migrations/20260313233237_add_user_image_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "image" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -183,6 +183,7 @@ model User {
   id                      String                   @id @default(uuid())
   name                    String                   @default("")
   email                   String                   @unique
+  image                   String?
   passwordHash            String?
   firstName               String
   lastName                String

--- a/apps/api/src/core/better-auth.ts
+++ b/apps/api/src/core/better-auth.ts
@@ -120,9 +120,11 @@ export const auth = betterAuth({
     },
   },
 
-  accountLinking: {
-    enabled: true,
-    trustedProviders: ["google"],
+  account: {
+    accountLinking: {
+      enabled: true,
+      trustedProviders: ["google"],
+    },
   },
 
   socialProviders: {

--- a/apps/api/src/core/better-auth.ts
+++ b/apps/api/src/core/better-auth.ts
@@ -120,6 +120,11 @@ export const auth = betterAuth({
     },
   },
 
+  accountLinking: {
+    enabled: true,
+    trustedProviders: ["google"],
+  },
+
   socialProviders: {
     ...(googleConfig.enabled &&
       googleConfig.clientId &&

--- a/apps/api/src/mappers/auth/auth.interfaces.ts
+++ b/apps/api/src/mappers/auth/auth.interfaces.ts
@@ -16,6 +16,7 @@ type WorkspaceData = {
 export type PrismaUserWithDates = {
   id: string;
   email: string;
+  image?: string | null;
   firstName: string | null;
   lastName: string | null;
   role: string;
@@ -33,6 +34,7 @@ export type PrismaUserWithDates = {
 export type UserApiResponse = {
   id: string;
   email: string;
+  image?: string | null;
   firstName: string | null;
   lastName: string | null;
   role: string;

--- a/apps/api/src/mappers/auth/auth.mapper.ts
+++ b/apps/api/src/mappers/auth/auth.mapper.ts
@@ -17,6 +17,7 @@ export class UserMapper {
     const response: UserApiResponse = {
       id: user.id,
       email: user.email,
+      image: user.image ?? null,
       firstName: user.firstName,
       lastName: user.lastName,
       role: user.role,

--- a/apps/api/src/trpc/routers/auth/session.ts
+++ b/apps/api/src/trpc/routers/auth/session.ts
@@ -24,6 +24,7 @@ export const sessionRouter = router({
         select: {
           id: true,
           email: true,
+          image: true,
           firstName: true,
           lastName: true,
           role: true,

--- a/apps/api/src/trpc/routers/user.ts
+++ b/apps/api/src/trpc/routers/user.ts
@@ -52,6 +52,7 @@ export const userRouter = router({
               select: {
                 id: true,
                 email: true,
+                image: true,
                 firstName: true,
                 lastName: true,
                 isActive: true,
@@ -102,6 +103,7 @@ export const userRouter = router({
         select: {
           id: true,
           email: true,
+          image: true,
           firstName: true,
           lastName: true,
           role: true,
@@ -246,6 +248,7 @@ export const userRouter = router({
             select: {
               id: true,
               email: true,
+              image: true,
               firstName: true,
               lastName: true,
               role: true,
@@ -275,6 +278,7 @@ export const userRouter = router({
             select: {
               id: true,
               email: true,
+              image: true,
               firstName: true,
               lastName: true,
               role: true,
@@ -364,6 +368,7 @@ export const userRouter = router({
           select: {
             id: true,
             email: true,
+            image: true,
             firstName: true,
             lastName: true,
             role: true,
@@ -459,6 +464,7 @@ export const userRouter = router({
           select: {
             id: true,
             email: true,
+            image: true,
             firstName: true,
             lastName: true,
             role: true,


### PR DESCRIPTION
## Summary
- Add `image` column to User model in Prisma schema — better-auth stores the Google profile picture URL in this field, and its absence caused a `PrismaClientValidationError` on signup
- Enable `accountLinking` for Google in better-auth config so users who registered with email/password can later link their Google account

## Test plan
- [ ] Sign up with Google OAuth on a fresh account — should succeed
- [ ] Sign up with Google using an email that already has an email/password account — should link accounts
- [ ] Sign in with Google on an already linked account — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- User profiles can now display custom profile images, enabling users to personalize their accounts with avatar pictures and enhance their online identity
- Google account linking functionality is now available, allowing users to connect and authenticate their accounts through their existing Google credentials for seamless access and improved convenience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->