### PR TITLE
fix: use smart invite url fallback and localhost warning for self-hosted

### DIFF
--- a/apps/api/src/trpc/routers/public/index.ts
+++ b/apps/api/src/trpc/routers/public/index.ts
@@ -3,7 +3,7 @@ import { logger } from "@/core/logger";
 
 import { CoreEmailService } from "@/services/email/core-email.service";
 
-import { googleConfig, registrationConfig } from "@/config";
+import { emailConfig, googleConfig, registrationConfig } from "@/config";
 import { getAllPremiumFeatures } from "@/config/features";
 
 import { publicProcedure, router } from "@/trpc/trpc";
@@ -36,6 +36,7 @@ export const publicRouter = router({
       registrationEnabled: registrationConfig.enabled,
       emailEnabled,
       oauthEnabled: googleConfig.enabled,
+      frontendUrl: emailConfig.frontendUrl,
     };
   }),
 

--- a/apps/app/public/locales/en/workspace.json
+++ b/apps/app/public/locales/en/workspace.json
@@ -46,7 +46,9 @@
     "title": "Share Invitation Links",
     "description": "Email is not configured. Share these links manually with your team members.",
     "done": "Done",
-    "copyFailed": "Failed to copy link"
+    "copyFailed": "Failed to copy link",
+    "localhostWarningTitle": "Invite link contains localhost",
+    "localhostWarningDescription": "Your server URL (FRONTEND_URL) is set to localhost. This link was adjusted to use your current browser address, but you should update FRONTEND_URL in your .env file to your server's network address (e.g., http://192.168.1.50:8080) and restart Qarote."
   },
   "invites": {
     "invalidEmail": "Please enter a valid email address",

--- a/apps/app/public/locales/es/workspace.json
+++ b/apps/app/public/locales/es/workspace.json
@@ -46,7 +46,9 @@
     "title": "Compartir enlaces de invitación",
     "description": "El correo electrónico no está configurado. Comparte estos enlaces manualmente con los miembros de tu equipo.",
     "done": "Listo",
-    "copyFailed": "Error al copiar el enlace"
+    "copyFailed": "Error al copiar el enlace",
+    "localhostWarningTitle": "El enlace de invitación contiene localhost",
+    "localhostWarningDescription": "La URL de su servidor (FRONTEND_URL) está configurada como localhost. Este enlace fue ajustado para usar la dirección de su navegador, pero debería actualizar FRONTEND_URL en su archivo .env con la dirección de red de su servidor (ej: http://192.168.1.50:8080) y reiniciar Qarote."
   },
   "invites": {
     "invalidEmail": "Por favor ingresa una dirección de correo válida",

--- a/apps/app/public/locales/fr/workspace.json
+++ b/apps/app/public/locales/fr/workspace.json
@@ -46,7 +46,9 @@
     "title": "Partager les liens d'invitation",
     "description": "L'e-mail n'est pas configuré. Partagez ces liens manuellement avec les membres de votre équipe.",
     "done": "Terminé",
-    "copyFailed": "Échec de la copie du lien"
+    "copyFailed": "Échec de la copie du lien",
+    "localhostWarningTitle": "Le lien d'invitation contient localhost",
+    "localhostWarningDescription": "L'URL de votre serveur (FRONTEND_URL) est définie sur localhost. Ce lien a été ajusté pour utiliser l'adresse de votre navigateur, mais vous devriez mettre à jour FRONTEND_URL dans votre fichier .env avec l'adresse réseau de votre serveur (ex : http://192.168.1.50:8080) et redémarrer Qarote."
   },
   "invites": {
     "invalidEmail": "Veuillez saisir une adresse e-mail valide",

--- a/apps/app/public/locales/zh/workspace.json
+++ b/apps/app/public/locales/zh/workspace.json
@@ -46,7 +46,9 @@
     "title": "分享邀请链接",
     "description": "邮件服务未配置。请手动将这些链接分享给您的团队成员。",
     "done": "完成",
-    "copyFailed": "复制链接失败"
+    "copyFailed": "复制链接失败",
+    "localhostWarningTitle": "邀请链接包含 localhost",
+    "localhostWarningDescription": "您的服务器地址 (FRONTEND_URL) 设置为 localhost。此链接已调整为使用您当前的浏览器地址，但您应该在 .env 文件中将 FRONTEND_URL 更新为服务器的网络地址（例如：http://192.168.1.50:8080），然后重启 Qarote。"
   },
   "invites": {
     "invalidEmail": "请输入有效的邮箱地址",

--- a/apps/app/src/components/InviteLinksDialog.tsx
+++ b/apps/app/src/components/InviteLinksDialog.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { Check, Copy, Link } from "lucide-react";
+import { AlertTriangle, Check, Copy, Link } from "lucide-react";
 import { toast } from "sonner";
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -15,6 +16,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 
+import { usePublicConfig } from "@/hooks/queries/usePublicConfig";
 import { type InviteLink } from "@/hooks/ui/useWorkspaceInvites";
 
 interface InviteLinksDialogProps {
@@ -22,14 +24,37 @@ interface InviteLinksDialogProps {
   onClose: () => void;
 }
 
+function isLocalhostUrl(url: string): boolean {
+  return url.includes("localhost") || url.includes("127.0.0.1");
+}
+
 export function InviteLinksDialog({
   inviteLinks,
   onClose,
 }: InviteLinksDialogProps) {
   const { t } = useTranslation("workspace");
+  const { data: publicConfig } = usePublicConfig();
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+  const [editableUrls, setEditableUrls] = useState<string[]>([]);
 
-  const handleCopy = async (url: string, index: number) => {
+  const showLocalhostWarning =
+    publicConfig?.frontendUrl && isLocalhostUrl(publicConfig.frontendUrl);
+
+  useEffect(() => {
+    setEditableUrls(inviteLinks.map((link) => link.inviteUrl));
+  }, [inviteLinks]);
+
+  const handleUrlChange = (index: number, value: string) => {
+    setEditableUrls((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  const handleCopy = async (index: number) => {
+    const url = editableUrls[index];
+    if (!url) return;
     try {
       await navigator.clipboard.writeText(url);
       setCopiedIndex(index);
@@ -50,6 +75,16 @@ export function InviteLinksDialog({
           <DialogDescription>{t("inviteLinks.description")}</DialogDescription>
         </DialogHeader>
 
+        {showLocalhostWarning && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>{t("inviteLinks.localhostWarningTitle")}</AlertTitle>
+            <AlertDescription>
+              {t("inviteLinks.localhostWarningDescription")}
+            </AlertDescription>
+          </Alert>
+        )}
+
         <div className="space-y-3">
           {inviteLinks.map((link, index) => (
             <div key={link.email} className="space-y-1">
@@ -58,8 +93,8 @@ export function InviteLinksDialog({
               </p>
               <div className="flex gap-2">
                 <Input
-                  readOnly
-                  value={link.inviteUrl}
+                  value={editableUrls[index] ?? link.inviteUrl}
+                  onChange={(e) => handleUrlChange(index, e.target.value)}
                   className="font-mono text-xs"
                   aria-label={`Invite URL for ${link.email}`}
                 />
@@ -67,7 +102,7 @@ export function InviteLinksDialog({
                   variant="outline"
                   size="icon"
                   className="shrink-0"
-                  onClick={() => handleCopy(link.inviteUrl, index)}
+                  onClick={() => handleCopy(index)}
                   aria-label={`Copy invite link for ${link.email}`}
                 >
                   {copiedIndex === index ? (

--- a/apps/app/src/components/InviteLinksDialog.tsx
+++ b/apps/app/src/components/InviteLinksDialog.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 import { AlertTriangle, Check, Copy, Link } from "lucide-react";
 import { toast } from "sonner";
 
+import { isLocalhostUrl } from "@/lib/url-utils";
+
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,10 +24,6 @@ import { type InviteLink } from "@/hooks/ui/useWorkspaceInvites";
 interface InviteLinksDialogProps {
   inviteLinks: InviteLink[];
   onClose: () => void;
-}
-
-function isLocalhostUrl(url: string): boolean {
-  return url.includes("localhost") || url.includes("127.0.0.1");
 }
 
 export function InviteLinksDialog({

--- a/apps/app/src/components/InviteLinksDialog.tsx
+++ b/apps/app/src/components/InviteLinksDialog.tsx
@@ -51,7 +51,7 @@ export function InviteLinksDialog({
   };
 
   const handleCopy = async (index: number) => {
-    const url = editableUrls[index];
+    const url = editableUrls[index] ?? inviteLinks[index]?.inviteUrl;
     if (!url) return;
     try {
       await navigator.clipboard.writeText(url);

--- a/apps/app/src/lib/url-utils.ts
+++ b/apps/app/src/lib/url-utils.ts
@@ -1,3 +1,13 @@
 export function isLocalhostUrl(url: string): boolean {
-  return url.includes("localhost") || url.includes("127.0.0.1");
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "[::1]" ||
+      hostname === "::1"
+    );
+  } catch {
+    return false;
+  }
 }

--- a/apps/app/src/lib/url-utils.ts
+++ b/apps/app/src/lib/url-utils.ts
@@ -1,0 +1,3 @@
+export function isLocalhostUrl(url: string): boolean {
+  return url.includes("localhost") || url.includes("127.0.0.1");
+}

--- a/apps/app/src/pages/settings/TeamSection.tsx
+++ b/apps/app/src/pages/settings/TeamSection.tsx
@@ -105,9 +105,15 @@ const TeamSection = () => {
             if (result.emailSent) {
               toast.success(t("toast.invitationSent", { email }));
             } else {
+              const backendUrl = result.inviteUrl;
+              const isLocalhost =
+                backendUrl &&
+                (backendUrl.includes("localhost") ||
+                  backendUrl.includes("127.0.0.1"));
               const inviteUrl =
-                result.inviteUrl ||
-                `${window.location.origin}/invite/${result.invitation.token}`;
+                !backendUrl || isLocalhost
+                  ? `${window.location.origin}/invite/${result.invitation.token}`
+                  : backendUrl;
               collectedLinks.push({ email, inviteUrl });
               toast.success(t("toast.invitationCreated", { email }));
             }

--- a/apps/app/src/pages/settings/TeamSection.tsx
+++ b/apps/app/src/pages/settings/TeamSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import { logger } from "@/lib/logger";
+import { isLocalhostUrl } from "@/lib/url-utils";
 
 import { InviteLinksDialog } from "@/components/InviteLinksDialog";
 import { EnhancedTeamTab, InviteFormState } from "@/components/profile";
@@ -106,12 +107,8 @@ const TeamSection = () => {
               toast.success(t("toast.invitationSent", { email }));
             } else {
               const backendUrl = result.inviteUrl;
-              const isLocalhost =
-                backendUrl &&
-                (backendUrl.includes("localhost") ||
-                  backendUrl.includes("127.0.0.1"));
               const inviteUrl =
-                !backendUrl || isLocalhost
+                !backendUrl || isLocalhostUrl(backendUrl)
                   ? `${window.location.origin}/invite/${result.invitation.token}`
                   : backendUrl;
               collectedLinks.push({ email, inviteUrl });


### PR DESCRIPTION
## Summary
- When `FRONTEND_URL` is `localhost` (self-hosted default), invite URLs are now built from `window.location.origin` instead — producing working links immediately
- Shows a warning in the `InviteLinksDialog` when `FRONTEND_URL` is localhost, with actionable fix instructions
- Invite URL field is now **editable** so admins can correct the address before copying
- Exposes `frontendUrl` in the public config API so the frontend can detect misconfiguration
- Translations added for EN, FR, ES, ZH

## Test plan
- [ ] Self-hosted with `FRONTEND_URL=http://localhost:8080`: create invite → URL uses browser origin, localhost warning shown
- [ ] Self-hosted with `FRONTEND_URL=http://192.168.1.50:8080`: create invite → URL uses FRONTEND_URL, no warning
- [ ] Cloud mode: no change in behavior, no warning
- [ ] Edit URL in dialog, copy → clipboard has edited value
- [ ] Copy link button on pending invitations table still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invite links are editable in the invitation dialog.
  * Public configuration now exposes the configured frontend URL to the app.
  * Added a warning when an invite link contains localhost, with guidance to update FRONTEND_URL.

* **Localization**
  * Added localhost warning messages in English, Spanish, French, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->