### PR TITLE
fix: replace mutable date mutations in stripe webhook handlers

### DIFF
--- a/apps/api/src/services/stripe/__tests__/webhook-handlers.test.ts
+++ b/apps/api/src/services/stripe/__tests__/webhook-handlers.test.ts
@@ -1,3 +1,4 @@
+import { addDays, subDays } from "date-fns";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { prisma } from "@/core/prisma";
@@ -199,8 +200,7 @@ describe("handleCustomerSubscriptionDeleted", () => {
       customer: "cus_123",
     } as any;
 
-    const futureDate = new Date();
-    futureDate.setDate(futureDate.getDate() + 30);
+    const futureDate = addDays(new Date(), 30);
 
     vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
       id: "db-sub-id",
@@ -326,8 +326,7 @@ describe("handleInvoicePaymentFailed", () => {
     const invoice = makeInvoice("sub_grace");
 
     // Period ended recently — still within 14-day grace period
-    const recentPeriodEnd = new Date();
-    recentPeriodEnd.setDate(recentPeriodEnd.getDate() - 2); // 2 days ago
+    const recentPeriodEnd = subDays(new Date(), 2); // 2 days ago
 
     vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
       id: "db-sub",
@@ -368,8 +367,7 @@ describe("handleInvoicePaymentFailed", () => {
     const invoice = makeInvoice("sub_expired");
 
     // Period ended 20 days ago — past 14-day grace period
-    const expiredPeriodEnd = new Date();
-    expiredPeriodEnd.setDate(expiredPeriodEnd.getDate() - 20);
+    const expiredPeriodEnd = subDays(new Date(), 20);
 
     vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
       id: "db-sub",

--- a/apps/api/src/services/stripe/webhook-handlers.ts
+++ b/apps/api/src/services/stripe/webhook-handlers.ts
@@ -734,7 +734,7 @@ export async function handleInvoicePaymentFailed(invoice: Invoice) {
     // Calculate days since first payment failure (for grace period tracking)
     // Stripe retries for 7 days, we allow 7 more = 14 days total
     const now = new Date();
-    const gracePeriodEnd = addDays(new Date(subscription.currentPeriodEnd), 14); // 14-day grace period
+    const gracePeriodEnd = addDays(subscription.currentPeriodEnd, 14); // 14-day grace period
 
     const isInGracePeriod = now < gracePeriodEnd;
     const daysRemaining = Math.ceil(

--- a/apps/api/src/services/stripe/webhook-handlers.ts
+++ b/apps/api/src/services/stripe/webhook-handlers.ts
@@ -1,3 +1,5 @@
+import { addDays, addMonths, addYears } from "date-fns";
+
 import { logger } from "@/core/logger";
 import { prisma } from "@/core/prisma";
 import { getUserDisplayName } from "@/core/utils";
@@ -243,12 +245,9 @@ async function handleLicensePurchase(
     }
 
     // Calculate expiration date
-    const expiresAt = new Date();
-    if (billingInterval === "yearly") {
-      expiresAt.setFullYear(expiresAt.getFullYear() + 1);
-    } else {
-      expiresAt.setMonth(expiresAt.getMonth() + 1);
-    }
+    const now = new Date();
+    const expiresAt =
+      billingInterval === "yearly" ? addYears(now, 1) : addMonths(now, 1);
 
     // Generate license
     const { licenseKey, licenseId } = await licenseService.generateLicense({
@@ -590,9 +589,8 @@ export async function handleInvoicePaymentSucceeded(invoice: Invoice) {
             continue;
           }
 
-          // Calculate new expiration date (365 days from now)
-          const newExpiresAt = new Date();
-          newExpiresAt.setFullYear(newExpiresAt.getFullYear() + 1);
+          // Calculate new expiration date (1 year from now)
+          const newExpiresAt = addYears(new Date(), 1);
 
           // Renew license (updates expiresAt and increments version)
           const { newVersion } = await licenseService.renewLicense(
@@ -736,8 +734,7 @@ export async function handleInvoicePaymentFailed(invoice: Invoice) {
     // Calculate days since first payment failure (for grace period tracking)
     // Stripe retries for 7 days, we allow 7 more = 14 days total
     const now = new Date();
-    const gracePeriodEnd = new Date(subscription.currentPeriodEnd);
-    gracePeriodEnd.setDate(gracePeriodEnd.getDate() + 14); // 14-day grace period
+    const gracePeriodEnd = addDays(new Date(subscription.currentPeriodEnd), 14); // 14-day grace period
 
     const isInGracePeriod = now < gracePeriodEnd;
     const daysRemaining = Math.ceil(


### PR DESCRIPTION
## Summary
- Replace mutable `Date` mutations (`setFullYear`, `setMonth`, `setDate`) with immutable `date-fns` functions (`addYears`, `addMonths`, `addDays`) in Stripe webhook handlers
- Apply the same cleanup to test setup code (`addDays`, `subDays`)
- Follows the same pattern established in PR #373 for the rest of the API

## Test plan
- [x] All 13 existing webhook-handler tests pass
- [ ] Verify license expiration dates are correct after checkout (yearly = +1 year, monthly = +1 month)
- [ ] Verify grace period calculation (14 days after period end) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved date handling for subscription renewals, grace periods, and license expirations to increase reliability and consistency.
* **Tests**
  * Updated tests to use more robust date calculations, reducing flakiness and improving coverage around billing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->