### PR TITLE
fix: resolve workspace deletion flow issues

### DIFF
--- a/apps/api/src/trpc/routers/workspace/management.ts
+++ b/apps/api/src/trpc/routers/workspace/management.ts
@@ -413,6 +413,7 @@ export const managementRouter = router({
               { members: { some: { userId: user.id } } },
             ],
           },
+          orderBy: { createdAt: "desc" },
           select: { id: true },
         });
 

--- a/apps/api/src/trpc/routers/workspace/management.ts
+++ b/apps/api/src/trpc/routers/workspace/management.ts
@@ -404,10 +404,28 @@ export const managementRouter = router({
           });
         });
 
+        // Auto-switch the requesting user to their next available workspace
+        // Check both ownership and membership (same logic as getUserWorkspaces)
+        const nextWorkspace = await ctx.prisma.workspace.findFirst({
+          where: {
+            OR: [
+              { ownerId: user.id },
+              { members: { some: { userId: user.id } } },
+            ],
+          },
+          select: { id: true },
+        });
+
+        await ctx.prisma.user.update({
+          where: { id: user.id },
+          data: { workspaceId: nextWorkspace?.id ?? null },
+        });
+
         ctx.logger.info(
           {
             workspaceId,
             userId: user.id,
+            switchedTo: nextWorkspace?.id ?? null,
           },
           "Workspace deleted successfully"
         );

--- a/apps/api/src/trpc/trpc.ts
+++ b/apps/api/src/trpc/trpc.ts
@@ -156,10 +156,12 @@ export const rateLimitedAdminProcedure = adminProcedure.use(
  * Workspace ID can come from input, context, or user's workspaceId
  */
 export const workspaceProcedure = rateLimitedProcedure.use(async (opts) => {
-  const { ctx, input } = opts;
+  const { ctx } = opts;
 
-  // Try to get workspaceId from input (if provided), context, or user's workspaceId
-  const inputWorkspaceId = (input as { workspaceId?: string })?.workspaceId;
+  // Use getRawInput() because this middleware runs before .input() in the chain,
+  // so opts.input is undefined. getRawInput() accesses the actual HTTP input.
+  const rawInput = await opts.getRawInput();
+  const inputWorkspaceId = (rawInput as { workspaceId?: string })?.workspaceId;
   const workspaceId =
     inputWorkspaceId && inputWorkspaceId.trim() !== ""
       ? inputWorkspaceId

--- a/apps/api/src/trpc/trpc.ts
+++ b/apps/api/src/trpc/trpc.ts
@@ -163,7 +163,7 @@ export const workspaceProcedure = rateLimitedProcedure.use(async (opts) => {
   const rawInput = await opts.getRawInput();
   const inputWorkspaceId = (rawInput as { workspaceId?: string })?.workspaceId;
   const workspaceId =
-    inputWorkspaceId && inputWorkspaceId.trim() !== ""
+    typeof inputWorkspaceId === "string" && inputWorkspaceId.trim() !== ""
       ? inputWorkspaceId
       : ctx.workspaceId || ctx.user.workspaceId || null;
 

--- a/apps/app/src/contexts/AuthContext.tsx
+++ b/apps/app/src/contexts/AuthContext.tsx
@@ -138,7 +138,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       return updatedUser;
     } catch (error) {
       logger.error("Failed to refetch user data:", error);
-      return null;
+      throw error;
     }
   }, [utils]);
 

--- a/apps/app/src/contexts/AuthContext.tsx
+++ b/apps/app/src/contexts/AuthContext.tsx
@@ -126,7 +126,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     syncSentryUser(newUser);
   }, []);
 
-  const refetchUser = useCallback(async () => {
+  const refetchUser = useCallback(async (): Promise<User | null> => {
     try {
       const response = await utils.auth.session.getSession.fetch();
       const updatedUser = {
@@ -135,8 +135,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       };
       dispatch({ type: "SET_USER", user: updatedUser });
       syncSentryUser(updatedUser);
+      return updatedUser;
     } catch (error) {
       logger.error("Failed to refetch user data:", error);
+      return null;
     }
   }, [utils]);
 

--- a/apps/app/src/contexts/AuthContextDefinition.tsx
+++ b/apps/app/src/contexts/AuthContextDefinition.tsx
@@ -9,7 +9,7 @@ interface AuthContextType {
   login: (user: User) => void;
   logout: () => Promise<void>;
   updateUser: (user: User) => void;
-  refetchUser: () => Promise<void>;
+  refetchUser: () => Promise<User | null>;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(

--- a/apps/app/src/hooks/queries/useWorkspaceApi.ts
+++ b/apps/app/src/hooks/queries/useWorkspaceApi.ts
@@ -127,7 +127,12 @@ export const useDeleteWorkspace = () => {
 
   return trpc.workspace.management.delete.useMutation({
     onSuccess: () => {
-      // Invalidate all queries so everything refetches with the new workspace context
+      // Reset workspace queries to clear cached data immediately (not just mark stale).
+      // This prevents /workspace from seeing the deleted workspace in cache and
+      // briefly redirecting to / before the refetch completes.
+      utils.workspace.management.getUserWorkspaces.reset();
+      utils.workspace.core.getCurrent.reset();
+      // Invalidate all remaining queries so everything refetches
       utils.invalidate();
     },
   });

--- a/apps/app/src/hooks/queries/useWorkspaceApi.ts
+++ b/apps/app/src/hooks/queries/useWorkspaceApi.ts
@@ -127,9 +127,8 @@ export const useDeleteWorkspace = () => {
 
   return trpc.workspace.management.delete.useMutation({
     onSuccess: () => {
-      utils.auth.session.getSession.invalidate();
-      utils.workspace.management.getUserWorkspaces.invalidate();
-      utils.workspace.core.getCurrent.invalidate();
+      // Invalidate all queries so everything refetches with the new workspace context
+      utils.invalidate();
     },
   });
 };

--- a/apps/app/src/pages/settings/WorkspaceSection.tsx
+++ b/apps/app/src/pages/settings/WorkspaceSection.tsx
@@ -6,24 +6,23 @@ import { toast } from "sonner";
 
 import { WorkspaceFormState, WorkspaceInfoTab } from "@/components/profile";
 
+import { useAuth } from "@/contexts/AuthContextDefinition";
+
 import { useProfile } from "@/hooks/queries/useProfile";
 import {
   useDeleteWorkspace,
-  useSwitchWorkspace,
   useUpdateWorkspace,
-  useUserWorkspaces,
 } from "@/hooks/queries/useWorkspaceApi";
 import { useWorkspace } from "@/hooks/ui/useWorkspace";
 
 const WorkspaceSection = () => {
   const { t } = useTranslation("profile");
   const { workspace, refetch: refetchWorkspace } = useWorkspace();
+  const { refetchUser } = useAuth();
   const { data: profileData } = useProfile();
   const navigate = useNavigate();
   const updateWorkspaceMutation = useUpdateWorkspace();
   const deleteWorkspaceMutation = useDeleteWorkspace();
-  const switchWorkspaceMutation = useSwitchWorkspace();
-  const { data: userWorkspaces } = useUserWorkspaces();
 
   const [editingWorkspace, setEditingWorkspace] = useState(false);
   const [workspaceForm, setWorkspaceForm] = useState<WorkspaceFormState>({
@@ -53,21 +52,12 @@ const WorkspaceSection = () => {
       return;
     }
 
+    // Refetch auth user so user.workspaceId updates (auth context uses reducer state,
+    // not reactive to React Query cache invalidation)
+    const updatedUser = await refetchUser();
     toast.success(t("toast.workspaceDeleted"));
-
-    const remaining = userWorkspaces?.filter((w) => w.id !== workspace.id);
-    if (remaining?.length) {
-      try {
-        await switchWorkspaceMutation.mutateAsync({
-          workspaceId: remaining[0].id,
-        });
-      } catch {
-        // Switch failed — fall through to workspace creation page
-      }
-      navigate("/", { replace: true });
-    } else {
-      navigate("/workspace", { replace: true });
-    }
+    // Navigate directly to the right page based on whether user still has a workspace
+    navigate(updatedUser?.workspaceId ? "/" : "/workspace", { replace: true });
   };
 
   const handleUpdateWorkspace = async () => {

--- a/apps/app/src/pages/settings/WorkspaceSection.tsx
+++ b/apps/app/src/pages/settings/WorkspaceSection.tsx
@@ -54,7 +54,11 @@ const WorkspaceSection = () => {
 
     // Refetch auth user so user.workspaceId updates (auth context uses reducer state,
     // not reactive to React Query cache invalidation)
-    await refetchUser();
+    try {
+      await refetchUser();
+    } catch {
+      // Continue even if refetch fails — deletion already succeeded
+    }
     toast.success(t("toast.workspaceDeleted"));
     // Always navigate to /workspace — its loading state acts as a clean transition:
     // if user has remaining workspaces, it redirects to /; otherwise shows creation form

--- a/apps/app/src/pages/settings/WorkspaceSection.tsx
+++ b/apps/app/src/pages/settings/WorkspaceSection.tsx
@@ -54,10 +54,11 @@ const WorkspaceSection = () => {
 
     // Refetch auth user so user.workspaceId updates (auth context uses reducer state,
     // not reactive to React Query cache invalidation)
-    const updatedUser = await refetchUser();
+    await refetchUser();
     toast.success(t("toast.workspaceDeleted"));
-    // Navigate directly to the right page based on whether user still has a workspace
-    navigate(updatedUser?.workspaceId ? "/" : "/workspace", { replace: true });
+    // Always navigate to /workspace — its loading state acts as a clean transition:
+    // if user has remaining workspaces, it redirects to /; otherwise shows creation form
+    navigate("/workspace", { replace: true });
   };
 
   const handleUpdateWorkspace = async () => {


### PR DESCRIPTION
## Summary
- **Fix tRPC middleware**: `workspaceProcedure` used `opts.input` which is always `undefined` before `.input()` in tRPC v11. Switched to `getRawInput()` so the workspace ID from HTTP request input is actually read, instead of silently falling back to `ctx.user.workspaceId`
- **Fix orphaned user state**: After deleting the last workspace, `user.workspaceId` was not cleared to `null`, causing `getCurrent` 404s and stale UI. Now always updates `user.workspaceId` (to next workspace or `null`)
- **Fix redirect flash**: Auth context uses reducer state not reactive to React Query cache invalidation. `refetchUser()` now returns the updated user so the delete handler navigates directly to `/workspace` (no workspaces) or `/` (auto-switched) without a dashboard flash
- **Invalidate all queries**: `useDeleteWorkspace` now calls `utils.invalidate()` instead of 3 specific queries, preventing stale `getServers` calls with deleted workspace IDs

## Test plan
- [ ] Delete last workspace → redirects directly to `/workspace` creation page (no flash)
- [ ] Delete workspace when others exist → auto-switches and redirects to `/` dashboard
- [ ] Create new workspace after deletion → `getServers` works without BAD_REQUEST errors
- [ ] Workspace selector shows correct workspace after deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a workspace now automatically switches you to your next available workspace (or clears selection if none remain).

* **Improvements**
  * Post-deletion flow simplified: auth and workspace data are refreshed, all related data refetched, then you’re routed to the workspace landing page.
  * Auth refresh behavior enhanced so refetch reliably returns the updated user state after changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->