### PR TITLE
feat(web): add workspace deletion and profile settings i18n

### DIFF
--- a/apps/api/src/trpc/routers/workspace/management.ts
+++ b/apps/api/src/trpc/routers/workspace/management.ts
@@ -385,12 +385,19 @@ export const managementRouter = router({
         }
 
         // Delete the workspace in a transaction:
-        // 1. Detach all users first (User.workspace has onDelete: Cascade, so without this all user accounts would be deleted)
-        // 2. Then delete the workspace (cascade deletes related workspace data)
+        // 1. Detach users (User.workspace has onDelete: Cascade, so without this all user accounts would be deleted)
+        // 2. Delete orphan-prone records that lack onDelete: Cascade on their workspace relation
+        // 3. Delete the workspace (cascade deletes remaining related data)
         await ctx.prisma.$transaction(async (tx) => {
           await tx.user.updateMany({
             where: { workspaceId },
             data: { workspaceId: null },
+          });
+          await tx.rabbitMQServer.deleteMany({
+            where: { workspaceId },
+          });
+          await tx.feedback.deleteMany({
+            where: { workspaceId },
           });
           await tx.workspace.delete({
             where: { id: workspaceId },

--- a/apps/api/src/trpc/routers/workspace/management.ts
+++ b/apps/api/src/trpc/routers/workspace/management.ts
@@ -384,17 +384,17 @@ export const managementRouter = router({
           });
         }
 
-        // Prevent deletion of user's current workspace
-        if (workspaceId === user.workspaceId) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: te(ctx.locale, "workspace.cannotDeleteCurrentActive"),
+        // Delete the workspace in a transaction:
+        // 1. Detach all users first (User.workspace has onDelete: Cascade, so without this all user accounts would be deleted)
+        // 2. Then delete the workspace (cascade deletes related workspace data)
+        await ctx.prisma.$transaction(async (tx) => {
+          await tx.user.updateMany({
+            where: { workspaceId },
+            data: { workspaceId: null },
           });
-        }
-
-        // Delete the workspace (this will cascade delete related records)
-        await ctx.prisma.workspace.delete({
-          where: { id: workspaceId },
+          await tx.workspace.delete({
+            where: { id: workspaceId },
+          });
         });
 
         ctx.logger.info(

--- a/apps/app/public/locales/en/profile.json
+++ b/apps/app/public/locales/en/profile.json
@@ -25,7 +25,9 @@
     "copyInviteLink": "Email is disabled. Share this link with the invited user.",
     "copyLink": "Copy Link",
     "linkCopied": "Invite link copied to clipboard.",
-    "invitationFailed": "Failed to invite {{email}}: {{error}}"
+    "invitationFailed": "Failed to invite {{email}}: {{error}}",
+    "workspaceDeleted": "Workspace deleted successfully.",
+    "workspaceDeleteFailed": "Failed to delete workspace."
   },
   "invite": {
     "title": "Invite Team Members",
@@ -81,7 +83,15 @@
     "created": "Created:",
     "cancel": "Cancel",
     "saveChanges": "Save Changes",
-    "editWorkspace": "Edit Workspace"
+    "editWorkspace": "Edit Workspace",
+    "dangerZone": "Danger Zone",
+    "deleteDescription": "Permanently delete this workspace and all its data. This action cannot be undone.",
+    "deleteWorkspace": "Delete Workspace",
+    "deleteDialogTitle": "Delete Workspace",
+    "deleteDialogDescription": "This will permanently delete the workspace <strong>{{name}}</strong> and all associated data including servers, alerts, alert rules, team members, invitations, and configuration. This action is irreversible.",
+    "deleteDialogConfirmLabel": "Type the workspace name to confirm:",
+    "deleteConfirm": "Delete Workspace",
+    "deleting": "Deleting..."
   },
   "team": {
     "title": "Team",

--- a/apps/app/public/locales/es/profile.json
+++ b/apps/app/public/locales/es/profile.json
@@ -25,7 +25,9 @@
     "copyInviteLink": "El correo electrónico está deshabilitado. Comparta este enlace con el usuario invitado.",
     "copyLink": "Copiar enlace",
     "linkCopied": "Enlace de invitación copiado al portapapeles.",
-    "invitationFailed": "Error al invitar a {{email}}: {{error}}"
+    "invitationFailed": "Error al invitar a {{email}}: {{error}}",
+    "workspaceDeleted": "Espacio de trabajo eliminado con éxito.",
+    "workspaceDeleteFailed": "Error al eliminar el espacio de trabajo."
   },
   "invite": {
     "title": "Invitar miembros del equipo",
@@ -81,7 +83,15 @@
     "created": "Creado el:",
     "cancel": "Cancelar",
     "saveChanges": "Guardar cambios",
-    "editWorkspace": "Editar espacio de trabajo"
+    "editWorkspace": "Editar espacio de trabajo",
+    "dangerZone": "Zona de peligro",
+    "deleteDescription": "Eliminar permanentemente este espacio de trabajo y todos sus datos. Esta acción no se puede deshacer.",
+    "deleteWorkspace": "Eliminar espacio de trabajo",
+    "deleteDialogTitle": "Eliminar espacio de trabajo",
+    "deleteDialogDescription": "Esto eliminará permanentemente el espacio de trabajo <strong>{{name}}</strong> y todos los datos asociados, incluidos servidores, alertas, reglas de alertas, miembros del equipo, invitaciones y configuración. Esta acción es irreversible.",
+    "deleteDialogConfirmLabel": "Escribe el nombre del espacio de trabajo para confirmar:",
+    "deleteConfirm": "Eliminar espacio de trabajo",
+    "deleting": "Eliminando..."
   },
   "team": {
     "title": "Equipo",

--- a/apps/app/public/locales/fr/profile.json
+++ b/apps/app/public/locales/fr/profile.json
@@ -25,7 +25,9 @@
     "copyInviteLink": "L'e-mail est désactivé. Partagez ce lien avec l'utilisateur invité.",
     "copyLink": "Copier le lien",
     "linkCopied": "Lien d'invitation copié dans le presse-papiers.",
-    "invitationFailed": "Échec de l'invitation pour {{email}} : {{error}}"
+    "invitationFailed": "Échec de l'invitation pour {{email}} : {{error}}",
+    "workspaceDeleted": "Espace de travail supprimé avec succès.",
+    "workspaceDeleteFailed": "Échec de la suppression de l'espace de travail."
   },
   "invite": {
     "title": "Inviter des membres",
@@ -81,7 +83,15 @@
     "created": "Créé le :",
     "cancel": "Annuler",
     "saveChanges": "Enregistrer",
-    "editWorkspace": "Modifier l'espace de travail"
+    "editWorkspace": "Modifier l'espace de travail",
+    "dangerZone": "Zone de danger",
+    "deleteDescription": "Supprimer définitivement cet espace de travail et toutes ses données. Cette action est irréversible.",
+    "deleteWorkspace": "Supprimer l'espace de travail",
+    "deleteDialogTitle": "Supprimer l'espace de travail",
+    "deleteDialogDescription": "Cela supprimera définitivement l'espace de travail <strong>{{name}}</strong> et toutes les données associées, y compris les serveurs, alertes, règles d'alertes, membres de l'équipe, invitations et la configuration. Cette action est irréversible.",
+    "deleteDialogConfirmLabel": "Saisissez le nom de l'espace de travail pour confirmer :",
+    "deleteConfirm": "Supprimer l'espace de travail",
+    "deleting": "Suppression..."
   },
   "team": {
     "title": "Équipe",

--- a/apps/app/public/locales/zh/profile.json
+++ b/apps/app/public/locales/zh/profile.json
@@ -25,7 +25,9 @@
     "copyInviteLink": "邮件已禁用。请将此链接分享给被邀请的用户。",
     "copyLink": "复制链接",
     "linkCopied": "邀请链接已复制到剪贴板。",
-    "invitationFailed": "邀请 {{email}} 失败：{{error}}"
+    "invitationFailed": "邀请 {{email}} 失败：{{error}}",
+    "workspaceDeleted": "工作区删除成功。",
+    "workspaceDeleteFailed": "工作区删除失败。"
   },
   "invite": {
     "title": "邀请团队成员",
@@ -81,7 +83,15 @@
     "created": "创建日期：",
     "cancel": "取消",
     "saveChanges": "保存更改",
-    "editWorkspace": "编辑工作区"
+    "editWorkspace": "编辑工作区",
+    "dangerZone": "危险区域",
+    "deleteDescription": "永久删除此工作区及其所有数据。此操作无法撤销。",
+    "deleteWorkspace": "删除工作区",
+    "deleteDialogTitle": "删除工作区",
+    "deleteDialogDescription": "这将永久删除工作区 <strong>{{name}}</strong> 及所有关联数据，包括服务器、警报、警报规则、团队成员、邀请和配置。此操作不可逆。",
+    "deleteDialogConfirmLabel": "输入工作区名称以确认：",
+    "deleteConfirm": "删除工作区",
+    "deleting": "删除中..."
   },
   "team": {
     "title": "团队",

--- a/apps/app/src/components/profile/WorkspaceInfoTab.tsx
+++ b/apps/app/src/components/profile/WorkspaceInfoTab.tsx
@@ -1,4 +1,5 @@
-import { useTranslation } from "react-i18next";
+import { useId, useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
 
 import {
   Building2,
@@ -6,12 +7,24 @@ import {
   Edit,
   Save,
   Settings,
+  Trash2,
   Users,
   X,
 } from "lucide-react";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alertDialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { PlanBadge } from "@/components/ui/PlanBadge";
 import { Separator } from "@/components/ui/separator";
 
@@ -32,6 +45,8 @@ interface WorkspaceInfoTabProps {
   setEditingWorkspace: (editing: boolean) => void;
   onUpdateWorkspace: () => void;
   isUpdating: boolean;
+  onDeleteWorkspace: () => void;
+  isDeleting: boolean;
 }
 
 export const WorkspaceInfoTab = ({
@@ -43,9 +58,14 @@ export const WorkspaceInfoTab = ({
   setEditingWorkspace,
   onUpdateWorkspace,
   isUpdating,
+  onDeleteWorkspace,
+  isDeleting,
 }: WorkspaceInfoTabProps) => {
-  const { user, planData } = useUser();
   const { t } = useTranslation("profile");
+  const { user, planData } = useUser();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [confirmName, setConfirmName] = useState("");
+  const confirmInputId = useId();
 
   if (!workspace) {
     return <NoWorkspaceCard />;
@@ -126,6 +146,77 @@ export const WorkspaceInfoTab = ({
               </Button>
             )}
           </div>
+        )}
+
+        {user.id === workspace.ownerId && (
+          <>
+            <Separator />
+
+            <div className="rounded-lg border border-destructive/50 p-4 space-y-3">
+              <h3 className="text-lg font-semibold text-destructive">
+                {t("workspace.dangerZone")}
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                {t("workspace.deleteDescription")}
+              </p>
+              <Button
+                variant="destructive"
+                onClick={() => setDeleteDialogOpen(true)}
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                {t("workspace.deleteWorkspace")}
+              </Button>
+            </div>
+
+            <AlertDialog
+              open={deleteDialogOpen}
+              onOpenChange={(open) => {
+                setDeleteDialogOpen(open);
+                if (!open) setConfirmName("");
+              }}
+            >
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    {t("workspace.deleteDialogTitle")}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription asChild>
+                    <p>
+                      <Trans
+                        i18nKey="workspace.deleteDialogDescription"
+                        ns="profile"
+                        values={{ name: workspace.name }}
+                        components={{ strong: <strong /> }}
+                      />
+                    </p>
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <div className="space-y-2 py-2">
+                  <label htmlFor={confirmInputId} className="text-sm font-medium">
+                    {t("workspace.deleteDialogConfirmLabel")}
+                  </label>
+                  <Input
+                    id={confirmInputId}
+                    value={confirmName}
+                    onChange={(e) => setConfirmName(e.target.value)}
+                    placeholder={workspace.name}
+                  />
+                </div>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>{t("workspace.cancel")}</AlertDialogCancel>
+                  <AlertDialogAction
+                    disabled={confirmName !== workspace.name || isDeleting}
+                    onClick={onDeleteWorkspace}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    {isDeleting
+                      ? t("workspace.deleting")
+                      : t("workspace.deleteConfirm")}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </>
         )}
       </CardContent>
     </Card>

--- a/apps/app/src/hooks/queries/useWorkspaceApi.ts
+++ b/apps/app/src/hooks/queries/useWorkspaceApi.ts
@@ -121,6 +121,19 @@ export const useCreateWorkspace = () => {
   });
 };
 
+// Delete workspace
+export const useDeleteWorkspace = () => {
+  const utils = trpc.useUtils();
+
+  return trpc.workspace.management.delete.useMutation({
+    onSuccess: () => {
+      utils.auth.session.getSession.invalidate();
+      utils.workspace.management.getUserWorkspaces.invalidate();
+      utils.workspace.core.getCurrent.invalidate();
+    },
+  });
+};
+
 // Switch workspace
 export const useSwitchWorkspace = () => {
   const utils = trpc.useUtils();

--- a/apps/app/src/pages/settings/WorkspaceSection.tsx
+++ b/apps/app/src/pages/settings/WorkspaceSection.tsx
@@ -5,15 +5,22 @@ import { toast } from "sonner";
 
 import { WorkspaceFormState, WorkspaceInfoTab } from "@/components/profile";
 
+import { useNavigate } from "react-router";
+
 import { useProfile } from "@/hooks/queries/useProfile";
-import { useUpdateWorkspace } from "@/hooks/queries/useWorkspaceApi";
+import {
+  useDeleteWorkspace,
+  useUpdateWorkspace,
+} from "@/hooks/queries/useWorkspaceApi";
 import { useWorkspace } from "@/hooks/ui/useWorkspace";
 
 const WorkspaceSection = () => {
   const { t } = useTranslation("profile");
   const { workspace, refetch: refetchWorkspace } = useWorkspace();
   const { data: profileData } = useProfile();
+  const navigate = useNavigate();
   const updateWorkspaceMutation = useUpdateWorkspace();
+  const deleteWorkspaceMutation = useDeleteWorkspace();
 
   const [editingWorkspace, setEditingWorkspace] = useState(false);
   const [workspaceForm, setWorkspaceForm] = useState<WorkspaceFormState>({
@@ -33,6 +40,17 @@ const WorkspaceSection = () => {
       contactEmail: workspace.contactEmail || "",
     });
   }
+
+  const handleDeleteWorkspace = async () => {
+    if (!workspace?.id) return;
+    try {
+      await deleteWorkspaceMutation.mutateAsync({ workspaceId: workspace.id });
+      toast.success(t("toast.workspaceDeleted"));
+      navigate("/workspace", { replace: true });
+    } catch {
+      toast.error(t("toast.workspaceDeleteFailed"));
+    }
+  };
 
   const handleUpdateWorkspace = async () => {
     if (!workspace?.id) {
@@ -63,6 +81,8 @@ const WorkspaceSection = () => {
         setEditingWorkspace={setEditingWorkspace}
         onUpdateWorkspace={handleUpdateWorkspace}
         isUpdating={updateWorkspaceMutation.isPending}
+        onDeleteWorkspace={handleDeleteWorkspace}
+        isDeleting={deleteWorkspaceMutation.isPending}
       />
     </div>
   );

--- a/apps/app/src/pages/settings/WorkspaceSection.tsx
+++ b/apps/app/src/pages/settings/WorkspaceSection.tsx
@@ -10,7 +10,9 @@ import { useNavigate } from "react-router";
 import { useProfile } from "@/hooks/queries/useProfile";
 import {
   useDeleteWorkspace,
+  useSwitchWorkspace,
   useUpdateWorkspace,
+  useUserWorkspaces,
 } from "@/hooks/queries/useWorkspaceApi";
 import { useWorkspace } from "@/hooks/ui/useWorkspace";
 
@@ -21,6 +23,8 @@ const WorkspaceSection = () => {
   const navigate = useNavigate();
   const updateWorkspaceMutation = useUpdateWorkspace();
   const deleteWorkspaceMutation = useDeleteWorkspace();
+  const switchWorkspaceMutation = useSwitchWorkspace();
+  const { data: userWorkspaces } = useUserWorkspaces();
 
   const [editingWorkspace, setEditingWorkspace] = useState(false);
   const [workspaceForm, setWorkspaceForm] = useState<WorkspaceFormState>({
@@ -46,7 +50,16 @@ const WorkspaceSection = () => {
     try {
       await deleteWorkspaceMutation.mutateAsync({ workspaceId: workspace.id });
       toast.success(t("toast.workspaceDeleted"));
-      navigate("/workspace", { replace: true });
+
+      const remaining = userWorkspaces?.filter((w) => w.id !== workspace.id);
+      if (remaining?.length) {
+        await switchWorkspaceMutation.mutateAsync({
+          workspaceId: remaining[0].id,
+        });
+        navigate("/", { replace: true });
+      } else {
+        navigate("/workspace", { replace: true });
+      }
     } catch {
       toast.error(t("toast.workspaceDeleteFailed"));
     }

--- a/apps/app/src/pages/settings/WorkspaceSection.tsx
+++ b/apps/app/src/pages/settings/WorkspaceSection.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
 
 import { toast } from "sonner";
 
 import { WorkspaceFormState, WorkspaceInfoTab } from "@/components/profile";
-
-import { useNavigate } from "react-router";
 
 import { useProfile } from "@/hooks/queries/useProfile";
 import {
@@ -49,19 +48,25 @@ const WorkspaceSection = () => {
     if (!workspace?.id) return;
     try {
       await deleteWorkspaceMutation.mutateAsync({ workspaceId: workspace.id });
-      toast.success(t("toast.workspaceDeleted"));
+    } catch {
+      toast.error(t("toast.workspaceDeleteFailed"));
+      return;
+    }
 
-      const remaining = userWorkspaces?.filter((w) => w.id !== workspace.id);
-      if (remaining?.length) {
+    toast.success(t("toast.workspaceDeleted"));
+
+    const remaining = userWorkspaces?.filter((w) => w.id !== workspace.id);
+    if (remaining?.length) {
+      try {
         await switchWorkspaceMutation.mutateAsync({
           workspaceId: remaining[0].id,
         });
-        navigate("/", { replace: true });
-      } else {
-        navigate("/workspace", { replace: true });
+      } catch {
+        // Switch failed — fall through to workspace creation page
       }
-    } catch {
-      toast.error(t("toast.workspaceDeleteFailed"));
+      navigate("/", { replace: true });
+    } else {
+      navigate("/workspace", { replace: true });
     }
   };
 


### PR DESCRIPTION
## Summary
- Add workspace deletion feature with danger zone UI and name-confirmation dialog (owner-only)
- Backend delete endpoint now uses a transaction to detach users before deleting the workspace, preventing cascade deletion of user accounts
- Add comprehensive i18n translations (en/es/fr/zh) for personal, workspace, and team profile sections

## Test plan
- [ ] Verify workspace owner sees the "Danger Zone" section in workspace settings
- [ ] Verify non-owners do not see the delete option
- [ ] Confirm the delete dialog requires typing the exact workspace name before enabling the button
- [ ] Delete a workspace and verify users are detached (not deleted) and redirect to `/workspace` works
- [ ] Check all 4 locales (en/es/fr/zh) render correctly in the profile settings pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace deletion UI: confirmation dialog requiring exact workspace name, loading state, success/failure toasts, and automatic fallback (switch or navigate) after deletion.
  * Expanded multilingual support: new profile, workspace, and team localization strings (en/es/fr/zh).

* **Bug Fixes**
  * Backend deletion made transactional so workspace removal and its related data are cleaned up reliably and atomically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->