### PR TITLE
docs: replace static thumbnail with animated demo gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [Features](#-features) • [Editions](#-editions) • [Quick Start](#-quick-start) • [Documentation](#-documentation) • [Contributing](#-contributing)
 
-[![Watch the demo](apps/web/public/images/dashboard.png)](https://www.youtube.com/watch?v=g9Coi3niYIY)
+![Qarote Demo](assets/demo.gif)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [Features](#-features) • [Editions](#-editions) • [Quick Start](#-quick-start) • [Documentation](#-documentation) • [Contributing](#-contributing)
 
-![Qarote Demo](assets/demo.gif)
+[![Animated demo showing Qarote's dashboard monitoring RabbitMQ queues, exchanges, and system metrics](assets/demo.gif)](https://www.youtube.com/watch?v=g9Coi3niYIY)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Replaces the static dashboard screenshot with an animated GIF demo in the README
- GIF generated from the project demo video (`qarote.mp4`) at 10fps, 800px wide (7.6MB)

## Test plan
- [ ] Verify the GIF renders and autoplays on GitHub README
- [ ] Verify file size is acceptable for GitHub rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README demo thumbnail: replaced the static image with an embedded GIF preview while keeping the same demo link destination, improving the in-page preview experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->