### PR TITLE
fix(app): add missing footer to settings pages

### DIFF
--- a/apps/app/src/components/AppFooter.tsx
+++ b/apps/app/src/components/AppFooter.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
+
+import { ExternalLink, HelpCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+import { LanguageSwitcher } from "./LanguageSwitcher";
+
+interface AppFooterProps {
+  className?: string;
+}
+
+export function AppFooter({ className = "" }: AppFooterProps) {
+  const { t } = useTranslation("common");
+
+  return (
+    <footer
+      className={`border-t bg-background/80 backdrop-blur-xs ${className}`}
+    >
+      <div className="max-w-5xl mx-auto px-6 py-6">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+          {/* Left side - Help */}
+          <div className="flex items-center gap-4">
+            <Link to="/help">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground hover:text-foreground gap-2"
+              >
+                <HelpCircle className="w-4 h-4" />
+                {t("helpAndSupport")}
+              </Button>
+            </Link>
+          </div>
+
+          {/* Center - Language Switcher */}
+          <LanguageSwitcher />
+
+          {/* Right side - App info and links */}
+          <div className="flex flex-col sm:flex-row items-center gap-4 text-sm text-muted-foreground">
+            <span>{t("rabbitMQDashboard")}</span>
+            <div className="flex items-center gap-4">
+              <a
+                href="https://www.rabbitmq.com/documentation.html"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-foreground transition-colors flex items-center gap-1"
+              >
+                {t("documentation")}
+                <ExternalLink className="w-3 h-3" />
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/app/src/components/Layout.tsx
+++ b/apps/app/src/components/Layout.tsx
@@ -1,21 +1,13 @@
 import { ReactNode } from "react";
-import { useTranslation } from "react-i18next";
-import { Link } from "react-router";
 
-import { ExternalLink, HelpCircle } from "lucide-react";
-
-import { Button } from "@/components/ui/button";
-
+import { AppFooter } from "./AppFooter";
 import { AppHeader } from "./AppHeader";
-import { LanguageSwitcher } from "./LanguageSwitcher";
 
 interface LayoutProps {
   children: ReactNode;
 }
 
 export function Layout({ children }: LayoutProps) {
-  const { t } = useTranslation("common");
-
   return (
     <div className="min-h-screen flex flex-col">
       {/* App Header with workspace selector */}
@@ -25,44 +17,7 @@ export function Layout({ children }: LayoutProps) {
       <div className="flex-1">{children}</div>
 
       {/* Footer - positioned to account for sidebar */}
-      <footer className="border-t bg-background/80 backdrop-blur-xs ml-0 md:ml-64 transition-[margin] duration-200 ease-linear">
-        <div className="max-w-5xl mx-auto px-6 py-6">
-          <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-            {/* Left side - Help */}
-            <div className="flex items-center gap-4">
-              <Link to="/help">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground hover:text-foreground gap-2"
-                >
-                  <HelpCircle className="w-4 h-4" />
-                  {t("helpAndSupport")}
-                </Button>
-              </Link>
-            </div>
-
-            {/* Center - Language Switcher */}
-            <LanguageSwitcher />
-
-            {/* Right side - App info and links */}
-            <div className="flex flex-col sm:flex-row items-center gap-4 text-sm text-muted-foreground">
-              <span>{t("rabbitMQDashboard")}</span>
-              <div className="flex items-center gap-4">
-                <a
-                  href="https://www.rabbitmq.com/documentation.html"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-foreground transition-colors flex items-center gap-1"
-                >
-                  {t("documentation")}
-                  <ExternalLink className="w-3 h-3" />
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <AppFooter className="ml-0 md:ml-64 transition-[margin] duration-200 ease-linear" />
     </div>
   );
 }

--- a/apps/app/src/pages/Settings.tsx
+++ b/apps/app/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { Outlet } from "react-router";
 
 import { Settings as SettingsIcon } from "lucide-react";
 
+import { AppFooter } from "@/components/AppFooter";
 import { AppSidebar } from "@/components/AppSidebar";
 import { SettingsSidebar } from "@/components/settings/SettingsSidebar";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
@@ -27,26 +28,29 @@ const Settings = () => {
     <SidebarProvider>
       <div className="page-layout">
         <AppSidebar />
-        <main className="main-content-scrollable">
-          <div className="container mx-auto p-6 space-y-6">
-            <div className="flex items-center gap-3">
-              <SidebarTrigger />
-              <SettingsIcon className="h-8 w-8" />
-              <h1 className="title-page">{t("pageTitle")}</h1>
-            </div>
+        <div className="flex-1 flex flex-col min-h-screen">
+          <main className="flex-1 p-6">
+            <div className="container mx-auto space-y-6">
+              <div className="flex items-center gap-3">
+                <SidebarTrigger />
+                <SettingsIcon className="h-8 w-8" />
+                <h1 className="title-page">{t("pageTitle")}</h1>
+              </div>
 
-            {isMobile && <SettingsSidebar />}
+              {isMobile && <SettingsSidebar />}
 
-            <div className="flex gap-8">
-              {!isMobile && <SettingsSidebar />}
-              <div className="flex-1 min-w-0">
-                <Suspense fallback={<SectionLoader />}>
-                  <Outlet />
-                </Suspense>
+              <div className="flex gap-8">
+                {!isMobile && <SettingsSidebar />}
+                <div className="flex-1 min-w-0">
+                  <Suspense fallback={<SectionLoader />}>
+                    <Outlet />
+                  </Suspense>
+                </div>
               </div>
             </div>
-          </div>
-        </main>
+          </main>
+          <AppFooter />
+        </div>
       </div>
     </SidebarProvider>
   );


### PR DESCRIPTION
## Summary
- Extract inline footer from `Layout.tsx` into a shared `AppFooter` component
- Add `AppFooter` to the Settings page layout, which was missing a footer
- Settings page now uses a flex column layout to properly pin the footer at the bottom

## Test plan
- [ ] Verify footer appears on all settings sub-pages (Profile, Workspace, Plans, SSO, Team)
- [ ] Verify footer still appears correctly on non-settings pages (Alerts, Exchanges, etc.)
- [ ] Verify footer is pushed to viewport bottom on short-content pages
- [ ] Test mobile responsive behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added footer section with Help support link, integrated Language Switcher for multi-language support, and RabbitMQ documentation access throughout the app.

* **Refactor**
  * Enhanced application layout structure with improved responsive design for better user experience and visual organization across mobile and desktop devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->