### PR TITLE
feat: move billing from user-scoped to org-scoped (phase 2)

### DIFF
--- a/apps/api/src/core/better-auth.ts
+++ b/apps/api/src/core/better-auth.ts
@@ -313,7 +313,10 @@ export const auth = betterAuth({
         after: async (user) => {
           const baUser = user as Record<string, unknown>;
 
-          // Auto-start Enterprise trial for cloud users
+          // Auto-create Organization and start Enterprise trial for cloud users.
+          // provisionTrialForNewUser() creates an Organization with the user as
+          // OWNER, provisions the Stripe trial on the org, and dual-writes
+          // stripeCustomerId/subscriptionId to the User for backward compat.
           // Awaited so the subscription exists before the auth callback returns
           // and the frontend can fetch the correct plan on first load.
           if (isCloudMode()) {
@@ -327,7 +330,7 @@ export const auth = betterAuth({
             } catch (error) {
               logger.warn(
                 { error, userId: user.id },
-                "Failed to auto-start trial at registration"
+                "Failed to auto-create org and start trial at registration"
               );
             }
           }

--- a/apps/api/src/services/plan/features.service.ts
+++ b/apps/api/src/services/plan/features.service.ts
@@ -11,6 +11,9 @@ export interface PlanFeatures {
   canInviteUsers: boolean;
 
   // Limits
+  // Note: maxWorkspaces and maxUsers are counted per-Organization when an org
+  // exists. See getOrgResourceCounts() in plan.service.ts. If the user has no
+  // org, counts fall back to user-level ownership (backward compat).
   maxServers: number | null;
   maxWorkspaces: number | null;
   maxUsers: number | null;

--- a/apps/api/src/services/plan/plan.service.ts
+++ b/apps/api/src/services/plan/plan.service.ts
@@ -212,7 +212,49 @@ export function getPlanDisplayName(plan: UserPlan): string {
   return getPlanFeatures(plan).displayName;
 }
 
-export async function getUserPlan(userId: string) {
+/**
+ * Get the plan for an organization by its ID.
+ * Looks up the org's subscription; falls back to FREE if none exists.
+ */
+export async function getOrgPlan(orgId: string): Promise<UserPlan> {
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: {
+      subscription: {
+        select: { plan: true },
+      },
+    },
+  });
+
+  if (!org) {
+    throw new Error("Organization not found");
+  }
+
+  if (org.subscription) {
+    return org.subscription.plan;
+  }
+
+  return UserPlan.FREE;
+}
+
+/**
+ * Get the plan for a user.
+ * If the user belongs to an Organization (via OrganizationMember), delegates
+ * to getOrgPlan so billing is org-scoped. Falls back to user-level subscription
+ * for backward compatibility when no org exists.
+ */
+export async function getUserPlan(userId: string): Promise<UserPlan> {
+  // Check if user belongs to an org — if so, use org-level plan
+  const membership = await prisma.organizationMember.findFirst({
+    where: { userId },
+    select: { organizationId: true },
+  });
+
+  if (membership) {
+    return getOrgPlan(membership.organizationId);
+  }
+
+  // Fallback: user-level subscription (backward compat for users without an org)
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: {
@@ -226,16 +268,60 @@ export async function getUserPlan(userId: string) {
     throw new Error("User not found");
   }
 
-  // If user has an active subscription, use that plan
   if (user.subscription) {
     return user.subscription.plan;
   }
 
-  // Otherwise, default to FREE plan
   return UserPlan.FREE;
 }
 
+/**
+ * Get resource counts scoped to an organization.
+ * - workspaces: all workspaces linked to the org
+ * - members: OrganizationMember count (maxUsers is per-org)
+ * - servers: all servers across org workspaces
+ */
+export async function getOrgResourceCounts(orgId: string) {
+  const [serverCount, memberCount, workspaceCount] = await Promise.all([
+    prisma.rabbitMQServer.count({
+      where: {
+        workspace: {
+          organizationId: orgId,
+        },
+      },
+    }),
+    prisma.organizationMember.count({
+      where: { organizationId: orgId },
+    }),
+    prisma.workspace.count({
+      where: { organizationId: orgId },
+    }),
+  ]);
+
+  return {
+    servers: serverCount,
+    users: memberCount,
+    workspaces: workspaceCount,
+  };
+}
+
+/**
+ * Get resource counts for a user.
+ * If the user belongs to an Organization, counts are org-scoped.
+ * Falls back to user-level counts for backward compatibility.
+ */
 export async function getUserResourceCounts(userId: string) {
+  // Check if user belongs to an org — if so, use org-level counts
+  const membership = await prisma.organizationMember.findFirst({
+    where: { userId },
+    select: { organizationId: true },
+  });
+
+  if (membership) {
+    return getOrgResourceCounts(membership.organizationId);
+  }
+
+  // Fallback: user-level counts (backward compat for users without an org)
   const [serverCount, userCount, workspaceCount] = await Promise.all([
     prisma.rabbitMQServer.count({
       where: {

--- a/apps/api/src/services/stripe/customer.service.ts
+++ b/apps/api/src/services/stripe/customer.service.ts
@@ -345,20 +345,22 @@ export class StripeCustomerService {
   }
 
   /**
-   * Provision a full trial for a newly registered user.
-   * Creates Stripe customer + trial subscription + DB records.
+   * Provision a full trial on an Organization.
+   * Creates Stripe customer on the org + trial subscription + DB Subscription record.
    * Returns null if Stripe is not configured (self-hosted mode).
    * Does NOT send emails — caller decides.
    */
-  static async provisionTrialForNewUser({
-    userId,
+  static async provisionTrialForOrg({
+    organizationId,
     email,
     name,
+    userId,
     prisma,
   }: {
-    userId: string;
+    organizationId: string;
     email: string;
     name: string;
+    userId: string;
     prisma: PrismaClient;
   }) {
     // Skip if Stripe is not configured (self-hosted deployments)
@@ -370,32 +372,35 @@ export class StripeCustomerService {
     const billingInterval = "monthly" as const;
     const trialDays = 14;
 
-    logger.info({ userId, plan, trialDays }, "Provisioning trial for new user");
+    logger.info(
+      { organizationId, userId, plan, trialDays },
+      "Provisioning trial for organization"
+    );
 
     // Reuse existing Stripe customer if one was already created (race condition guard)
-    const user = await prisma.user.findUniqueOrThrow({
-      where: { id: userId },
+    const org = await prisma.organization.findUniqueOrThrow({
+      where: { id: organizationId },
       select: { stripeCustomerId: true },
     });
 
-    let customerId = user.stripeCustomerId;
+    let customerId = org.stripeCustomerId;
     if (!customerId) {
       const customer = await StripeCustomerService.createCustomer({
         email,
         name,
-        userId,
+        userId, // metadata still references the founding user
       });
       customerId = customer.id;
 
       // Conditional write: only set if still null (avoids overwriting concurrent request)
-      await prisma.user.updateMany({
-        where: { id: userId, stripeCustomerId: null },
+      await prisma.organization.updateMany({
+        where: { id: organizationId, stripeCustomerId: null },
         data: { stripeCustomerId: customerId },
       });
     }
 
     // Create trial subscription via Stripe API
-    const idempotencyKey = `auto_trial_${userId}`;
+    const idempotencyKey = `auto_trial_org_${organizationId}`;
     const subscription = await StripeCustomerService.createTrialSubscription({
       customerId,
       plan,
@@ -405,13 +410,13 @@ export class StripeCustomerService {
       idempotencyKey,
     });
 
-    // Update user with subscription ID
-    await prisma.user.update({
-      where: { id: userId },
+    // Update org with subscription ID
+    await prisma.organization.update({
+      where: { id: organizationId },
       data: { stripeSubscriptionId: subscription.id },
     });
 
-    // Upsert subscription record (idempotent against duplicate events/retries)
+    // Upsert subscription record linked to both user and org (idempotent)
     const firstItem = subscription.items?.data?.[0];
     const currentPeriodStart = firstItem?.current_period_start
       ? new Date(firstItem.current_period_start * 1000)
@@ -422,6 +427,7 @@ export class StripeCustomerService {
 
     const subscriptionData = {
       userId,
+      organizationId,
       stripeSubscriptionId: subscription.id,
       stripePriceId: firstItem?.price?.id || "",
       stripeCustomerId: customerId,
@@ -447,6 +453,7 @@ export class StripeCustomerService {
       where: { userId },
       create: subscriptionData,
       update: {
+        organizationId: subscriptionData.organizationId,
         stripeSubscriptionId: subscriptionData.stripeSubscriptionId,
         stripePriceId: subscriptionData.stripePriceId,
         stripeCustomerId: subscriptionData.stripeCustomerId,
@@ -460,13 +467,110 @@ export class StripeCustomerService {
 
     logger.info(
       {
+        organizationId,
         userId,
         subscriptionId: dbSubscription.stripeSubscriptionId,
         plan,
         trialEnd: dbSubscription.trialEnd,
       },
-      "Trial provisioned for new user"
+      "Trial provisioned for organization"
     );
+
+    return dbSubscription;
+  }
+
+  /**
+   * Provision a full trial for a newly registered user.
+   * Creates an Organization for the user, then provisions the trial on the org.
+   * Also dual-writes stripeCustomerId/subscriptionId to the User for backward compat.
+   * Returns null if Stripe is not configured (self-hosted mode).
+   * Does NOT send emails — caller decides.
+   */
+  static async provisionTrialForNewUser({
+    userId,
+    email,
+    name,
+    prisma,
+  }: {
+    userId: string;
+    email: string;
+    name: string;
+    prisma: PrismaClient;
+  }) {
+    // Skip if Stripe is not configured (self-hosted deployments)
+    if (!STRIPE_PRICE_IDS) {
+      return null;
+    }
+
+    const plan = UserPlan.ENTERPRISE;
+    const trialDays = 14;
+
+    logger.info({ userId, plan, trialDays }, "Provisioning trial for new user");
+
+    // Create an Organization for the user (or find existing one from a concurrent request)
+    const org = await prisma.organizationMember.findFirst({
+      where: { userId },
+      select: { organizationId: true, organization: true },
+    });
+
+    let organizationId: string;
+
+    if (org) {
+      organizationId = org.organizationId;
+    } else {
+      // Create the org inside a transaction to ensure atomicity
+      const slug = `${name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "")}-${userId.slice(0, 8)}`;
+      const newOrg = await prisma.$transaction(async (tx) => {
+        const created = await tx.organization.create({
+          data: {
+            name: name ? `${name}'s Organization` : "My Organization",
+            slug,
+            contactEmail: email,
+          },
+        });
+
+        // Add user as OWNER
+        // Role hierarchy:
+        // - Org OWNER: Can manage billing, SSO, delete org, manage all workspaces
+        // - Org ADMIN: Can create/manage workspaces, invite org members
+        // - Org MEMBER: Can access assigned workspaces only
+        await tx.organizationMember.create({
+          data: {
+            userId,
+            organizationId: created.id,
+            role: "OWNER",
+          },
+        });
+
+        return created;
+      });
+      organizationId = newOrg.id;
+    }
+
+    // Provision trial on the organization
+    const dbSubscription = await StripeCustomerService.provisionTrialForOrg({
+      organizationId,
+      email,
+      name,
+      userId,
+      prisma,
+    });
+
+    if (dbSubscription) {
+      // Dual-write to User for backward compatibility:
+      // Existing code that reads user.stripeCustomerId / stripeSubscriptionId
+      // will continue working until all read paths are fully migrated.
+      await prisma.user.update({
+        where: { id: userId },
+        data: {
+          stripeCustomerId: dbSubscription.stripeCustomerId,
+          stripeSubscriptionId: dbSubscription.stripeSubscriptionId,
+        },
+      });
+    }
 
     return dbSubscription;
   }

--- a/apps/api/src/services/stripe/webhook-handlers.ts
+++ b/apps/api/src/services/stripe/webhook-handlers.ts
@@ -76,6 +76,14 @@ export async function handleCheckoutSessionCompleted(session: Session) {
       },
     });
 
+    // Dual-write to Organization (if user belongs to one)
+    if (customerId) {
+      await dualWriteToOrg(customerId, {
+        stripeCustomerId: customerId,
+        stripeSubscriptionId: subscriptionId ?? undefined,
+      });
+    }
+
     // Get user for email
     const user = await prisma.user.findUnique({
       where: { id: userId },
@@ -330,10 +338,31 @@ export async function handleSubscriptionChange(subscription: Subscription) {
       return;
     }
 
-    // Find user by Stripe customer ID
-    const user = await prisma.user.findFirst({
+    // Find user by Stripe customer ID (check User first, then resolve via org)
+    let user = await prisma.user.findFirst({
       where: { stripeCustomerId: customerId },
     });
+
+    if (!user) {
+      // Try to find via org: org owns the Stripe customer, find the owner member
+      const org = await prisma.organization.findUnique({
+        where: { stripeCustomerId: customerId },
+        select: {
+          id: true,
+          members: {
+            where: { role: "OWNER" },
+            select: { userId: true },
+            take: 1,
+          },
+        },
+      });
+
+      if (org?.members[0]) {
+        user = await prisma.user.findUnique({
+          where: { id: org.members[0].userId },
+        });
+      }
+    }
 
     if (!user) {
       logger.warn(
@@ -342,6 +371,11 @@ export async function handleSubscriptionChange(subscription: Subscription) {
       );
       return;
     }
+
+    // Dual-write subscription ID to Organization
+    await dualWriteToOrg(customerId, {
+      stripeSubscriptionId: subscriptionId,
+    });
 
     // Get or create subscription record
     const existingSubscription = await prisma.subscription.findUnique({
@@ -381,16 +415,23 @@ export async function handleSubscriptionChange(subscription: Subscription) {
       cancelAtPeriodEnd: subscription.cancel_at_period_end || false,
     };
 
+    // Resolve org for linking the subscription record
+    const resolvedOrg = await resolveOrgFromStripeCustomerId(customerId);
+
     if (existingSubscription) {
       await prisma.subscription.update({
         where: { stripeSubscriptionId: subscriptionId },
-        data: subscriptionData,
+        data: {
+          ...subscriptionData,
+          ...(resolvedOrg && { organizationId: resolvedOrg.id }),
+        },
       });
     } else {
       await prisma.subscription.create({
         data: {
           userId: user.id,
           stripeSubscriptionId: subscriptionId,
+          ...(resolvedOrg && { organizationId: resolvedOrg.id }),
           ...subscriptionData,
         },
       });
@@ -867,12 +908,34 @@ export async function handleTrialWillEnd(subscription: Subscription) {
       return;
     }
 
-    const user = await prisma.user.findFirst({
+    // Find user by Stripe customer ID (check User first, then resolve via org)
+    let user = await prisma.user.findFirst({
       where: { stripeCustomerId: customerId },
       include: {
         workspace: true,
       },
     });
+
+    if (!user) {
+      // Try to find via org owner
+      const org = await prisma.organization.findUnique({
+        where: { stripeCustomerId: customerId },
+        select: {
+          members: {
+            where: { role: "OWNER" },
+            select: { userId: true },
+            take: 1,
+          },
+        },
+      });
+
+      if (org?.members[0]) {
+        user = await prisma.user.findUnique({
+          where: { id: org.members[0].userId },
+          include: { workspace: true },
+        });
+      }
+    }
 
     if (!user) {
       logger.warn(
@@ -1086,6 +1149,77 @@ export async function handleCustomerUpdated(customer: Customer) {
       handler: "handleCustomerUpdated",
       error_message: error instanceof Error ? error.message : "Unknown error",
     });
+  }
+}
+
+/**
+ * Resolve an Organization from a Stripe customer ID.
+ * Checks Organization.stripeCustomerId first, then falls back to
+ * finding the User with that stripeCustomerId and their org membership.
+ * Returns null if no org can be resolved.
+ */
+async function resolveOrgFromStripeCustomerId(
+  customerId: string
+): Promise<{ id: string } | null> {
+  // Direct match: org owns the Stripe customer
+  const org = await prisma.organization.findUnique({
+    where: { stripeCustomerId: customerId },
+    select: { id: true },
+  });
+
+  if (org) return org;
+
+  // Indirect match: user owns the Stripe customer, find their org
+  const user = await prisma.user.findFirst({
+    where: { stripeCustomerId: customerId },
+    select: { id: true },
+  });
+
+  if (!user) return null;
+
+  const membership = await prisma.organizationMember.findFirst({
+    where: { userId: user.id },
+    select: { organizationId: true },
+  });
+
+  if (membership) {
+    return { id: membership.organizationId };
+  }
+
+  return null;
+}
+
+/**
+ * Dual-write stripeCustomerId and stripeSubscriptionId to the Organization
+ * associated with the given Stripe customer ID.
+ * This is a best-effort operation — failures are logged but do not block
+ * the webhook handler.
+ */
+async function dualWriteToOrg(
+  customerId: string,
+  data: {
+    stripeCustomerId?: string;
+    stripeSubscriptionId?: string;
+  }
+): Promise<void> {
+  try {
+    const org = await resolveOrgFromStripeCustomerId(customerId);
+    if (!org) return;
+
+    await prisma.organization.update({
+      where: { id: org.id },
+      data,
+    });
+
+    logger.info(
+      { organizationId: org.id, ...data },
+      "Dual-wrote Stripe IDs to organization"
+    );
+  } catch (error) {
+    logger.warn(
+      { error, customerId, data },
+      "Failed to dual-write Stripe IDs to organization (non-fatal)"
+    );
   }
 }
 

--- a/apps/api/src/trpc/routers/payment/billing.ts
+++ b/apps/api/src/trpc/routers/payment/billing.ts
@@ -14,6 +14,31 @@ import {
 import { te } from "@/i18n";
 
 /**
+ * Resolve the Stripe customer ID for a user.
+ * Prefers org-level stripeCustomerId, falls back to user-level for backward compat.
+ */
+async function resolveStripeCustomerId(
+  userId: string,
+  userStripeCustomerId: string | null,
+  prisma: typeof import("@/core/prisma").prisma
+): Promise<string | null> {
+  const membership = await prisma.organizationMember.findFirst({
+    where: { userId },
+    select: {
+      organization: {
+        select: { stripeCustomerId: true },
+      },
+    },
+  });
+
+  if (membership?.organization?.stripeCustomerId) {
+    return membership.organization.stripeCustomerId;
+  }
+
+  return userStripeCustomerId;
+}
+
+/**
  * Billing router
  * Handles billing overview and portal session creation
  */
@@ -260,12 +285,19 @@ export const billingRouter = router({
 
   /**
    * Create billing portal session (PROTECTED)
+   * Uses org-level stripeCustomerId when the user belongs to an org.
    */
   createBillingPortalSession: rateLimitedProcedure.mutation(async ({ ctx }) => {
-    const { user } = ctx;
+    const { user, prisma } = ctx;
 
     try {
-      if (!user.stripeCustomerId) {
+      const stripeCustomerId = await resolveStripeCustomerId(
+        user.id,
+        user.stripeCustomerId,
+        prisma
+      );
+
+      if (!stripeCustomerId) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: te(ctx.locale, "billing.noStripeCustomerId"),
@@ -273,7 +305,7 @@ export const billingRouter = router({
       }
 
       const session = await StripeService.createPortalSession(
-        user.stripeCustomerId,
+        stripeCustomerId,
         `${config.FRONTEND_URL}/billing`
       );
 
@@ -292,12 +324,19 @@ export const billingRouter = router({
 
   /**
    * Create portal session (PROTECTED) - alias for createBillingPortalSession
+   * Uses org-level stripeCustomerId when the user belongs to an org.
    */
   createPortalSession: rateLimitedProcedure.mutation(async ({ ctx }) => {
-    const { user } = ctx;
+    const { user, prisma } = ctx;
 
     try {
-      if (!user.stripeCustomerId) {
+      const stripeCustomerId = await resolveStripeCustomerId(
+        user.id,
+        user.stripeCustomerId,
+        prisma
+      );
+
+      if (!stripeCustomerId) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: te(ctx.locale, "billing.noStripeCustomerFound"),
@@ -305,7 +344,7 @@ export const billingRouter = router({
       }
 
       const session = await StripeService.createPortalSession(
-        user.stripeCustomerId,
+        stripeCustomerId,
         `${config.FRONTEND_URL}/billing`
       );
 

--- a/apps/api/src/trpc/routers/payment/subscription.ts
+++ b/apps/api/src/trpc/routers/payment/subscription.ts
@@ -15,6 +15,33 @@ import { router, strictRateLimitedProcedure } from "@/trpc/trpc";
 import { te } from "@/i18n";
 
 /**
+ * Resolve the Stripe subscription ID for a user.
+ * Prefers org-level subscription, falls back to user-level for backward compat.
+ */
+async function resolveStripeSubscriptionId(
+  userId: string,
+  userStripeSubId: string | null,
+  prisma: typeof import("@/core/prisma").prisma
+): Promise<string | null> {
+  // Check if user belongs to an org with a subscription
+  const membership = await prisma.organizationMember.findFirst({
+    where: { userId },
+    select: {
+      organization: {
+        select: { stripeSubscriptionId: true },
+      },
+    },
+  });
+
+  if (membership?.organization?.stripeSubscriptionId) {
+    return membership.organization.stripeSubscriptionId;
+  }
+
+  // Fallback to user-level
+  return userStripeSubId;
+}
+
+/**
  * Subscription router
  * Handles subscription cancellation and renewal
  */
@@ -29,7 +56,14 @@ export const subscriptionRouter = router({
       const { user, prisma } = ctx;
 
       try {
-        if (!user.stripeSubscriptionId) {
+        // Resolve subscription ID: prefer org-level, fall back to user-level
+        const stripeSubscriptionId = await resolveStripeSubscriptionId(
+          user.id,
+          user.stripeSubscriptionId,
+          prisma
+        );
+
+        if (!stripeSubscriptionId) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: te(ctx.locale, "billing.noActiveSubscription"),
@@ -37,7 +71,7 @@ export const subscriptionRouter = router({
         }
 
         const subscription = await StripeService.cancelSubscription(
-          user.stripeSubscriptionId,
+          stripeSubscriptionId,
           cancelImmediately
         );
 

--- a/apps/api/src/trpc/routers/workspace/management.ts
+++ b/apps/api/src/trpc/routers/workspace/management.ts
@@ -106,24 +106,45 @@ export const managementRouter = router({
       // For new users creating their first workspace, they won't have a workspaceId yet
       let currentPlan: UserPlan = UserPlan.FREE; // Default plan for new users
 
-      // Get user with subscription
-      const userWithSubscription = await ctx.prisma.user.findUnique({
-        where: { id: user.id },
+      // Resolve org membership for org-scoped plan and workspace counting
+      const membership = await ctx.prisma.organizationMember.findFirst({
+        where: { userId: user.id },
         select: {
-          subscription: {
-            select: { plan: true },
+          organizationId: true,
+          organization: {
+            select: {
+              subscription: {
+                select: { plan: true },
+              },
+            },
           },
         },
       });
 
-      // Plans are now user-level, get from user's subscription
-      if (userWithSubscription?.subscription) {
-        currentPlan = userWithSubscription.subscription.plan;
+      if (membership?.organization?.subscription) {
+        currentPlan = membership.organization.subscription.plan;
+      } else {
+        // Fallback: user-level subscription (backward compat)
+        const userWithSubscription = await ctx.prisma.user.findUnique({
+          where: { id: user.id },
+          select: {
+            subscription: {
+              select: { plan: true },
+            },
+          },
+        });
+
+        if (userWithSubscription?.subscription) {
+          currentPlan = userWithSubscription.subscription.plan;
+        }
       }
 
-      // Count owned workspaces
+      // Count workspaces: org-scoped if user has an org, else user-owned
+      const workspaceCountWhere = membership
+        ? { organizationId: membership.organizationId }
+        : { ownerId: user.id };
       const ownedWorkspaceCount = await ctx.prisma.workspace.count({
-        where: { ownerId: user.id },
+        where: workspaceCountWhere,
       });
 
       const planFeatures = getPlanFeatures(currentPlan);
@@ -164,30 +185,52 @@ export const managementRouter = router({
       const { name, contactEmail, tags } = input;
 
       try {
-        // Get user's current plan from their subscription
-        let currentPlan: UserPlan = UserPlan.FREE; // Default plan for new users
-
-        const userWithSubscription = await ctx.prisma.user.findUnique({
-          where: { id: user.id },
+        // Resolve user's org membership (if any) for org-scoped plan validation
+        const membership = await ctx.prisma.organizationMember.findFirst({
+          where: { userId: user.id },
           select: {
-            subscription: {
-              select: { plan: true },
+            organizationId: true,
+            organization: {
+              select: {
+                subscription: {
+                  select: { plan: true },
+                },
+              },
             },
           },
         });
 
-        if (userWithSubscription?.subscription) {
-          currentPlan = userWithSubscription.subscription.plan;
+        // Determine plan: org-level if available, else user-level
+        let currentPlan: UserPlan = UserPlan.FREE;
+
+        if (membership?.organization?.subscription) {
+          currentPlan = membership.organization.subscription.plan;
+        } else {
+          const userWithSubscription = await ctx.prisma.user.findUnique({
+            where: { id: user.id },
+            select: {
+              subscription: {
+                select: { plan: true },
+              },
+            },
+          });
+
+          if (userWithSubscription?.subscription) {
+            currentPlan = userWithSubscription.subscription.plan;
+          }
         }
 
-        // Count current owned workspaces
-        const ownedWorkspaceCount = await ctx.prisma.workspace.count({
-          where: { ownerId: user.id },
+        // Count workspaces: org-scoped if user has an org, else user-owned
+        const workspaceCountWhere = membership
+          ? { organizationId: membership.organizationId }
+          : { ownerId: user.id };
+        const workspaceCount = await ctx.prisma.workspace.count({
+          where: workspaceCountWhere,
         });
 
         // Validate workspace creation against plan limits
         // Errors will be caught by planValidationProcedure middleware
-        validateWorkspaceCreation(currentPlan, ownedWorkspaceCount);
+        validateWorkspaceCreation(currentPlan, workspaceCount);
 
         // Check if workspace name already exists for this user
         const existingWorkspace = await ctx.prisma.workspace.findFirst({
@@ -205,6 +248,9 @@ export const managementRouter = router({
         }
 
         // Create the new workspace and assign user to it
+        // Set organizationId from the user's org membership (if any)
+        const organizationId = membership?.organizationId ?? null;
+
         const newWorkspace = await ctx.prisma.$transaction(async (tx) => {
           // Create the workspace
           const workspace = await tx.workspace.create({
@@ -213,6 +259,7 @@ export const managementRouter = router({
               contactEmail,
               tags: tags ? tags : undefined, // Store tags as JSON array or undefined
               ownerId: user.id,
+              ...(organizationId && { organizationId }),
             },
             include: {
               _count: {


### PR DESCRIPTION
## Summary
- `getUserPlan()` now resolves through the user's Organization, falling back to user-level subscription if no org exists
- `getUserResourceCounts()` counts workspaces and members across the org
- `provisionTrialForNewUser()` auto-creates an Organization, then provisions the Stripe trial on the org
- Webhook handlers dual-write Stripe IDs to both User and Organization (best-effort)
- Billing portal and subscription cancellation resolve Stripe IDs from org first
- Workspace creation validates limits against org plan and sets `organizationId`

**Phase 2 of 4** — billing moves to org scope. All existing API callers work unchanged (delegation happens internally). See [ADR-001](docs/adr/001-add-organization-entity.md).

**Depends on:** #390 (Phase 1)

## Files changed
| File | Change |
|---|---|
| `plan.service.ts` | Add `getOrgPlan()`, `getOrgResourceCounts()`, delegate user functions through org |
| `features.service.ts` | Document org-scoped counting |
| `customer.service.ts` | Add `provisionTrialForOrg()`, auto-create org in `provisionTrialForNewUser()` |
| `webhook-handlers.ts` | Dual-write to org, resolve org from Stripe customer ID |
| `subscription.ts` | Resolve subscription ID from org |
| `billing.ts` | Resolve customer ID from org for portal sessions |
| `management.ts` | Org-scoped workspace limit checks, set organizationId on creation |
| `better-auth.ts` | Updated comment documenting org auto-creation |

## Test plan
- [ ] New user signup creates Organization + provisions trial on org
- [ ] Existing users without org fall back to user-level plan (backward compat)
- [ ] Workspace creation respects org-level workspace limits
- [ ] Stripe webhook updates write to both User and Organization
- [ ] Billing portal uses org's Stripe customer ID
- [ ] Subscription cancellation resolves from org

🤖 Generated with [Claude Code](https://claude.com/claude-code)