### PR TITLE
docs: add clickable demo video thumbnail to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 [Features](#-features) • [Editions](#-editions) • [Quick Start](#-quick-start) • [Documentation](#-documentation) • [Contributing](#-contributing)
 
+[![Watch the demo](apps/web/public/images/dashboard.png)](https://www.youtube.com/watch?v=g9Coi3niYIY)
+
 </div>
 
 ---


### PR DESCRIPTION
## Summary
- Adds a clickable dashboard screenshot thumbnail to the README that links to the YouTube demo video
- Placed below the title/badges section for immediate visibility

## Test plan
- [ ] Verify the thumbnail image renders correctly on GitHub
- [ ] Verify clicking the image opens the YouTube video

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a demo link badge to the README for quick access to the project demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->