### PR TITLE
feat: protect RabbitMQ connection user from modification

### DIFF
--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -170,6 +170,7 @@
     "failedToCreateUser": "Failed to create user",
     "failedToUpdateUser": "Failed to update user",
     "failedToDeleteUser": "Failed to delete user",
+    "cannotModifyConnectionUser": "Cannot modify or delete the connection user. This is the account Qarote uses to connect to this RabbitMQ server.",
     "failedToSetPermissions": "Failed to set permissions",
     "failedToDeletePermissions": "Failed to delete permissions",
     "failedToFetchVhosts": "Failed to fetch virtual hosts",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -171,6 +171,7 @@
     "failedToCreateUser": "Error al crear el usuario",
     "failedToUpdateUser": "Error al actualizar el usuario",
     "failedToDeleteUser": "Error al eliminar el usuario",
+    "cannotModifyConnectionUser": "No se puede modificar o eliminar el usuario de conexión. Esta es la cuenta que Qarote utiliza para conectarse a este servidor RabbitMQ.",
     "failedToSetPermissions": "Error al establecer los permisos",
     "failedToDeletePermissions": "Error al eliminar los permisos",
     "failedToFetchVhosts": "Error al obtener los hosts virtuales",

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -171,6 +171,7 @@
     "failedToCreateUser": "Échec de la création de l'utilisateur",
     "failedToUpdateUser": "Échec de la mise à jour de l'utilisateur",
     "failedToDeleteUser": "Échec de la suppression de l'utilisateur",
+    "cannotModifyConnectionUser": "Impossible de modifier ou supprimer l'utilisateur de connexion. C'est le compte utilisé par Qarote pour se connecter à ce serveur RabbitMQ.",
     "failedToSetPermissions": "Échec de la définition des permissions",
     "failedToDeletePermissions": "Échec de la suppression des permissions",
     "failedToFetchVhosts": "Échec de la récupération des hôtes virtuels",

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -171,6 +171,7 @@
     "failedToCreateUser": "创建用户失败",
     "failedToUpdateUser": "更新用户失败",
     "failedToDeleteUser": "删除用户失败",
+    "cannotModifyConnectionUser": "无法修改或删除连接用户。这是 Qarote 用于连接此 RabbitMQ 服务器的账户。",
     "failedToSetPermissions": "设置权限失败",
     "failedToDeletePermissions": "删除权限失败",
     "failedToFetchVhosts": "获取虚拟主机列表失败",

--- a/apps/api/src/trpc/routers/rabbitmq/users.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/users.ts
@@ -1,5 +1,7 @@
 import { TRPCError } from "@trpc/server";
 
+import { EncryptionService } from "@/services/encryption.service";
+
 import {
   CreateUserSchema,
   ServerWorkspaceInputSchema,
@@ -12,7 +14,11 @@ import { UserMapper } from "@/mappers/rabbitmq";
 
 import { authorize, router } from "@/trpc/trpc";
 
-import { createRabbitMQClient, verifyServerAccess } from "./shared";
+import {
+  createRabbitMQClient,
+  createRabbitMQClientFromServer,
+  verifyServerAccess,
+} from "./shared";
 
 import { UserRole } from "@/generated/prisma/client";
 import { te } from "@/i18n";
@@ -170,7 +176,18 @@ export const usersRouter = router({
           });
         }
 
-        const client = await createRabbitMQClient(serverId, workspaceId);
+        // Prevent modifying the connection user (the user Qarote uses to connect)
+        const connectionUsername = EncryptionService.decrypt(
+          verifiedServer.username
+        );
+        if (username === connectionUsername) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: te(ctx.locale, "rabbitmq.cannotModifyConnectionUser"),
+          });
+        }
+
+        const client = createRabbitMQClientFromServer(verifiedServer);
 
         const payload: {
           tags?: string;
@@ -209,9 +226,15 @@ export const usersRouter = router({
           throw error;
         }
         ctx.logger.error({ error }, "Error updating user:");
+        const reason =
+          error instanceof Error && typeof error.cause === "string"
+            ? error.cause
+            : undefined;
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
-          message: te(ctx.locale, "rabbitmq.failedToUpdateUser"),
+          message: reason
+            ? `${te(ctx.locale, "rabbitmq.failedToUpdateUser")}: ${reason}`
+            : te(ctx.locale, "rabbitmq.failedToUpdateUser"),
         });
       }
     }),
@@ -234,7 +257,18 @@ export const usersRouter = router({
           });
         }
 
-        const client = await createRabbitMQClient(serverId, workspaceId);
+        // Prevent deleting the connection user (the user Qarote uses to connect)
+        const connectionUsername = EncryptionService.decrypt(
+          verifiedServer.username
+        );
+        if (username === connectionUsername) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: te(ctx.locale, "rabbitmq.cannotModifyConnectionUser"),
+          });
+        }
+
+        const client = createRabbitMQClientFromServer(verifiedServer);
         await client.deleteUser(username);
 
         ctx.logger.info(

--- a/apps/app/public/locales/en/users.json
+++ b/apps/app/public/locales/en/users.json
@@ -56,6 +56,7 @@
   "dangerZone": "Danger zone",
   "deleteUser": "Delete user",
   "cannotDeleteAdmin": "Cannot delete the admin user",
+  "cannotModifyConnectionUser": "Cannot modify or delete the connection user. This is the account Qarote uses to connect to this server.",
   "maxConnections": "Max Connections",
   "maxChannels": "Max Channels",
   "limitsLabel": "Limits",

--- a/apps/app/public/locales/es/users.json
+++ b/apps/app/public/locales/es/users.json
@@ -56,6 +56,7 @@
   "dangerZone": "Zona de peligro",
   "deleteUser": "Eliminar usuario",
   "cannotDeleteAdmin": "No se puede eliminar el usuario administrador",
+  "cannotModifyConnectionUser": "No se puede modificar o eliminar el usuario de conexión. Esta es la cuenta que Qarote utiliza para conectarse a este servidor.",
   "maxConnections": "M\u00e1ximo de conexiones",
   "maxChannels": "M\u00e1ximo de canales",
   "limitsLabel": "L\u00edmites",

--- a/apps/app/public/locales/fr/users.json
+++ b/apps/app/public/locales/fr/users.json
@@ -56,6 +56,7 @@
   "dangerZone": "Zone dangereuse",
   "deleteUser": "Supprimer l'utilisateur",
   "cannotDeleteAdmin": "Impossible de supprimer l'utilisateur administrateur",
+  "cannotModifyConnectionUser": "Impossible de modifier ou supprimer l'utilisateur de connexion. C'est le compte utilisé par Qarote pour se connecter à ce serveur.",
   "maxConnections": "Connexions max.",
   "maxChannels": "Canaux max.",
   "limitsLabel": "Limites",

--- a/apps/app/public/locales/zh/users.json
+++ b/apps/app/public/locales/zh/users.json
@@ -56,6 +56,7 @@
   "dangerZone": "危险操作",
   "deleteUser": "删除用户",
   "cannotDeleteAdmin": "无法删除管理员用户",
+  "cannotModifyConnectionUser": "无法修改或删除连接用户。这是 Qarote 用于连接此服务器的账户。",
   "maxConnections": "最大连接数",
   "maxChannels": "最大通道数",
   "limitsLabel": "限制",

--- a/apps/app/src/pages/UserDetailsPage.tsx
+++ b/apps/app/src/pages/UserDetailsPage.tsx
@@ -79,9 +79,13 @@ export default function UserDetailsPage() {
   const currentServerId = serverId || selectedServerId;
   const decodedUsername = decodeURIComponent(username || "");
   // Validate that the server actually exists
-  const serverExists = currentServerId
-    ? servers.some((s) => s.id === currentServerId)
-    : false;
+  const currentServer = currentServerId
+    ? servers.find((s) => s.id === currentServerId)
+    : undefined;
+  const serverExists = !!currentServer;
+
+  // Check if this is the connection user (the account Qarote uses to connect)
+  const isConnectionUser = currentServer?.username === decodedUsername;
 
   const {
     data: userData,
@@ -720,7 +724,14 @@ export default function UserDetailsPage() {
                         <Button
                           className="btn-primary"
                           onClick={handleUpdateUser}
-                          disabled={updateUserMutation.isPending}
+                          disabled={
+                            updateUserMutation.isPending || isConnectionUser
+                          }
+                          title={
+                            isConnectionUser
+                              ? t("cannotModifyConnectionUser")
+                              : undefined
+                          }
                         >
                           {updateUserMutation.isPending
                             ? t("updating")
@@ -743,13 +754,25 @@ export default function UserDetailsPage() {
                   <Button
                     variant="destructive"
                     onClick={() => setShowDeleteModal(true)}
-                    disabled={decodedUsername === "admin"}
+                    disabled={
+                      decodedUsername === "admin" || isConnectionUser
+                    }
+                    title={
+                      isConnectionUser
+                        ? t("cannotModifyConnectionUser")
+                        : undefined
+                    }
                   >
                     {t("deleteUser")}
                   </Button>
                   {decodedUsername === "admin" && (
                     <p className="text-sm text-muted-foreground mt-2">
                       {t("cannotDeleteAdmin")}
+                    </p>
+                  )}
+                  {isConnectionUser && (
+                    <p className="text-sm text-muted-foreground mt-2">
+                      {t("cannotModifyConnectionUser")}
                     </p>
                   )}
                 </CardContent>


### PR DESCRIPTION
## Summary
- Prevents the RabbitMQ connection user (the account Qarote uses to connect to the server) from being modified or deleted via the API
- Disables the update and delete buttons in the frontend UI when viewing the connection user, with explanatory tooltips/messages
- Adds `cannotModifyConnectionUser` translations in EN/ES/FR/ZH for both API errors and frontend UI
- Improves error messages for user update failures by including the error cause when available

## Test plan
- [ ] Verify that attempting to update the connection user via the API returns a 403 FORBIDDEN error
- [ ] Verify that attempting to delete the connection user via the API returns a 403 FORBIDDEN error
- [ ] Verify that the update button is disabled on the connection user's detail page
- [ ] Verify that the delete button is disabled on the connection user's detail page
- [ ] Verify that other users can still be modified and deleted normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental modification or deletion of the RabbitMQ connection user account. The system now blocks these operations and displays clear warnings when attempting to modify the account used to connect to the server.

* **Localization**
  * Added multi-language support (English, Spanish, French, Chinese) for connection user protection messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->