### PR TITLE
feat: UI improvements, settings refactor, and performance optimizations

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "/bin/zsh",
+      "runtimeArgs": ["-c", "source ~/.nvm/nvm.sh && nvm use && pnpm run dev"],
+      "port": 8080
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# Qarote
+
+RabbitMQ monitoring dashboard with a freemium model. Core monitoring is free (MIT); premium features (workspaces, alerting, integrations) are unlocked via JWT license keys validated offline.
+
+## Tech Stack
+
+- **Monorepo**: pnpm 9 workspaces + Turborepo
+- **Backend** (`apps/api`): Hono.js, tRPC, Prisma (PostgreSQL), better-auth, Stripe
+- **Frontend** (`apps/app`): Vite, React 19, Tailwind CSS 4, Radix UI / shadcn, React Hook Form + Zod, TanStack Query, i18next
+- **Website** (`apps/web`): Vite + React (landing page)
+- **Portal** (`apps/portal`): Vite + React (customer portal)
+- **E2E** (`apps/e2e`): Playwright
+- **Shared**: `packages/i18n`
+- **Node**: v24, **pnpm**: v9
+
+## Common Commands
+
+```bash
+pnpm dev              # Start all apps in dev mode
+pnpm dev:api          # API only
+pnpm dev:app          # Frontend only
+pnpm build            # Build API
+pnpm build:app        # Build frontend
+pnpm test             # Run all tests
+pnpm lint             # ESLint across all workspaces
+pnpm format           # Prettier check
+pnpm format:fix       # Prettier fix
+pnpm type-check       # TypeScript check
+pnpm db:migrate:dev   # Create Prisma migration
+pnpm db:migrate       # Run migrations
+pnpm db:generate      # Generate Prisma client
+pnpm db:studio        # Open Prisma Studio
+```
+
+## Code Conventions
+
+- **Commits**: Conventional Commits enforced by commitlint + Husky. Types: `feat`, `fix`, `refactor`, `chore`, `docs`, `style`, `perf`, `test`, `build`, `ci`, `revert`. Lowercase subject, no period, max 100 chars.
+- **Formatting**: Prettier — double quotes, semicolons, 2-space indent, trailing commas (ES5), LF line endings.
+- **Linting**: ESLint flat config per app. No `console.log` in production. `simple-import-sort` with strict group ordering. No `any`.
+- **Styling**: Tailwind CSS 4 utility classes. Radix UI primitives wrapped as shadcn components.
+- **Database**: Prisma schema at `apps/api/prisma/schema.prisma`. Generated client at `apps/api/src/generated/prisma`.
+
+## Architecture
+
+- **API**: Hono.js serves tRPC routes. Auth via better-auth (email/password + SSO via OIDC/SAML). RabbitMQ connections via amqplib.
+- **Frontend**: SPA with React Router. Data fetching via TanStack Query + tRPC client.
+- **Licensing**: JWT license keys validated offline with baked-in public key. Two tiers: Developer ($348/yr), Enterprise ($1,188/yr).
+- **Deployment**: Dokku (recommended), Docker Compose, or standalone binary. Procfile workers: `web`, `worker` (alerts), `license-worker`, `release-notifier`.
+
+## Key Directories
+
+```
+apps/api/src/          # Backend source
+apps/api/prisma/       # Prisma schema & migrations
+apps/app/src/          # Frontend source
+apps/app/src/components/ui/  # shadcn UI components
+apps/app/src/pages/    # Page components
+apps/web/              # Landing site
+apps/portal/           # Customer portal
+packages/i18n/         # Shared i18n
+scripts/               # Utility scripts (seed, migrate, stripe, etc.)
+docs/                  # Project documentation
+docs/adr/              # Architecture Decision Records
+```
+
+## Documentation
+
+- `docs/README.md` — Documentation hub
+- `docs/SELF_HOSTED_DEPLOYMENT.md` — Deployment guide (binary, Docker, Dokku)
+- `docs/COMMUNITY_EDITION.md` — Free edition guide
+- `docs/ENTERPRISE_EDITION.md` — Licensed features guide
+- `docs/FEATURE_COMPARISON.md` — Edition comparison
+- `docs/RELEASE_MANAGEMENT.md` — Versioning & release-it workflow
+- `docs/adr/` — Architecture Decision Records

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ pnpm db:studio        # Open Prisma Studio
 
 ## Key Directories
 
-```
+```text
 apps/api/src/          # Backend source
 apps/api/prisma/       # Prisma schema & migrations
 apps/app/src/          # Frontend source

--- a/apps/api/src/trpc/routers/rabbitmq/users.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/users.ts
@@ -12,7 +12,7 @@ import { UserMapper } from "@/mappers/rabbitmq";
 
 import { authorize, router } from "@/trpc/trpc";
 
-import { createRabbitMQClient, verifyServerAccess } from "./shared";
+import { createRabbitMQClientFromServer, verifyServerAccess } from "./shared";
 
 import { UserRole } from "@/generated/prisma/client";
 import { te } from "@/i18n";
@@ -40,7 +40,7 @@ export const usersRouter = router({
           });
         }
 
-        const client = await createRabbitMQClient(serverId, workspaceId);
+        const client = createRabbitMQClientFromServer(verifiedServer);
         const users = await client.getUsers();
 
         // Map users to API response format (only include fields used by web)
@@ -77,7 +77,7 @@ export const usersRouter = router({
           });
         }
 
-        const client = await createRabbitMQClient(serverId, workspaceId);
+        const client = createRabbitMQClientFromServer(verifiedServer);
         const userDetails = await client.getUser(username);
         const permissions = await client.getUserPermissions(username);
 
@@ -118,7 +118,7 @@ export const usersRouter = router({
           });
         }
 
-        const client = await createRabbitMQClient(serverId, workspaceId);
+        const client = createRabbitMQClientFromServer(verifiedServer);
         await client.createUser(username, {
           password,
           tags,
@@ -170,7 +170,7 @@ export const usersRouter = router({
           });
         }
 
-        const client = await createRabbitMQClient(serverId, workspaceId);
+        const client = createRabbitMQClientFromServer(verifiedServer);
 
         const payload: {
           tags?: string;
@@ -234,7 +234,7 @@ export const usersRouter = router({
           });
         }
 
-        const client = await createRabbitMQClient(serverId, workspaceId);
+        const client = createRabbitMQClientFromServer(verifiedServer);
         await client.deleteUser(username);
 
         ctx.logger.info(
@@ -277,7 +277,7 @@ export const usersRouter = router({
           });
         }
 
-        const client = await createRabbitMQClient(serverId, workspaceId);
+        const client = createRabbitMQClientFromServer(verifiedServer);
         await client.setUserPermissions(vhost, username, {
           user: username,
           configure,
@@ -324,7 +324,7 @@ export const usersRouter = router({
           });
         }
 
-        const client = await createRabbitMQClient(serverId, workspaceId);
+        const client = createRabbitMQClientFromServer(verifiedServer);
         await client.deleteUserPermissions(vhost, username);
 
         ctx.logger.info(

--- a/apps/app/public/locales/en/alerts.json
+++ b/apps/app/public/locales/en/alerts.json
@@ -76,6 +76,13 @@
     "description": "Configure email and webhook notifications for new alerts. Select which alert severities you want to receive notifications for.",
     "loadingWorkspace": "Loading workspace...",
     "close": "Close",
+    "tabs": {
+      "general": "General",
+      "email": "Email",
+      "browser": "Browser",
+      "webhook": "Webhook",
+      "slack": "Slack"
+    },
     "servers": "Servers",
     "serversDescription": "Select which servers you want to receive notifications for. If none are selected, notifications will be sent for all servers.",
     "searchAndSelect": "Search and select servers...",

--- a/apps/app/public/locales/en/alerts.json
+++ b/apps/app/public/locales/en/alerts.json
@@ -146,6 +146,9 @@
     "httpHeaders": "HTTP Headers",
     "jsonPayload": "JSON Payload",
     "webhookSignatureNote": "<strong>Note:</strong> If you configure a secret, the payload will include an <code>X-Qarote-Signature</code> header with an HMAC-SHA256 signature. You can use this to verify the authenticity of the webhook request.",
+    "webhookSignatureNoteLabel": "Note:",
+    "webhookSignatureNoteText": "If you configure a secret, the payload will include an",
+    "webhookSignatureNoteSuffix": "header with an HMAC-SHA256 signature. You can use this to verify the authenticity of the webhook request.",
     "toastSettingsUpdated": "Settings updated successfully",
     "toastEmailRequired": "Please provide an email address for notifications",
     "toastEmailInvalid": "Please provide a valid email address",
@@ -170,6 +173,8 @@
     "toastSlackCreated": "Slack configuration created successfully",
     "toastSlackCreateFailed": "Failed to create Slack configuration",
     "toastSlackDeleted": "Slack configuration deleted successfully",
-    "toastSlackDeleteFailed": "Failed to delete Slack configuration"
+    "toastSlackDeleteFailed": "Failed to delete Slack configuration",
+    "toastSlackEnabled": "Slack notifications enabled",
+    "toastSlackDisabled": "Slack notifications disabled"
   }
 }

--- a/apps/app/public/locales/en/billing.json
+++ b/apps/app/public/locales/en/billing.json
@@ -171,6 +171,9 @@
     "seeAllOptions": "See all available options",
     "compare": "Compare",
     "license": "License",
-    "manageLicense": "Activate or manage your license"
+    "manageLicense": "Activate or manage your license",
+    "preferSelfHost": "Prefer to self-host?",
+    "preferSelfHostDesc": "Deploy Qarote on your own infrastructure with a license key.",
+    "learnMore": "Learn more"
   }
 }

--- a/apps/app/public/locales/en/help.json
+++ b/apps/app/public/locales/en/help.json
@@ -28,6 +28,12 @@
     "copyFailed": "Copy failed",
     "copyFailedDescription": "Please manually copy: support@qarote.io"
   },
+  "chat": {
+    "title": "Live Chat",
+    "description": "Prefer real-time help? Start a conversation with our team.",
+    "startChat": "Start a conversation",
+    "unavailable": "Chat is currently unavailable. Please try again later or contact us via email."
+  },
   "community": {
     "title": "Community Support",
     "description": "Join our Discord community to get help from other users and the team."
@@ -36,23 +42,43 @@
   "faqs": {
     "connectServer": {
       "question": "How do I connect to my RabbitMQ server?",
-      "answer": "Go to the Dashboard and look for the server selector or 'Add Server' option. Enter your RabbitMQ connection details including host, port, username, and password. You can test the connection before saving."
+      "answer": "From the sidebar, click the server selector or the gear icon, then 'Add Server'. Enter your RabbitMQ Management API host, port, and credentials. Hit 'Test Connection' to verify before saving. Qarote connects via the HTTP Management API (default port 15672 or 443 for TLS)."
     },
-    "cantSeeQueues": {
-      "question": "Why can't I see my queues?",
-      "answer": "Make sure your RabbitMQ server is running and accessible. Check that your user has the necessary permissions to view queues. You can test the connection from the Dashboard or by selecting a different server from the server dropdown."
+    "credentialsSecurity": {
+      "question": "Is my RabbitMQ password stored securely?",
+      "answer": "Yes. Your server credentials are encrypted at rest using AES-256 encryption. They are never exposed in the UI after initial setup, and are only used server-side to communicate with your RabbitMQ Management API over HTTPS."
     },
-    "dataStorage": {
-      "question": "What data does the dashboard store?",
-      "answer": "The dashboard operates in live mode with no persistent storage."
+    "readOnly": {
+      "question": "Does Qarote modify my RabbitMQ server?",
+      "answer": "Qarote is primarily a read-only monitoring tool. It uses the RabbitMQ Management API to fetch metrics, queues, connections, and node data. Queue actions like purge or delete are explicit user actions that require confirmation — Qarote never modifies your server automatically."
+    },
+    "compatibility": {
+      "question": "Can I use Qarote with Amazon MQ, CloudAMQP, or self-hosted?",
+      "answer": "Yes. Qarote works with any RabbitMQ instance that exposes the Management API, including Amazon MQ for RabbitMQ, CloudAMQP, Bitnami, Docker, and bare-metal installations. Just make sure the Management plugin is enabled and the API port is accessible."
+    },
+    "multipleServers": {
+      "question": "Can I monitor multiple servers across environments?",
+      "answer": "Yes. You can add multiple servers (dev, staging, production) to your workspace and switch between them from the sidebar. Each server has its own connection settings and virtual host selector."
+    },
+    "refreshRate": {
+      "question": "How often does the dashboard refresh data?",
+      "answer": "Metric cards refresh every 10-30 seconds depending on the data type. The queued messages chart updates every 5 seconds. You can see the refresh interval displayed on each card. Data is fetched directly from your RabbitMQ server and briefly cached between refresh cycles for performance."
+    },
+    "availability": {
+      "question": "What happens if Qarote goes down?",
+      "answer": "Nothing. Qarote is a passive observer — it reads data from your RabbitMQ servers but is not in the message path. If Qarote is unavailable, your RabbitMQ clusters continue operating normally. You just temporarily lose dashboard visibility and alert notifications."
     },
     "setupAlerts": {
       "question": "How do I set up alerts?",
-      "answer": "Go to the Alerts page and create alert rules based on queue metrics like message count, consumer count, or memory usage. You can set threshold preferences."
+      "answer": "Go to the Alerts page and click 'Create Alert Rule'. Choose a metric type (queue depth, memory, disk, etc.), set a threshold and severity level. You'll be notified via your configured channels (email, browser, webhook, or Slack) when the threshold is breached."
     },
-    "managePermissions": {
-      "question": "How do I manage user permissions?",
-      "answer": "Workspace administrators can manage user roles and permissions from the Users page. Different roles have different levels of access to features and data."
+    "teamMembers": {
+      "question": "How do I add team members to my workspace?",
+      "answer": "Go to Settings > Organization and click 'Invite'. Enter your teammate's email — they'll receive an invitation to join your workspace. You can assign roles (Member or Admin) to control access levels."
+    },
+    "plans": {
+      "question": "What's the difference between free and paid plans?",
+      "answer": "The free plan includes 1 server and basic monitoring. Paid plans unlock multiple servers, advanced alerts, webhook/Slack integrations, team collaboration, and priority support. Check Settings > Subscription for current plan details and upgrade options."
     }
   }
 }

--- a/apps/app/public/locales/en/settings.json
+++ b/apps/app/public/locales/en/settings.json
@@ -15,7 +15,19 @@
     "sso": "SSO",
     "license": "License",
     "smtp": "Email",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "enterprise": "Enterprise"
+  },
+  "sso": {
+    "upgradeTitle": "Enterprise Feature",
+    "upgradeDescription": "SSO with OIDC and SAML 2.0 is available on the Enterprise plan.",
+    "upgradeRequirement": "Enterprise Plan Required",
+    "upgradeCloudHint": "Upgrade your plan to configure single sign-on for your organization.",
+    "upgradeSelfHostedHint": "Activate an Enterprise license to configure single sign-on for your organization.",
+    "viewPlans": "View Plans",
+    "contactSales": "Contact Sales",
+    "activateLicense": "Activate License",
+    "purchaseLicense": "Purchase License"
   },
   "feedback": {
     "title": "Send Feedback",

--- a/apps/app/public/locales/es/alerts.json
+++ b/apps/app/public/locales/es/alerts.json
@@ -146,6 +146,9 @@
     "httpHeaders": "Encabezados HTTP",
     "jsonPayload": "Carga útil JSON",
     "webhookSignatureNote": "<strong>Nota:</strong> Si configuras un secreto, la carga útil incluirá un encabezado <code>X-Qarote-Signature</code> con una firma HMAC-SHA256. Puedes usarlo para verificar la autenticidad de la solicitud webhook.",
+    "webhookSignatureNoteLabel": "Nota:",
+    "webhookSignatureNoteText": "Si configuras un secreto, la carga útil incluirá un encabezado",
+    "webhookSignatureNoteSuffix": "con una firma HMAC-SHA256. Puedes usarlo para verificar la autenticidad de la solicitud webhook.",
     "toastSettingsUpdated": "Configuración actualizada correctamente",
     "toastEmailRequired": "Por favor proporciona una dirección de correo electrónico para las notificaciones",
     "toastEmailInvalid": "Por favor proporciona una dirección de correo electrónico válida",
@@ -170,6 +173,8 @@
     "toastSlackCreated": "Configuración de Slack creada correctamente",
     "toastSlackCreateFailed": "Error al crear la configuración de Slack",
     "toastSlackDeleted": "Configuración de Slack eliminada correctamente",
-    "toastSlackDeleteFailed": "Error al eliminar la configuración de Slack"
+    "toastSlackDeleteFailed": "Error al eliminar la configuración de Slack",
+    "toastSlackEnabled": "Notificaciones de Slack habilitadas",
+    "toastSlackDisabled": "Notificaciones de Slack deshabilitadas"
   }
 }

--- a/apps/app/public/locales/es/alerts.json
+++ b/apps/app/public/locales/es/alerts.json
@@ -76,6 +76,13 @@
     "description": "Configura las notificaciones por correo electrónico y webhook para nuevas alertas. Selecciona los niveles de gravedad para los que deseas recibir notificaciones.",
     "loadingWorkspace": "Cargando espacio de trabajo...",
     "close": "Cerrar",
+    "tabs": {
+      "general": "General",
+      "email": "Correo",
+      "browser": "Navegador",
+      "webhook": "Webhook",
+      "slack": "Slack"
+    },
     "servers": "Servidores",
     "serversDescription": "Selecciona los servidores para los que deseas recibir notificaciones. Si no se selecciona ninguno, se enviarán notificaciones para todos los servidores.",
     "searchAndSelect": "Buscar y seleccionar servidores...",

--- a/apps/app/public/locales/es/billing.json
+++ b/apps/app/public/locales/es/billing.json
@@ -171,6 +171,9 @@
     "seeAllOptions": "Ver todas las opciones disponibles",
     "compare": "Comparar",
     "license": "Licencia",
-    "manageLicense": "Activar o administrar tu licencia"
+    "manageLicense": "Activar o administrar tu licencia",
+    "preferSelfHost": "¿Prefieres el auto-alojamiento?",
+    "preferSelfHostDesc": "Despliega Qarote en tu propia infraestructura con una clave de licencia.",
+    "learnMore": "Más información"
   }
 }

--- a/apps/app/public/locales/es/help.json
+++ b/apps/app/public/locales/es/help.json
@@ -28,6 +28,12 @@
     "copyFailed": "Error al copiar",
     "copyFailedDescription": "Por favor copia manualmente: support@qarote.io"
   },
+  "chat": {
+    "title": "Chat en vivo",
+    "description": "¿Prefieres ayuda en tiempo real? Inicia una conversación con nuestro equipo.",
+    "startChat": "Iniciar una conversación",
+    "unavailable": "El chat no está disponible actualmente. Inténtelo de nuevo más tarde o contáctenos por correo electrónico."
+  },
   "community": {
     "title": "Soporte comunitario",
     "description": "Únete a nuestra comunidad de Discord para obtener ayuda de otros usuarios y del equipo."
@@ -36,23 +42,43 @@
   "faqs": {
     "connectServer": {
       "question": "¿Cómo me conecto a mi servidor RabbitMQ?",
-      "answer": "Ve al Panel y busca el selector de servidor o la opción 'Agregar servidor'. Ingresa los detalles de conexión de tu RabbitMQ, incluyendo host, puerto, nombre de usuario y contraseña. Puedes probar la conexión antes de guardar."
+      "answer": "Desde la barra lateral, haz clic en el selector de servidor o el icono de engranaje, luego 'Agregar servidor'. Ingresa el host, puerto y credenciales de la API Management de RabbitMQ. Haz clic en 'Probar conexión' para verificar antes de guardar. Qarote se conecta a través de la API HTTP Management (puerto predeterminado 15672 o 443 para TLS)."
     },
-    "cantSeeQueues": {
-      "question": "¿Por qué no puedo ver mis colas?",
-      "answer": "Asegúrate de que tu servidor RabbitMQ esté en ejecución y accesible. Verifica que tu usuario tenga los permisos necesarios para ver las colas. Puedes probar la conexión desde el Panel o seleccionando un servidor diferente en el menú desplegable de servidores."
+    "credentialsSecurity": {
+      "question": "¿Mi contraseña de RabbitMQ se almacena de forma segura?",
+      "answer": "Sí. Las credenciales de tu servidor están cifradas en reposo con cifrado AES-256. Nunca se exponen en la interfaz después de la configuración inicial y solo se utilizan del lado del servidor para comunicarse con tu API Management de RabbitMQ a través de HTTPS."
     },
-    "dataStorage": {
-      "question": "¿Qué datos almacena el panel?",
-      "answer": "El panel opera en modo en vivo sin almacenamiento persistente."
+    "readOnly": {
+      "question": "¿Qarote modifica mi servidor RabbitMQ?",
+      "answer": "Qarote es principalmente una herramienta de monitoreo de solo lectura. Utiliza la API Management de RabbitMQ para obtener métricas, colas, conexiones y datos de nodos. Las acciones en colas como purgar o eliminar son acciones explícitas del usuario que requieren confirmación — Qarote nunca modifica tu servidor automáticamente."
+    },
+    "compatibility": {
+      "question": "¿Puedo usar Qarote con Amazon MQ, CloudAMQP o autoalojado?",
+      "answer": "Sí. Qarote funciona con cualquier instancia de RabbitMQ que exponga la API Management, incluyendo Amazon MQ para RabbitMQ, CloudAMQP, Bitnami, Docker e instalaciones bare-metal. Solo asegúrate de que el plugin Management esté habilitado y el puerto API sea accesible."
+    },
+    "multipleServers": {
+      "question": "¿Puedo monitorear múltiples servidores en diferentes entornos?",
+      "answer": "Sí. Puedes agregar múltiples servidores (dev, staging, producción) a tu espacio de trabajo y cambiar entre ellos desde la barra lateral. Cada servidor tiene sus propias configuraciones de conexión y selector de virtual host."
+    },
+    "refreshRate": {
+      "question": "¿Con qué frecuencia se actualizan los datos del panel?",
+      "answer": "Las tarjetas de métricas se actualizan cada 10-30 segundos según el tipo de datos. El gráfico de mensajes en cola se actualiza cada 5 segundos. El intervalo de actualización se muestra en cada tarjeta. Los datos se obtienen directamente de su servidor RabbitMQ y se almacenan brevemente en caché entre los ciclos de actualización para mejorar el rendimiento."
+    },
+    "availability": {
+      "question": "¿Qué pasa si Qarote se cae?",
+      "answer": "Nada. Qarote es un observador pasivo — lee datos de tus servidores RabbitMQ pero no está en la ruta de mensajes. Si Qarote no está disponible, tus clusters de RabbitMQ continúan operando normalmente. Solo pierdes temporalmente la visibilidad del panel y las notificaciones de alertas."
     },
     "setupAlerts": {
       "question": "¿Cómo configuro las alertas?",
-      "answer": "Ve a la página de Alertas y crea reglas de alerta basadas en métricas de colas como cantidad de mensajes, cantidad de consumidores o uso de memoria. Puedes establecer preferencias de umbrales."
+      "answer": "Ve a la página de Alertas y haz clic en 'Crear regla de alerta'. Elige un tipo de métrica (profundidad de cola, memoria, disco, etc.), establece un umbral y nivel de severidad. Serás notificado a través de tus canales configurados (email, navegador, webhook o Slack) cuando se supere el umbral."
     },
-    "managePermissions": {
-      "question": "¿Cómo administro los permisos de usuarios?",
-      "answer": "Los administradores del espacio de trabajo pueden administrar roles y permisos de usuarios desde la página de Usuarios. Los diferentes roles tienen diferentes niveles de acceso a funciones y datos."
+    "teamMembers": {
+      "question": "¿Cómo agrego miembros del equipo a mi espacio de trabajo?",
+      "answer": "Ve a Configuración > Organización y haz clic en 'Invitar'. Ingresa el email de tu compañero — recibirá una invitación para unirse a tu espacio de trabajo. Puedes asignar roles (Miembro o Admin) para controlar los niveles de acceso."
+    },
+    "plans": {
+      "question": "¿Cuál es la diferencia entre los planes gratuito y de pago?",
+      "answer": "El plan gratuito incluye 1 servidor y monitoreo básico. Los planes de pago desbloquean múltiples servidores, alertas avanzadas, integraciones webhook/Slack, colaboración en equipo y soporte prioritario. Consulta Configuración > Suscripción para los detalles de tu plan actual y opciones de actualización."
     }
   }
 }

--- a/apps/app/public/locales/es/settings.json
+++ b/apps/app/public/locales/es/settings.json
@@ -15,7 +15,19 @@
     "sso": "SSO",
     "license": "Licencia",
     "smtp": "Correo",
-    "feedback": "Comentarios"
+    "feedback": "Comentarios",
+    "enterprise": "Enterprise"
+  },
+  "sso": {
+    "upgradeTitle": "Función Enterprise",
+    "upgradeDescription": "SSO con OIDC y SAML 2.0 está disponible en el plan Enterprise.",
+    "upgradeRequirement": "Plan Enterprise requerido",
+    "upgradeCloudHint": "Actualice su plan para configurar el inicio de sesión único para su organización.",
+    "upgradeSelfHostedHint": "Active una licencia Enterprise para configurar el inicio de sesión único para su organización.",
+    "viewPlans": "Ver planes",
+    "contactSales": "Contactar ventas",
+    "activateLicense": "Activar licencia",
+    "purchaseLicense": "Comprar licencia"
   },
   "feedback": {
     "title": "Enviar comentarios",

--- a/apps/app/public/locales/fr/alerts.json
+++ b/apps/app/public/locales/fr/alerts.json
@@ -146,6 +146,9 @@
     "httpHeaders": "En-têtes HTTP",
     "jsonPayload": "Charge utile JSON",
     "webhookSignatureNote": "<strong>Remarque :</strong> Si vous configurez un secret, la charge utile inclura un en-tête <code>X-Qarote-Signature</code> avec une signature HMAC-SHA256. Vous pouvez l'utiliser pour vérifier l'authenticité de la requête webhook.",
+    "webhookSignatureNoteLabel": "Remarque :",
+    "webhookSignatureNoteText": "Si vous configurez un secret, la charge utile inclura un en-tête",
+    "webhookSignatureNoteSuffix": "avec une signature HMAC-SHA256. Vous pouvez l'utiliser pour vérifier l'authenticité de la requête webhook.",
     "toastSettingsUpdated": "Paramètres mis à jour avec succès",
     "toastEmailRequired": "Veuillez fournir une adresse e-mail pour les notifications",
     "toastEmailInvalid": "Veuillez fournir une adresse e-mail valide",
@@ -170,6 +173,8 @@
     "toastSlackCreated": "Configuration Slack créée avec succès",
     "toastSlackCreateFailed": "Échec de la création de la configuration Slack",
     "toastSlackDeleted": "Configuration Slack supprimée avec succès",
-    "toastSlackDeleteFailed": "Échec de la suppression de la configuration Slack"
+    "toastSlackDeleteFailed": "Échec de la suppression de la configuration Slack",
+    "toastSlackEnabled": "Notifications Slack activées",
+    "toastSlackDisabled": "Notifications Slack désactivées"
   }
 }

--- a/apps/app/public/locales/fr/alerts.json
+++ b/apps/app/public/locales/fr/alerts.json
@@ -76,6 +76,13 @@
     "description": "Configurez les notifications par e-mail et webhook pour les nouvelles alertes. Sélectionnez les niveaux de gravité pour lesquels vous souhaitez recevoir des notifications.",
     "loadingWorkspace": "Chargement de l'espace de travail...",
     "close": "Fermer",
+    "tabs": {
+      "general": "Général",
+      "email": "Email",
+      "browser": "Navigateur",
+      "webhook": "Webhook",
+      "slack": "Slack"
+    },
     "servers": "Serveurs",
     "serversDescription": "Sélectionnez les serveurs pour lesquels vous souhaitez recevoir des notifications. Si aucun n'est sélectionné, les notifications seront envoyées pour tous les serveurs.",
     "searchAndSelect": "Rechercher et sélectionner des serveurs...",

--- a/apps/app/public/locales/fr/billing.json
+++ b/apps/app/public/locales/fr/billing.json
@@ -171,6 +171,9 @@
     "seeAllOptions": "Voir toutes les options disponibles",
     "compare": "Comparer",
     "license": "Licence",
-    "manageLicense": "Activer ou gérer votre licence"
+    "manageLicense": "Activer ou gérer votre licence",
+    "preferSelfHost": "Vous préférez l'auto-hébergement ?",
+    "preferSelfHostDesc": "Déployez Qarote sur votre propre infrastructure avec une clé de licence.",
+    "learnMore": "En savoir plus"
   }
 }

--- a/apps/app/public/locales/fr/help.json
+++ b/apps/app/public/locales/fr/help.json
@@ -28,6 +28,12 @@
     "copyFailed": "Échec de la copie",
     "copyFailedDescription": "Veuillez copier manuellement : support@qarote.io"
   },
+  "chat": {
+    "title": "Chat en direct",
+    "description": "Besoin d'aide en temps réel ? Démarrez une conversation avec notre équipe.",
+    "startChat": "Démarrer une conversation",
+    "unavailable": "Le chat est actuellement indisponible. Veuillez réessayer plus tard ou nous contacter par email."
+  },
   "community": {
     "title": "Support communautaire",
     "description": "Rejoignez notre communauté Discord pour obtenir de l'aide des autres utilisateurs et de l'équipe."
@@ -36,23 +42,43 @@
   "faqs": {
     "connectServer": {
       "question": "Comment me connecter à mon serveur RabbitMQ ?",
-      "answer": "Allez sur le tableau de bord et cherchez le sélecteur de serveur ou l'option 'Ajouter un serveur'. Entrez les détails de votre connexion RabbitMQ, y compris l'hôte, le port, le nom d'utilisateur et le mot de passe. Vous pouvez tester la connexion avant de l'enregistrer."
+      "answer": "Depuis la barre latérale, cliquez sur le sélecteur de serveur ou l'icône engrenage, puis 'Ajouter un serveur'. Entrez l'hôte, le port et les identifiants de l'API Management RabbitMQ. Cliquez sur 'Tester la connexion' pour vérifier avant d'enregistrer. Qarote se connecte via l'API HTTP Management (port par défaut 15672 ou 443 pour TLS)."
     },
-    "cantSeeQueues": {
-      "question": "Pourquoi ne puis-je pas voir mes files d'attente ?",
-      "answer": "Assurez-vous que votre serveur RabbitMQ est en cours d'exécution et accessible. Vérifiez que votre utilisateur dispose des permissions nécessaires pour afficher les files d'attente. Vous pouvez tester la connexion depuis le tableau de bord ou en sélectionnant un autre serveur dans le menu déroulant."
+    "credentialsSecurity": {
+      "question": "Mon mot de passe RabbitMQ est-il stocké de manière sécurisée ?",
+      "answer": "Oui. Vos identifiants serveur sont chiffrés au repos avec un chiffrement AES-256. Ils ne sont jamais exposés dans l'interface après la configuration initiale et sont uniquement utilisés côté serveur pour communiquer avec votre API Management RabbitMQ via HTTPS."
     },
-    "dataStorage": {
-      "question": "Quelles données le tableau de bord stocke-t-il ?",
-      "answer": "Le tableau de bord fonctionne en mode temps réel sans stockage persistant."
+    "readOnly": {
+      "question": "Qarote modifie-t-il mon serveur RabbitMQ ?",
+      "answer": "Qarote est principalement un outil de surveillance en lecture seule. Il utilise l'API Management RabbitMQ pour récupérer les métriques, files d'attente, connexions et données des nœuds. Les actions sur les files (purge, suppression) sont des actions utilisateur explicites nécessitant une confirmation — Qarote ne modifie jamais votre serveur automatiquement."
+    },
+    "compatibility": {
+      "question": "Puis-je utiliser Qarote avec Amazon MQ, CloudAMQP ou en auto-hébergé ?",
+      "answer": "Oui. Qarote fonctionne avec toute instance RabbitMQ qui expose l'API Management, y compris Amazon MQ pour RabbitMQ, CloudAMQP, Bitnami, Docker et les installations bare-metal. Assurez-vous simplement que le plugin Management est activé et que le port API est accessible."
+    },
+    "multipleServers": {
+      "question": "Puis-je surveiller plusieurs serveurs dans différents environnements ?",
+      "answer": "Oui. Vous pouvez ajouter plusieurs serveurs (dev, staging, production) à votre espace de travail et basculer entre eux depuis la barre latérale. Chaque serveur a ses propres paramètres de connexion et sélecteur de virtual host."
+    },
+    "refreshRate": {
+      "question": "À quelle fréquence le tableau de bord actualise-t-il les données ?",
+      "answer": "Les cartes métriques se rafraîchissent toutes les 10 à 30 secondes selon le type de données. Le graphique des messages en file se met à jour toutes les 5 secondes. L'intervalle de rafraîchissement est affiché sur chaque carte. Les données sont récupérées directement depuis votre serveur RabbitMQ et brièvement mises en cache entre les cycles de rafraîchissement pour la performance."
+    },
+    "availability": {
+      "question": "Que se passe-t-il si Qarote tombe en panne ?",
+      "answer": "Rien. Qarote est un observateur passif — il lit les données de vos serveurs RabbitMQ mais n'est pas dans le chemin des messages. Si Qarote est indisponible, vos clusters RabbitMQ continuent de fonctionner normalement. Vous perdez temporairement la visibilité du tableau de bord et les notifications d'alerte."
     },
     "setupAlerts": {
       "question": "Comment configurer les alertes ?",
-      "answer": "Allez sur la page Alertes et créez des règles d'alerte basées sur les métriques des files d'attente comme le nombre de messages, le nombre de consommateurs ou l'utilisation de la mémoire. Vous pouvez définir vos préférences de seuils."
+      "answer": "Allez sur la page Alertes et cliquez sur 'Créer une règle d'alerte'. Choisissez un type de métrique (profondeur de file, mémoire, disque, etc.), définissez un seuil et un niveau de sévérité. Vous serez notifié via vos canaux configurés (email, navigateur, webhook ou Slack) lorsque le seuil est dépassé."
     },
-    "managePermissions": {
-      "question": "Comment gérer les permissions des utilisateurs ?",
-      "answer": "Les administrateurs de l'espace de travail peuvent gérer les rôles et les permissions des utilisateurs depuis la page Utilisateurs. Les différents rôles offrent différents niveaux d'accès aux fonctionnalités et aux données."
+    "teamMembers": {
+      "question": "Comment ajouter des membres à mon espace de travail ?",
+      "answer": "Allez dans Paramètres > Organisation et cliquez sur 'Inviter'. Entrez l'email de votre collègue — il recevra une invitation à rejoindre votre espace de travail. Vous pouvez attribuer des rôles (Membre ou Admin) pour contrôler les niveaux d'accès."
+    },
+    "plans": {
+      "question": "Quelle est la différence entre les plans gratuit et payant ?",
+      "answer": "Le plan gratuit inclut 1 serveur et la surveillance de base. Les plans payants débloquent plusieurs serveurs, les alertes avancées, les intégrations webhook/Slack, la collaboration en équipe et le support prioritaire. Consultez Paramètres > Abonnement pour les détails de votre plan actuel et les options de mise à niveau."
     }
   }
 }

--- a/apps/app/public/locales/fr/settings.json
+++ b/apps/app/public/locales/fr/settings.json
@@ -15,7 +15,19 @@
     "sso": "SSO",
     "license": "Licence",
     "smtp": "E-mail",
-    "feedback": "Commentaires"
+    "feedback": "Commentaires",
+    "enterprise": "Enterprise"
+  },
+  "sso": {
+    "upgradeTitle": "Fonctionnalité Enterprise",
+    "upgradeDescription": "Le SSO avec OIDC et SAML 2.0 est disponible avec le plan Enterprise.",
+    "upgradeRequirement": "Plan Enterprise requis",
+    "upgradeCloudHint": "Mettez à niveau votre plan pour configurer l'authentification unique pour votre organisation.",
+    "upgradeSelfHostedHint": "Activez une licence Enterprise pour configurer l'authentification unique pour votre organisation.",
+    "viewPlans": "Voir les plans",
+    "contactSales": "Contacter les ventes",
+    "activateLicense": "Activer la licence",
+    "purchaseLicense": "Acheter une licence"
   },
   "feedback": {
     "title": "Envoyer un commentaire",

--- a/apps/app/public/locales/zh/alerts.json
+++ b/apps/app/public/locales/zh/alerts.json
@@ -76,6 +76,13 @@
     "description": "配置新告警的电子邮件和 Webhook 通知。选择您希望接收通知的告警严重级别。",
     "loadingWorkspace": "正在加载工作区...",
     "close": "关闭",
+    "tabs": {
+      "general": "常规",
+      "email": "邮件",
+      "browser": "浏览器",
+      "webhook": "Webhook",
+      "slack": "Slack"
+    },
     "servers": "服务器",
     "serversDescription": "选择您希望接收通知的服务器。如果未选择任何服务器，将发送所有服务器的通知。",
     "searchAndSelect": "搜索并选择服务器...",

--- a/apps/app/public/locales/zh/alerts.json
+++ b/apps/app/public/locales/zh/alerts.json
@@ -146,6 +146,9 @@
     "httpHeaders": "HTTP 请求头",
     "jsonPayload": "JSON 负载",
     "webhookSignatureNote": "<strong>注意：</strong>如果您配置了密钥，负载将包含带有 HMAC-SHA256 签名的 <code>X-Qarote-Signature</code> 请求头。您可以使用它来验证 Webhook 请求的真实性。",
+    "webhookSignatureNoteLabel": "注意：",
+    "webhookSignatureNoteText": "如果您配置了密钥，负载将包含带有 HMAC-SHA256 签名的",
+    "webhookSignatureNoteSuffix": "请求头。您可以使用它来验证 Webhook 请求的真实性。",
     "toastSettingsUpdated": "设置更新成功",
     "toastEmailRequired": "请提供用于通知的电子邮件地址",
     "toastEmailInvalid": "请提供有效的电子邮件地址",
@@ -170,6 +173,8 @@
     "toastSlackCreated": "Slack 配置创建成功",
     "toastSlackCreateFailed": "Slack 配置创建失败",
     "toastSlackDeleted": "Slack 配置删除成功",
-    "toastSlackDeleteFailed": "Slack 配置删除失败"
+    "toastSlackDeleteFailed": "Slack 配置删除失败",
+    "toastSlackEnabled": "Slack 通知已启用",
+    "toastSlackDisabled": "Slack 通知已禁用"
   }
 }

--- a/apps/app/public/locales/zh/billing.json
+++ b/apps/app/public/locales/zh/billing.json
@@ -171,6 +171,9 @@
     "seeAllOptions": "查看所有可用选项",
     "compare": "比较",
     "license": "许可证",
-    "manageLicense": "激活或管理您的许可证"
+    "manageLicense": "激活或管理您的许可证",
+    "preferSelfHost": "更喜欢自托管？",
+    "preferSelfHostDesc": "使用许可证密钥在您自己的基础设施上部署 Qarote。",
+    "learnMore": "了解更多"
   }
 }

--- a/apps/app/public/locales/zh/help.json
+++ b/apps/app/public/locales/zh/help.json
@@ -28,6 +28,12 @@
     "copyFailed": "复制失败",
     "copyFailedDescription": "请手动复制：support@qarote.io"
   },
+  "chat": {
+    "title": "在线聊天",
+    "description": "需要实时帮助？与我们的团队开始对话。",
+    "startChat": "开始对话",
+    "unavailable": "聊天目前不可用。请稍后再试或通过邮件联系我们。"
+  },
   "community": {
     "title": "社区支持",
     "description": "加入我们的 Discord 社区，从其他用户和团队获取帮助。"
@@ -36,23 +42,43 @@
   "faqs": {
     "connectServer": {
       "question": "如何连接到我的 RabbitMQ 服务器？",
-      "answer": "前往仪表盘，找到服务器选择器或「添加服务器」选项。输入您的 RabbitMQ 连接详情，包括主机、端口、用户名和密码。您可以在保存前测试连接。"
+      "answer": "在侧边栏中，点击服务器选择器或齿轮图标，然后选择「添加服务器」。输入 RabbitMQ Management API 的主机、端口和凭据。点击「测试连接」在保存前进行验证。Qarote 通过 HTTP Management API 连接（默认端口 15672 或 TLS 使用 443）。"
     },
-    "cantSeeQueues": {
-      "question": "为什么看不到我的队列？",
-      "answer": "请确保您的 RabbitMQ 服务器正在运行且可以访问。检查您的用户是否具有查看队列所需的权限。您可以从仪表盘测试连接，或从服务器下拉菜单中选择其他服务器。"
+    "credentialsSecurity": {
+      "question": "我的 RabbitMQ 密码是否安全存储？",
+      "answer": "是的。您的服务器凭据使用 AES-256 加密进行静态加密。初始设置后永远不会在界面中暴露，仅在服务端通过 HTTPS 与您的 RabbitMQ Management API 通信时使用。"
     },
-    "dataStorage": {
-      "question": "仪表盘存储哪些数据？",
-      "answer": "仪表盘以实时模式运行，不进行持久化存储。"
+    "readOnly": {
+      "question": "Qarote 是否会修改我的 RabbitMQ 服务器？",
+      "answer": "Qarote 主要是只读监控工具。它使用 RabbitMQ Management API 获取指标、队列、连接和节点数据。清除或删除队列等操作是需要确认的显式用户操作 — Qarote 绝不会自动修改您的服务器。"
+    },
+    "compatibility": {
+      "question": "可以配合 Amazon MQ、CloudAMQP 或自托管使用 Qarote 吗？",
+      "answer": "可以。Qarote 支持任何暴露 Management API 的 RabbitMQ 实例，包括 Amazon MQ for RabbitMQ、CloudAMQP、Bitnami、Docker 和裸机安装。只需确保 Management 插件已启用且 API 端口可访问。"
+    },
+    "multipleServers": {
+      "question": "可以监控不同环境的多台服务器吗？",
+      "answer": "可以。您可以将多台服务器（开发、预发布、生产）添加到工作区，并从侧边栏在它们之间切换。每台服务器有独立的连接设置和虚拟主机选择器。"
+    },
+    "refreshRate": {
+      "question": "仪表盘多久刷新一次数据？",
+      "answer": "指标卡片根据数据类型每 10-30 秒刷新一次。队列消息图表每 5 秒更新一次。每张卡片上都显示刷新间隔。数据直接从您的 RabbitMQ 服务器获取，并在刷新周期之间短暂缓存以提高性能。"
+    },
+    "availability": {
+      "question": "如果 Qarote 宕机会怎样？",
+      "answer": "什么都不会发生。Qarote 是被动观察者 — 它从您的 RabbitMQ 服务器读取数据，但不在消息路径中。如果 Qarote 不可用，您的 RabbitMQ 集群将继续正常运行。您只是暂时失去仪表盘可见性和告警通知。"
     },
     "setupAlerts": {
       "question": "如何设置告警？",
-      "answer": "前往告警页面，根据队列指标（如消息数量、消费者数量或内存使用率）创建告警规则。您可以设置阈值偏好。"
+      "answer": "前往告警页面，点击「创建告警规则」。选择指标类型（队列深度、内存、磁盘等），设置阈值和严重级别。当阈值被突破时，您将通过配置的渠道（邮件、浏览器、Webhook 或 Slack）收到通知。"
     },
-    "managePermissions": {
-      "question": "如何管理用户权限？",
-      "answer": "工作区管理员可以从用户页面管理用户角色和权限。不同角色对功能和数据具有不同级别的访问权限。"
+    "teamMembers": {
+      "question": "如何将团队成员添加到工作区？",
+      "answer": "前往设置 > 组织，点击「邀请」。输入同事的邮箱 — 他们将收到加入您工作区的邀请。您可以分配角色（成员或管理员）来控制访问级别。"
+    },
+    "plans": {
+      "question": "免费计划和付费计划有什么区别？",
+      "answer": "免费计划包含 1 台服务器和基本监控。付费计划解锁多台服务器、高级告警、Webhook/Slack 集成、团队协作和优先支持。查看设置 > 订阅了解当前计划详情和升级选项。"
     }
   }
 }

--- a/apps/app/public/locales/zh/settings.json
+++ b/apps/app/public/locales/zh/settings.json
@@ -15,7 +15,19 @@
     "sso": "SSO",
     "license": "许可证",
     "smtp": "邮件",
-    "feedback": "反馈"
+    "feedback": "反馈",
+    "enterprise": "企业版"
+  },
+  "sso": {
+    "upgradeTitle": "企业版功能",
+    "upgradeDescription": "支持 OIDC 和 SAML 2.0 的单点登录仅在企业版计划中提供。",
+    "upgradeRequirement": "需要企业版计划",
+    "upgradeCloudHint": "升级您的计划以为您的组织配置单点登录。",
+    "upgradeSelfHostedHint": "激活企业版许可证以为您的组织配置单点登录。",
+    "viewPlans": "查看计划",
+    "contactSales": "联系销售",
+    "activateLicense": "激活许可证",
+    "purchaseLicense": "购买许可证"
   },
   "feedback": {
     "title": "发送反馈",

--- a/apps/app/src/components/AppSidebar.tsx
+++ b/apps/app/src/components/AppSidebar.tsx
@@ -359,7 +359,7 @@ export function AppSidebar() {
           to="/help"
           className={`flex items-center gap-2 text-sm rounded-md px-2 py-1.5 transition-colors ${
             location.pathname === "/help"
-              ? "bg-primary text-primary-foreground font-medium"
+              ? "bg-linear-to-r from-orange-600 to-red-600 text-white font-medium"
               : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent"
           }`}
         >
@@ -370,8 +370,17 @@ export function AppSidebar() {
         {/* User section */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2 text-sm">
-            <User className="w-4 h-4 text-sidebar-foreground/70" />
-            <div className="flex flex-col">
+            {user?.image ? (
+              <img
+                src={user.image}
+                alt=""
+                className="w-6 h-6 rounded-full object-cover shrink-0"
+                referrerPolicy="no-referrer"
+              />
+            ) : (
+              <User className="w-4 h-4 text-sidebar-foreground/70 shrink-0" />
+            )}
+            <div className="flex flex-col min-w-0">
               <span className="font-medium text-sidebar-foreground">
                 {user?.firstName} {user?.lastName}
               </span>

--- a/apps/app/src/components/alerts/AlertNotificationSettingsModal.tsx
+++ b/apps/app/src/components/alerts/AlertNotificationSettingsModal.tsx
@@ -56,6 +56,7 @@ interface AlertNotificationSettingsModalProps {
 function StatusDot({ enabled }: { enabled: boolean }) {
   return (
     <span
+      aria-hidden="true"
       className={`h-2 w-2 rounded-full shrink-0 ${
         enabled ? "bg-green-500" : "bg-muted-foreground/30"
       }`}

--- a/apps/app/src/components/alerts/AlertNotificationSettingsModal.tsx
+++ b/apps/app/src/components/alerts/AlertNotificationSettingsModal.tsx
@@ -375,6 +375,18 @@ export function AlertNotificationSettingsModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [notificationSeverities]);
 
+  // Auto-save when notification server IDs change
+  useEffect(() => {
+    if (isInitialMount.current) return;
+    const timeoutId = setTimeout(() => {
+      if (emailNotificationsEnabled) {
+        autoSaveSettings({ onlyEmailNotifications: true });
+      }
+    }, 100);
+    return () => clearTimeout(timeoutId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [notificationServerIds]);
+
   // Auto-save when browser notifications toggle changes
   useEffect(() => {
     if (isInitialMount.current) return;

--- a/apps/app/src/components/alerts/AlertNotificationSettingsModal.tsx
+++ b/apps/app/src/components/alerts/AlertNotificationSettingsModal.tsx
@@ -1,43 +1,20 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
   Bell,
-  BellOff,
-  Eye,
-  EyeOff,
   Loader2,
   Mail,
   MessageSquare,
-  Plus,
-  Search,
-  Trash2,
+  Settings,
   Webhook,
-  X,
 } from "lucide-react";
 import { toast } from "sonner";
 
 import { ApiError } from "@/lib/api/types";
 import { logger } from "@/lib/logger";
 
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
 import {
   Dialog,
   DialogContent,
@@ -45,14 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { useAuth } from "@/contexts/AuthContextDefinition";
 
@@ -71,9 +41,26 @@ import {
 import { useServers } from "@/hooks/queries/useServer";
 import { useWorkspace } from "@/hooks/ui/useWorkspace";
 
+import { BrowserTab } from "./notification-settings/BrowserTab";
+import { EmailTab } from "./notification-settings/EmailTab";
+import { GeneralTab } from "./notification-settings/GeneralTab";
+import { SlackTab } from "./notification-settings/SlackTab";
+import { WebhookExampleModal } from "./notification-settings/WebhookExampleModal";
+import { WebhookTab } from "./notification-settings/WebhookTab";
+
 interface AlertNotificationSettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
+}
+
+function StatusDot({ enabled }: { enabled: boolean }) {
+  return (
+    <span
+      className={`h-2 w-2 rounded-full shrink-0 ${
+        enabled ? "bg-green-500" : "bg-muted-foreground/30"
+      }`}
+    />
+  );
 }
 
 export function AlertNotificationSettingsModal({
@@ -102,8 +89,7 @@ export function AlertNotificationSettingsModal({
     NotificationPermission | "unsupported"
   >("Notification" in window ? Notification.permission : "unsupported");
 
-  // Resync permission state on each open so changes made in browser settings
-  // between opens are reflected immediately.
+  // Resync permission state on each open
   useEffect(() => {
     if (isOpen) {
       setNotificationPermission(
@@ -150,13 +136,13 @@ export function AlertNotificationSettingsModal({
   // Selected servers count
   const selectedCount = notificationServerIds?.length || 0;
 
-  // Webhook hooks (must be called before any early returns)
+  // Webhook hooks
   const { data: webhooks = [] } = useWebhooks(isOpen);
   const createWebhookMutation = useCreateWebhook();
   const updateWebhookMutation = useUpdateWebhook();
   const deleteWebhookMutation = useDeleteWebhook();
 
-  // Slack hooks (must be called before any early returns)
+  // Slack hooks
   const { data: slackConfigs = [] } = useSlackConfigs(isOpen);
   const createSlackConfigMutation = useCreateSlackConfig();
   const updateSlackConfigMutation = useUpdateSlackConfig();
@@ -198,8 +184,6 @@ export function AlertNotificationSettingsModal({
       setNotificationServerIds(
         settingsData.settings.notificationServerIds || null
       );
-      // Mark initial load as complete after settings are loaded
-      // Use a small delay to ensure state updates are complete
       const timeoutId = setTimeout(() => {
         isInitialMount.current = false;
       }, 200);
@@ -207,7 +191,7 @@ export function AlertNotificationSettingsModal({
     }
   }, [settingsData, workspace?.contactEmail]);
 
-  // Update webhook fields from first webhook (if exists)
+  // Update webhook fields from first webhook
   useEffect(() => {
     const firstWebhook = webhooks[0];
     if (firstWebhook) {
@@ -221,7 +205,7 @@ export function AlertNotificationSettingsModal({
     }
   }, [webhooks]);
 
-  // Update Slack fields from first Slack config (if exists)
+  // Update Slack fields from first Slack config
   useEffect(() => {
     const firstSlack = slackConfigs[0];
     if (firstSlack) {
@@ -233,7 +217,7 @@ export function AlertNotificationSettingsModal({
     }
   }, [slackConfigs]);
 
-  // Show loading state only if workspace is loading (settings will use placeholder data for instant display)
+  // Show loading state only if workspace is loading
   const isLoading = isWorkspaceLoading || !workspace?.id;
 
   // Mutation for updating settings
@@ -248,10 +232,8 @@ export function AlertNotificationSettingsModal({
   const [slackEnabled, setSlackEnabled] = useState(true);
 
   const [showWebhookExample, setShowWebhookExample] = useState(false);
-  const [webhookExampleVersion, setWebhookExampleVersion] = useState("v1");
 
-  // Auto-save function for email notifications and severities
-  // Use refs to access latest values without causing re-renders
+  // Auto-save refs
   const emailNotificationsEnabledRef = useRef(emailNotificationsEnabled);
   const contactEmailRef = useRef(contactEmail);
   const notificationSeveritiesRef = useRef(notificationSeverities);
@@ -260,7 +242,7 @@ export function AlertNotificationSettingsModal({
     browserNotificationSeverities
   );
 
-  // Keep refs in sync with state
+  // Keep refs in sync
   useEffect(() => {
     emailNotificationsEnabledRef.current = emailNotificationsEnabled;
   }, [emailNotificationsEnabled]);
@@ -296,26 +278,21 @@ export function AlertNotificationSettingsModal({
       const currentBrowserEnabled = browserNotificationsEnabledRef.current;
       const currentBrowserSeverities = browserNotificationSeveritiesRef.current;
 
-      // Validate email if notifications are enabled AND we're not only changing browser notifications
       if (!skipValidation && currentEnabled && !onlyBrowserNotifications) {
         if (!currentEmail.trim()) {
           toast.error(t("modal.toastEmailRequired"));
           return;
         }
-
         if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(currentEmail)) {
           toast.error(t("modal.toastEmailInvalid"));
           return;
         }
-
-        // Validate at least one severity is selected
         if (currentSeverities.length === 0) {
           toast.error(t("modal.toastSelectSeverity"));
           return;
         }
       }
 
-      // Validate browser notification severities
       if (!skipValidation && currentBrowserEnabled && !onlyEmailNotifications) {
         if (currentBrowserSeverities.length === 0) {
           toast.error(t("modal.toastSelectBrowserSeverity"));
@@ -323,7 +300,6 @@ export function AlertNotificationSettingsModal({
         }
       }
 
-      // Build the update payload - only include fields that are being changed
       const updatePayload: {
         emailNotificationsEnabled?: boolean;
         contactEmail?: string | null;
@@ -334,13 +310,11 @@ export function AlertNotificationSettingsModal({
       } = {};
 
       if (onlyBrowserNotifications) {
-        // Only update browser notification settings
         updatePayload.browserNotificationsEnabled = currentBrowserEnabled;
         updatePayload.browserNotificationSeverities = currentBrowserEnabled
           ? currentBrowserSeverities
           : undefined;
       } else if (onlyEmailNotifications) {
-        // Only update email notification settings
         updatePayload.emailNotificationsEnabled = currentEnabled;
         updatePayload.contactEmail = currentEnabled ? currentEmail : null;
         updatePayload.notificationSeverities = currentEnabled
@@ -348,7 +322,6 @@ export function AlertNotificationSettingsModal({
           : undefined;
         updatePayload.notificationServerIds = notificationServerIds;
       } else {
-        // Update all settings
         updatePayload.emailNotificationsEnabled = currentEnabled;
         updatePayload.contactEmail = currentEnabled ? currentEmail : null;
         updatePayload.notificationSeverities = currentEnabled
@@ -379,32 +352,24 @@ export function AlertNotificationSettingsModal({
   // Auto-save when email notifications toggle changes
   useEffect(() => {
     if (isInitialMount.current) return;
-
     const timeoutId = setTimeout(() => {
       autoSaveSettings({
-        skipValidation: !emailNotificationsEnabled, // Skip validation when toggling off
-        onlyEmailNotifications: true, // Only update email notification settings
+        skipValidation: !emailNotificationsEnabled,
+        onlyEmailNotifications: true,
       });
     }, 100);
-
     return () => clearTimeout(timeoutId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [emailNotificationsEnabled]);
 
-  // Email input changes - no auto-save, only save on button click
-
   // Auto-save when severities change
   useEffect(() => {
     if (isInitialMount.current) return;
-
     const timeoutId = setTimeout(() => {
       if (emailNotificationsEnabled) {
-        autoSaveSettings({
-          onlyEmailNotifications: true, // Only update email notification settings
-        });
+        autoSaveSettings({ onlyEmailNotifications: true });
       }
     }, 100);
-
     return () => clearTimeout(timeoutId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [notificationSeverities]);
@@ -412,14 +377,12 @@ export function AlertNotificationSettingsModal({
   // Auto-save when browser notifications toggle changes
   useEffect(() => {
     if (isInitialMount.current) return;
-
     const timeoutId = setTimeout(() => {
       autoSaveSettings({
-        skipValidation: !browserNotificationsEnabled, // Skip validation when toggling off
-        onlyBrowserNotifications: true, // Only update browser notification settings
+        skipValidation: !browserNotificationsEnabled,
+        onlyBrowserNotifications: true,
       });
     }, 100);
-
     return () => clearTimeout(timeoutId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [browserNotificationsEnabled]);
@@ -427,21 +390,15 @@ export function AlertNotificationSettingsModal({
   // Auto-save when browser notification severities change
   useEffect(() => {
     if (isInitialMount.current) return;
-
     const timeoutId = setTimeout(() => {
       if (browserNotificationsEnabled) {
-        autoSaveSettings({
-          onlyBrowserNotifications: true, // Only update browser notification settings
-        });
+        autoSaveSettings({ onlyBrowserNotifications: true });
       }
     }, 100);
-
     return () => clearTimeout(timeoutId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [browserNotificationSeverities]);
 
-  // Show modal immediately, but show loading state only if workspace is loading
-  // Settings will use placeholder data for instant display
   if (isLoading) {
     return (
       <Dialog open={isOpen} onOpenChange={onClose}>
@@ -459,14 +416,14 @@ export function AlertNotificationSettingsModal({
   }
 
   const firstWebhook = webhooks[0];
+  const firstSlack = slackConfigs[0];
 
+  // --- Webhook handlers ---
   const handleSaveWebhook = () => {
     if (!webhookUrl.trim()) {
       toast.error(t("modal.toastWebhookUrlRequired"));
       return;
     }
-
-    // Validate URL format
     let urlObj: URL;
     try {
       urlObj = new URL(webhookUrl.trim());
@@ -474,15 +431,11 @@ export function AlertNotificationSettingsModal({
       toast.error(t("modal.toastWebhookUrlInvalid"));
       return;
     }
-
-    // Prevent Slack webhook URLs in general webhook section
     if (urlObj.hostname === "hooks.slack.com") {
       toast.error(t("modal.toastWebhookSlackError"));
       return;
     }
-
     if (firstWebhook) {
-      // Update existing webhook
       updateWebhookMutation.mutate(
         {
           id: firstWebhook.id,
@@ -491,16 +444,12 @@ export function AlertNotificationSettingsModal({
           secret: webhookSecret.trim() || null,
         },
         {
-          onSuccess: () => {
-            toast.success(t("modal.toastWebhookUpdated"));
-          },
-          onError: (error: ApiError) => {
-            toast.error(error.message || t("modal.toastWebhookUpdateFailed"));
-          },
+          onSuccess: () => toast.success(t("modal.toastWebhookUpdated")),
+          onError: (error: ApiError) =>
+            toast.error(error.message || t("modal.toastWebhookUpdateFailed")),
         }
       );
     } else {
-      // Create new webhook
       createWebhookMutation.mutate(
         {
           url: webhookUrl.trim(),
@@ -508,12 +457,9 @@ export function AlertNotificationSettingsModal({
           secret: webhookSecret.trim() || null,
         },
         {
-          onSuccess: () => {
-            toast.success(t("modal.toastWebhookCreated"));
-          },
-          onError: (error: ApiError) => {
-            toast.error(error.message || t("modal.toastWebhookCreateFailed"));
-          },
+          onSuccess: () => toast.success(t("modal.toastWebhookCreated")),
+          onError: (error: ApiError) =>
+            toast.error(error.message || t("modal.toastWebhookCreateFailed")),
         }
       );
     }
@@ -528,21 +474,37 @@ export function AlertNotificationSettingsModal({
         setWebhookSecret("");
         setWebhookEnabled(true);
       },
-      onError: (error: ApiError) => {
-        toast.error(error.message || t("modal.toastWebhookDeleteFailed"));
-      },
+      onError: (error: ApiError) =>
+        toast.error(error.message || t("modal.toastWebhookDeleteFailed")),
     });
   };
 
-  const firstSlack = slackConfigs[0];
+  const handleToggleWebhook = (enabled: boolean) => {
+    setWebhookEnabled(enabled);
+    if (!firstWebhook) return;
+    updateWebhookMutation.mutate(
+      { id: firstWebhook.id, enabled },
+      {
+        onSuccess: () =>
+          toast.success(
+            enabled
+              ? t("modal.toastWebhookEnabled")
+              : t("modal.toastWebhookDisabled")
+          ),
+        onError: (error: ApiError) => {
+          toast.error(error.message || t("modal.toastWebhookUpdateFailed"));
+          setWebhookEnabled(!enabled);
+        },
+      }
+    );
+  };
 
+  // --- Slack handlers ---
   const handleSaveSlack = () => {
     if (!slackWebhookUrl.trim()) {
       toast.error(t("modal.toastSlackUrlRequired"));
       return;
     }
-
-    // Validate URL format
     let urlObj: URL;
     try {
       urlObj = new URL(slackWebhookUrl.trim());
@@ -550,8 +512,6 @@ export function AlertNotificationSettingsModal({
       toast.error(t("modal.toastWebhookUrlInvalid"));
       return;
     }
-
-    // Validate Slack webhook URL format
     if (
       urlObj.hostname !== "hooks.slack.com" ||
       !urlObj.pathname.startsWith("/services/") ||
@@ -560,9 +520,7 @@ export function AlertNotificationSettingsModal({
       toast.error(t("modal.toastSlackUrlInvalid"));
       return;
     }
-
     if (firstSlack) {
-      // Update existing Slack config
       updateSlackConfigMutation.mutate(
         {
           id: firstSlack.id,
@@ -570,28 +528,18 @@ export function AlertNotificationSettingsModal({
           enabled: slackEnabled,
         },
         {
-          onSuccess: () => {
-            toast.success(t("modal.toastSlackUpdated"));
-          },
-          onError: (error: ApiError) => {
-            toast.error(error.message || t("modal.toastSlackUpdateFailed"));
-          },
+          onSuccess: () => toast.success(t("modal.toastSlackUpdated")),
+          onError: (error: ApiError) =>
+            toast.error(error.message || t("modal.toastSlackUpdateFailed")),
         }
       );
     } else {
-      // Create new Slack config
       createSlackConfigMutation.mutate(
+        { webhookUrl: slackWebhookUrl.trim(), enabled: slackEnabled },
         {
-          webhookUrl: slackWebhookUrl.trim(),
-          enabled: slackEnabled,
-        },
-        {
-          onSuccess: () => {
-            toast.success(t("modal.toastSlackCreated"));
-          },
-          onError: (error: ApiError) => {
-            toast.error(error.message || t("modal.toastSlackCreateFailed"));
-          },
+          onSuccess: () => toast.success(t("modal.toastSlackCreated")),
+          onError: (error: ApiError) =>
+            toast.error(error.message || t("modal.toastSlackCreateFailed")),
         }
       );
     }
@@ -605,1078 +553,200 @@ export function AlertNotificationSettingsModal({
         setSlackWebhookUrl("");
         setSlackEnabled(true);
       },
-      onError: (error: ApiError) => {
-        toast.error(error.message || t("modal.toastSlackDeleteFailed"));
-      },
+      onError: (error: ApiError) =>
+        toast.error(error.message || t("modal.toastSlackDeleteFailed")),
     });
   };
 
   const handleToggleSlack = (enabled: boolean) => {
     setSlackEnabled(enabled);
-    if (!firstSlack) return; // Just update local state if no config exists yet
+    if (!firstSlack) return;
     updateSlackConfigMutation.mutate(
-      {
-        id: firstSlack.id,
-        enabled,
-      },
+      { id: firstSlack.id, enabled },
       {
         onError: (error: ApiError) => {
           toast.error(error.message || t("modal.toastSlackUpdateFailed"));
-          // Revert state on error
           setSlackEnabled(!enabled);
         },
       }
     );
   };
 
-  const handleToggleWebhook = (enabled: boolean) => {
-    setWebhookEnabled(enabled);
-    if (!firstWebhook) return; // Just update local state if no webhook exists yet
-    updateWebhookMutation.mutate(
-      {
-        id: firstWebhook.id,
-        enabled,
-      },
-      {
-        onSuccess: () => {
-          toast.success(
-            enabled
-              ? t("modal.toastWebhookEnabled")
-              : t("modal.toastWebhookDisabled")
-          );
-        },
-        onError: (error: ApiError) => {
-          toast.error(error.message || t("modal.toastWebhookUpdateFailed"));
-          // Revert state on error
-          setWebhookEnabled(!enabled);
-        },
-      }
-    );
+  const handleSaveEmail = () => {
+    if (contactEmail.trim() && emailNotificationsEnabled) {
+      autoSaveSettings({ onlyEmailNotifications: true });
+    }
   };
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Mail className="h-5 w-5" />
-            {t("modal.title")}
-          </DialogTitle>
-          <DialogDescription>{t("modal.description")}</DialogDescription>
-        </DialogHeader>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden p-0">
+        <div className="p-6 pb-0">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Mail className="h-5 w-5" />
+              {t("modal.title")}
+            </DialogTitle>
+            <DialogDescription>{t("modal.description")}</DialogDescription>
+          </DialogHeader>
+        </div>
 
-        <div className="space-y-6">
-          {/* Server Selection */}
-          {servers.length > 0 && (
-            <div className="space-y-3 p-4 border rounded-lg">
-              <div>
-                <Label className="text-base">{t("modal.servers")}</Label>
-                <p className="text-sm text-muted-foreground mt-1">
-                  {t("modal.serversDescription")}
-                </p>
-              </div>
-
-              {/* Selected Servers as Tags */}
-              {selectedServers.length > 0 && (
-                <div className="flex flex-wrap gap-2 p-3 border rounded-md bg-muted/50">
-                  {selectedServers.map((server) => (
-                    <Badge
-                      key={server.id}
-                      variant="secondary"
-                      className="flex items-center gap-1.5 pr-1"
-                    >
-                      <span className="text-xs">
-                        {server.name} ({server.host}:{server.port})
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const currentIds = notificationServerIds || [];
-                          const newIds = currentIds.filter(
-                            (id) => id !== server.id
-                          );
-                          setNotificationServerIds(
-                            newIds.length > 0 ? newIds : null
-                          );
-                        }}
-                        disabled={updateSettingsMutation.isPending}
-                        className="ml-1 rounded-full hover:bg-destructive hover:text-destructive-foreground transition-colors"
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </Badge>
-                  ))}
-                </div>
-              )}
-
-              {/* Search Input with Popover */}
-              <div className="flex items-center gap-2">
-                <Popover
-                  open={serverSearchOpen}
-                  onOpenChange={setServerSearchOpen}
-                >
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      role="combobox"
-                      aria-controls="server-search-list"
-                      aria-expanded={serverSearchOpen}
-                      className="w-full justify-between"
-                      disabled={updateSettingsMutation.isPending}
-                    >
-                      <div className="flex items-center gap-2">
-                        <Search className="h-4 w-4 text-muted-foreground" />
-                        <span className="text-muted-foreground">
-                          {selectedCount > 0
-                            ? t("modal.serversSelected", {
-                                count: selectedCount,
-                              })
-                            : t("modal.searchAndSelect")}
-                        </span>
-                      </div>
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-[400px] p-0" align="start">
-                    <Command>
-                      <CommandInput
-                        placeholder={t("modal.searchPlaceholder")}
-                        value={serverSearchTerm}
-                        onValueChange={setServerSearchTerm}
-                      />
-                      <CommandList id="server-search-list">
-                        <CommandEmpty>
-                          {serverSearchTerm
-                            ? t("modal.noServersFound", {
-                                term: serverSearchTerm,
-                              })
-                            : t("modal.noServersAvailable")}
-                        </CommandEmpty>
-                        <CommandGroup>
-                          {filteredServers.map((server) => (
-                            <CommandItem
-                              key={server.id}
-                              value={`${server.name} ${server.host} ${server.port}`}
-                              onSelect={() => {
-                                const currentIds = notificationServerIds || [];
-                                const newIds = [...currentIds, server.id];
-                                setNotificationServerIds(newIds);
-                                setServerSearchTerm("");
-                                // Keep popover open for multiple selections
-                              }}
-                            >
-                              <div className="flex flex-col">
-                                <span className="font-medium">
-                                  {server.name}
-                                </span>
-                                <span className="text-xs text-muted-foreground">
-                                  {server.host}:{server.port}
-                                </span>
-                              </div>
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
-
-                {selectedCount > 0 && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      setNotificationServerIds(null);
-                      setServerSearchOpen(false);
-                    }}
-                    disabled={updateSettingsMutation.isPending}
-                  >
-                    {t("modal.clearAll")}
-                  </Button>
-                )}
-              </div>
-
-              {selectedCount > 0 && (
-                <p className="text-xs text-muted-foreground">
-                  {t("modal.serverSelectionCount", {
-                    selected: selectedCount,
-                    total: servers.length,
-                    count: servers.length,
-                  })}
-                </p>
-              )}
-            </div>
-          )}
-
-          {/* Alert Severity Selection */}
-          <div className="space-y-3 p-4 border rounded-lg">
-            <Label className="text-base">{t("modal.alertSeverities")}</Label>
-            <p className="text-sm text-muted-foreground mb-3">
-              {t("modal.alertSeveritiesDescription")}
-            </p>
-            <div className="space-y-3">
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="severity-critical"
-                  checked={notificationSeverities.includes("CRITICAL")}
-                  onCheckedChange={(checked) => {
-                    const newSeverities = checked
-                      ? [...notificationSeverities, "CRITICAL"]
-                      : notificationSeverities.filter((s) => s !== "CRITICAL");
-                    setNotificationSeverities(newSeverities);
-                  }}
-                  disabled={updateSettingsMutation.isPending}
-                  className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                />
-                <Label
-                  htmlFor="severity-critical"
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <span className="text-red-600 font-medium">
-                    {t("modal.severityCritical")}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {t("modal.severityCriticalDesc")}
-                  </span>
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="severity-high"
-                  checked={notificationSeverities.includes("HIGH")}
-                  onCheckedChange={(checked) => {
-                    const newSeverities = checked
-                      ? [...notificationSeverities, "HIGH"]
-                      : notificationSeverities.filter((s) => s !== "HIGH");
-                    setNotificationSeverities(newSeverities);
-                  }}
-                  disabled={updateSettingsMutation.isPending}
-                  className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                />
-                <Label
-                  htmlFor="severity-high"
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <span className="text-orange-600 font-medium">
-                    {t("modal.severityHigh")}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {t("modal.severityHighDesc")}
-                  </span>
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="severity-medium"
-                  checked={notificationSeverities.includes("MEDIUM")}
-                  onCheckedChange={(checked) => {
-                    const newSeverities = checked
-                      ? [...notificationSeverities, "MEDIUM"]
-                      : notificationSeverities.filter((s) => s !== "MEDIUM");
-                    setNotificationSeverities(newSeverities);
-                  }}
-                  disabled={updateSettingsMutation.isPending}
-                  className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                />
-                <Label
-                  htmlFor="severity-medium"
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <span className="text-yellow-600 font-medium">
-                    {t("modal.severityMedium")}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {t("modal.severityMediumDesc")}
-                  </span>
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="severity-low"
-                  checked={notificationSeverities.includes("LOW")}
-                  onCheckedChange={(checked) => {
-                    const newSeverities = checked
-                      ? [...notificationSeverities, "LOW"]
-                      : notificationSeverities.filter((s) => s !== "LOW");
-                    setNotificationSeverities(newSeverities);
-                  }}
-                  disabled={updateSettingsMutation.isPending}
-                  className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                />
-                <Label
-                  htmlFor="severity-low"
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <span className="text-blue-600 font-medium">
-                    {t("modal.severityLow")}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {t("modal.severityLowDesc")}
-                  </span>
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="severity-info"
-                  checked={notificationSeverities.includes("INFO")}
-                  onCheckedChange={(checked) => {
-                    const newSeverities = checked
-                      ? [...notificationSeverities, "INFO"]
-                      : notificationSeverities.filter((s) => s !== "INFO");
-                    setNotificationSeverities(newSeverities);
-                  }}
-                  disabled={updateSettingsMutation.isPending}
-                  className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                />
-                <Label
-                  htmlFor="severity-info"
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <span className="text-gray-600 font-medium">
-                    {t("modal.severityInfo")}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {t("modal.severityInfoDesc")}
-                  </span>
-                </Label>
-              </div>
-            </div>
-            {notificationSeverities.length === 0 && (
-              <p className="text-xs text-red-500 mt-2">
-                {t("modal.selectAtLeastOneSeverity")}
-              </p>
-            )}
-          </div>
-
-          {/* Browser Notifications Section */}
-          <div className="space-y-3 p-4 border rounded-lg">
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label
-                  htmlFor="browser-notifications"
-                  className="text-base flex items-center gap-2"
-                >
-                  <Bell className="h-4 w-4" />
-                  {t("modal.browserNotifications")}
-                  {notificationPermission === "granted" && (
-                    <Badge
-                      variant="secondary"
-                      className="text-xs font-normal text-green-600"
-                    >
-                      {t("modal.permissionGranted")}
-                    </Badge>
-                  )}
-                  {notificationPermission === "denied" && (
-                    <Badge
-                      variant="destructive"
-                      className="text-xs font-normal"
-                    >
-                      {t("modal.permissionDenied")}
-                    </Badge>
-                  )}
-                </Label>
-                <p className="text-sm text-muted-foreground">
-                  {t("modal.browserNotificationsDescription")}
-                </p>
-              </div>
-              <Switch
-                id="browser-notifications"
-                checked={browserNotificationsEnabled}
-                onCheckedChange={(checked) => {
-                  if (!checked) {
-                    setBrowserNotificationsEnabled(false);
-                    return;
-                  }
-                  if (!("Notification" in window)) {
-                    setBrowserNotificationsEnabled(false);
-                    setNotificationPermission("unsupported");
-                    return;
-                  }
-                  if (Notification.permission === "granted") {
-                    setBrowserNotificationsEnabled(true);
-                    return;
-                  }
-                  if (Notification.permission === "denied") {
-                    setBrowserNotificationsEnabled(false);
-                    setNotificationPermission("denied");
-                    return;
-                  }
-                  Notification.requestPermission().then((permission) => {
-                    setNotificationPermission(permission);
-                    setBrowserNotificationsEnabled(permission === "granted");
-                  });
-                }}
-                disabled={updateSettingsMutation.isPending}
-                className="data-[state=checked]:bg-gradient-button"
-              />
-            </div>
-
-            {"Notification" in window &&
-              browserNotificationsEnabled &&
-              notificationPermission === "denied" && (
-                <Alert className="mt-4" variant="destructive">
-                  <BellOff className="h-4 w-4" />
-                  <AlertDescription>
-                    {t("modal.browserNotificationsBlocked")}
-                  </AlertDescription>
-                </Alert>
-              )}
-
-            {browserNotificationsEnabled &&
-              notificationPermission === "granted" && (
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {t("modal.browserNotificationsSystemHint")}
-                </p>
-              )}
-
-            {browserNotificationsEnabled && (
-              <div className="mt-4 space-y-3 pt-4 border-t">
-                <Label className="text-sm font-medium">
-                  {t("modal.browserNotificationSeverities")}
-                </Label>
-                <p className="text-xs text-muted-foreground mb-3">
-                  {t("modal.browserNotificationSeveritiesDescription")}
-                </p>
-                <div className="space-y-3">
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="browser-severity-critical"
-                      checked={browserNotificationSeverities.includes(
-                        "CRITICAL"
-                      )}
-                      onCheckedChange={(checked) => {
-                        const newSeverities = checked
-                          ? [...browserNotificationSeverities, "CRITICAL"]
-                          : browserNotificationSeverities.filter(
-                              (s) => s !== "CRITICAL"
-                            );
-                        setBrowserNotificationSeverities(newSeverities);
-                      }}
-                      disabled={updateSettingsMutation.isPending}
-                      className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                    />
-                    <Label
-                      htmlFor="browser-severity-critical"
-                      className="flex items-center gap-2 cursor-pointer"
-                    >
-                      <span className="text-red-600 font-medium">
-                        {t("modal.severityCritical")}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {t("modal.severityCriticalDesc")}
-                      </span>
-                    </Label>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="browser-severity-high"
-                      checked={browserNotificationSeverities.includes("HIGH")}
-                      onCheckedChange={(checked) => {
-                        const newSeverities = checked
-                          ? [...browserNotificationSeverities, "HIGH"]
-                          : browserNotificationSeverities.filter(
-                              (s) => s !== "HIGH"
-                            );
-                        setBrowserNotificationSeverities(newSeverities);
-                      }}
-                      disabled={updateSettingsMutation.isPending}
-                      className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                    />
-                    <Label
-                      htmlFor="browser-severity-high"
-                      className="flex items-center gap-2 cursor-pointer"
-                    >
-                      <span className="text-orange-600 font-medium">
-                        {t("modal.severityHigh")}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {t("modal.severityHighDesc")}
-                      </span>
-                    </Label>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="browser-severity-medium"
-                      checked={browserNotificationSeverities.includes("MEDIUM")}
-                      onCheckedChange={(checked) => {
-                        const newSeverities = checked
-                          ? [...browserNotificationSeverities, "MEDIUM"]
-                          : browserNotificationSeverities.filter(
-                              (s) => s !== "MEDIUM"
-                            );
-                        setBrowserNotificationSeverities(newSeverities);
-                      }}
-                      disabled={updateSettingsMutation.isPending}
-                      className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                    />
-                    <Label
-                      htmlFor="browser-severity-medium"
-                      className="flex items-center gap-2 cursor-pointer"
-                    >
-                      <span className="text-yellow-600 font-medium">
-                        {t("modal.severityMedium")}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {t("modal.severityMediumDesc")}
-                      </span>
-                    </Label>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="browser-severity-low"
-                      checked={browserNotificationSeverities.includes("LOW")}
-                      onCheckedChange={(checked) => {
-                        const newSeverities = checked
-                          ? [...browserNotificationSeverities, "LOW"]
-                          : browserNotificationSeverities.filter(
-                              (s) => s !== "LOW"
-                            );
-                        setBrowserNotificationSeverities(newSeverities);
-                      }}
-                      disabled={updateSettingsMutation.isPending}
-                      className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                    />
-                    <Label
-                      htmlFor="browser-severity-low"
-                      className="flex items-center gap-2 cursor-pointer"
-                    >
-                      <span className="text-blue-600 font-medium">
-                        {t("modal.severityLow")}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {t("modal.severityLowDesc")}
-                      </span>
-                    </Label>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="browser-severity-info"
-                      checked={browserNotificationSeverities.includes("INFO")}
-                      onCheckedChange={(checked) => {
-                        const newSeverities = checked
-                          ? [...browserNotificationSeverities, "INFO"]
-                          : browserNotificationSeverities.filter(
-                              (s) => s !== "INFO"
-                            );
-                        setBrowserNotificationSeverities(newSeverities);
-                      }}
-                      disabled={updateSettingsMutation.isPending}
-                      className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
-                    />
-                    <Label
-                      htmlFor="browser-severity-info"
-                      className="flex items-center gap-2 cursor-pointer"
-                    >
-                      <span className="text-gray-600 font-medium">
-                        {t("modal.severityInfo")}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {t("modal.severityInfoDesc")}
-                      </span>
-                    </Label>
-                  </div>
-                </div>
-                {browserNotificationSeverities.length === 0 && (
-                  <p className="text-xs text-red-500 mt-2">
-                    {t("modal.selectAtLeastOneBrowserSeverity")}
-                  </p>
-                )}
-              </div>
-            )}
-
-            {!browserNotificationsEnabled && (
-              <Alert className="mt-4">
-                <BellOff className="h-4 w-4" />
-                <AlertDescription>
-                  {t("modal.browserNotificationsDisabled")}
-                </AlertDescription>
-              </Alert>
-            )}
-          </div>
-
-          {/* Divider */}
-          <hr className="border-t border-border" />
-
-          {/* Email Notifications Toggle */}
-          <div className="flex items-center justify-between p-4 border rounded-lg">
-            <div className="space-y-0.5">
-              <Label htmlFor="email-notifications" className="text-base">
-                {t("modal.emailNotifications")}
-              </Label>
-              <p className="text-sm text-muted-foreground">
-                {t("modal.emailNotificationsDescription")}
-              </p>
-            </div>
-            <Switch
-              id="email-notifications"
-              checked={emailNotificationsEnabled}
-              onCheckedChange={setEmailNotificationsEnabled}
-              disabled={updateSettingsMutation.isPending}
-              className="data-[state=checked]:bg-gradient-button"
-            />
-          </div>
-
-          {/* Contact Email Input */}
-          {emailNotificationsEnabled && (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="contact-email">
-                  {t("modal.notificationEmailAddress")}
-                  <span className="text-red-500 ml-1">*</span>
-                </Label>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    if (contactEmail.trim() && emailNotificationsEnabled) {
-                      autoSaveSettings({
-                        onlyEmailNotifications: true, // Only update email notification settings
-                      });
-                    }
-                  }}
-                  disabled={
-                    updateSettingsMutation.isPending || !contactEmail.trim()
-                  }
-                  className="bg-gradient-button hover:bg-gradient-button-hover text-white hover:text-white"
-                >
-                  <Plus className="h-4 w-4 mr-2" />
-                  {t("modal.update")}
-                </Button>
-              </div>
-              <Input
-                id="contact-email"
-                type="email"
-                placeholder="your-email@example.com"
-                value={contactEmail}
-                onChange={(e) => setContactEmail(e.target.value)}
-                onKeyDown={(e) => {
-                  // Save on Enter key
-                  if (
-                    e.key === "Enter" &&
-                    contactEmail.trim() &&
-                    emailNotificationsEnabled
-                  ) {
-                    e.preventDefault();
-                    autoSaveSettings({
-                      onlyEmailNotifications: true, // Only update email notification settings
-                    });
-                  }
-                }}
-                disabled={updateSettingsMutation.isPending}
-                required={emailNotificationsEnabled}
-              />
-              <p className="text-xs text-muted-foreground">
-                {t("modal.emailHelp")}
-              </p>
-            </div>
-          )}
-
-          {/* Info Alert */}
-          {!emailNotificationsEnabled && (
-            <Alert>
-              <BellOff className="h-4 w-4" />
-              <AlertDescription>
-                {t("modal.emailNotificationsDisabled")}
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {/* Webhooks Section */}
-          <div className="space-y-4 pt-6 border-t">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Webhook className="h-5 w-5" />
-                <Label className="text-base">
-                  {t("modal.webhookNotifications")}
-                </Label>
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setShowWebhookExample(true)}
-              >
-                {t("modal.viewExamplePayload")}
-              </Button>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {t("modal.webhookDescription")}
-            </p>
-
-            <div className="p-4 border rounded-lg space-y-3">
-              <div className="space-y-2">
-                <Label htmlFor="webhook-url">
-                  {t("modal.webhookUrl")}
-                  <span className="text-red-500 ml-1">*</span>
-                </Label>
-                <Input
-                  id="webhook-url"
-                  type="url"
-                  placeholder="https://your-endpoint.com/webhook"
-                  value={webhookUrl}
-                  onChange={(e) => setWebhookUrl(e.target.value)}
-                  disabled={
-                    createWebhookMutation.isPending ||
-                    updateWebhookMutation.isPending
-                  }
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="webhook-secret">
-                  {t("modal.webhookSecretOptional")}
-                </Label>
-                <div className="relative">
-                  <Input
-                    id="webhook-secret"
-                    type={showSecret ? "text" : "password"}
-                    placeholder={t("modal.webhookSecretPlaceholder")}
-                    value={webhookSecret}
-                    onChange={(e) => setWebhookSecret(e.target.value)}
-                    disabled={
-                      createWebhookMutation.isPending ||
-                      updateWebhookMutation.isPending
-                    }
-                    className="pr-10"
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
-                    onClick={() => setShowSecret(!showSecret)}
-                    disabled={
-                      createWebhookMutation.isPending ||
-                      updateWebhookMutation.isPending
-                    }
-                  >
-                    {showSecret ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </Button>
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  {t("modal.webhookSecretHelp")}
-                </p>
-              </div>
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="webhook-enabled"
-                    checked={webhookEnabled}
-                    onCheckedChange={handleToggleWebhook}
-                    disabled={
-                      createWebhookMutation.isPending ||
-                      updateWebhookMutation.isPending
-                    }
-                    className="data-[state=checked]:bg-gradient-button"
-                  />
-                  <Label htmlFor="webhook-enabled">{t("modal.enabled")}</Label>
-                </div>
-                <div className="flex gap-2">
-                  {firstWebhook && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleDeleteWebhook}
-                      disabled={deleteWebhookMutation.isPending}
-                    >
-                      <Trash2 className="h-4 w-4 text-red-600" />
-                    </Button>
-                  )}
-                  <Button
-                    type="button"
-                    size="sm"
-                    onClick={handleSaveWebhook}
-                    disabled={
-                      createWebhookMutation.isPending ||
-                      updateWebhookMutation.isPending ||
-                      !webhookUrl.trim()
-                    }
-                    className="bg-gradient-button hover:bg-gradient-button-hover text-white hover:text-white"
-                  >
-                    {createWebhookMutation.isPending ||
-                    updateWebhookMutation.isPending ? (
-                      <>
-                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                        {firstWebhook
-                          ? t("modal.updating")
-                          : t("modal.creating")}
-                      </>
-                    ) : firstWebhook ? (
-                      t("modal.update")
-                    ) : (
-                      t("modal.save")
-                    )}
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Slack Section */}
-          <div className="space-y-4 pt-6 border-t">
-            <div className="flex items-center gap-2">
-              <MessageSquare className="h-5 w-5" />
-              <Label className="text-base">
-                {t("modal.slackNotifications")}
-              </Label>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {t("modal.slackDescription")}
-            </p>
-
-            <div className="space-y-4 p-4 border rounded-lg">
-              <div className="space-y-2">
-                <Label htmlFor="slack-webhook-url">
-                  {t("modal.slackWebhookUrl")}
-                  <span className="text-red-500 ml-1">*</span>
-                </Label>
-                <Input
-                  id="slack-webhook-url"
-                  type="url"
-                  placeholder="https://hooks.slack.com/services/..."
-                  value={slackWebhookUrl}
-                  onChange={(e) => setSlackWebhookUrl(e.target.value)}
-                  disabled={
-                    createSlackConfigMutation.isPending ||
-                    updateSlackConfigMutation.isPending
-                  }
-                />
-                <p className="text-xs text-muted-foreground">
-                  {t("modal.slackWebhookHelp")}{" "}
-                  <a
-                    href="https://api.slack.com/messaging/webhooks"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-primary hover:underline font-medium"
-                  >
-                    {t("modal.slackWebhookLink")}
-                  </a>
-                  .
-                </p>
-              </div>
-
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Switch
-                    checked={slackEnabled}
-                    onCheckedChange={handleToggleSlack}
-                    disabled={
-                      createSlackConfigMutation.isPending ||
-                      updateSlackConfigMutation.isPending
-                    }
-                    className="data-[state=checked]:bg-gradient-button"
-                  />
-                  <Label htmlFor="slack-enabled">{t("modal.enabled")}</Label>
-                </div>
-                <div className="flex gap-2">
-                  {firstSlack && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleDeleteSlack}
-                      disabled={deleteSlackConfigMutation.isPending}
-                    >
-                      <Trash2 className="h-4 w-4 text-red-600" />
-                    </Button>
-                  )}
-                  <Button
-                    type="button"
-                    onClick={handleSaveSlack}
-                    disabled={
-                      createSlackConfigMutation.isPending ||
-                      updateSlackConfigMutation.isPending ||
-                      !slackWebhookUrl.trim()
-                    }
-                    className="bg-gradient-button hover:bg-gradient-button-hover text-white hover:text-white"
-                  >
-                    {createSlackConfigMutation.isPending ||
-                    updateSlackConfigMutation.isPending ? (
-                      <>
-                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                        {firstSlack ? t("modal.updating") : t("modal.creating")}
-                      </>
-                    ) : firstSlack ? (
-                      t("modal.update")
-                    ) : (
-                      t("modal.save")
-                    )}
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Actions */}
-          <div className="flex items-center justify-end gap-2 pt-4 border-t">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={onClose}
-              disabled={updateSettingsMutation.isPending}
+        <Tabs
+          defaultValue="general"
+          orientation="vertical"
+          className="flex flex-1 min-h-0 px-6"
+        >
+          <TabsList className="flex flex-col h-auto bg-transparent gap-1 pr-4 border-r min-w-[160px] rounded-none justify-start py-2">
+            <TabsTrigger
+              value="general"
+              className="w-full justify-start gap-2 px-3 py-2 data-[state=active]:bg-muted rounded-md"
             >
-              {t("modal.close")}
-            </Button>
+              <Settings className="h-4 w-4" />
+              {t("modal.tabs.general")}
+            </TabsTrigger>
+            <TabsTrigger
+              value="email"
+              className="w-full justify-start gap-2 px-3 py-2 data-[state=active]:bg-muted rounded-md"
+            >
+              <Mail className="h-4 w-4" />
+              {t("modal.tabs.email")}
+              <StatusDot enabled={emailNotificationsEnabled} />
+            </TabsTrigger>
+            <TabsTrigger
+              value="browser"
+              className="w-full justify-start gap-2 px-3 py-2 data-[state=active]:bg-muted rounded-md"
+            >
+              <Bell className="h-4 w-4" />
+              {t("modal.tabs.browser")}
+              <StatusDot enabled={browserNotificationsEnabled} />
+            </TabsTrigger>
+            <TabsTrigger
+              value="webhook"
+              className="w-full justify-start gap-2 px-3 py-2 data-[state=active]:bg-muted rounded-md"
+            >
+              <Webhook className="h-4 w-4" />
+              {t("modal.tabs.webhook")}
+              <StatusDot enabled={!!firstWebhook?.enabled} />
+            </TabsTrigger>
+            <TabsTrigger
+              value="slack"
+              className="w-full justify-start gap-2 px-3 py-2 data-[state=active]:bg-muted rounded-md"
+            >
+              <MessageSquare className="h-4 w-4" />
+              {t("modal.tabs.slack")}
+              <StatusDot enabled={!!firstSlack?.enabled} />
+            </TabsTrigger>
+          </TabsList>
+
+          <div className="flex-1 min-h-0 overflow-y-auto pl-6 py-2">
+            <TabsContent value="general" className="mt-0 min-h-[400px]">
+              <GeneralTab
+                servers={servers}
+                notificationServerIds={notificationServerIds}
+                setNotificationServerIds={setNotificationServerIds}
+                selectedServers={selectedServers}
+                filteredServers={filteredServers}
+                selectedCount={selectedCount}
+                serverSearchOpen={serverSearchOpen}
+                setServerSearchOpen={setServerSearchOpen}
+                serverSearchTerm={serverSearchTerm}
+                setServerSearchTerm={setServerSearchTerm}
+                notificationSeverities={notificationSeverities}
+                setNotificationSeverities={setNotificationSeverities}
+                isPending={updateSettingsMutation.isPending}
+                t={t}
+              />
+            </TabsContent>
+
+            <TabsContent value="email" className="mt-0 min-h-[400px]">
+              <EmailTab
+                emailNotificationsEnabled={emailNotificationsEnabled}
+                setEmailNotificationsEnabled={setEmailNotificationsEnabled}
+                contactEmail={contactEmail}
+                setContactEmail={setContactEmail}
+                onSaveEmail={handleSaveEmail}
+                isPending={updateSettingsMutation.isPending}
+                t={t}
+              />
+            </TabsContent>
+
+            <TabsContent value="browser" className="mt-0 min-h-[400px]">
+              <BrowserTab
+                browserNotificationsEnabled={browserNotificationsEnabled}
+                setBrowserNotificationsEnabled={setBrowserNotificationsEnabled}
+                browserNotificationSeverities={browserNotificationSeverities}
+                setBrowserNotificationSeverities={
+                  setBrowserNotificationSeverities
+                }
+                notificationPermission={notificationPermission}
+                setNotificationPermission={setNotificationPermission}
+                isPending={updateSettingsMutation.isPending}
+                t={t}
+              />
+            </TabsContent>
+
+            <TabsContent value="webhook" className="mt-0 min-h-[400px]">
+              <WebhookTab
+                webhookUrl={webhookUrl}
+                setWebhookUrl={setWebhookUrl}
+                webhookSecret={webhookSecret}
+                setWebhookSecret={setWebhookSecret}
+                webhookEnabled={webhookEnabled}
+                showSecret={showSecret}
+                setShowSecret={setShowSecret}
+                onToggleWebhook={handleToggleWebhook}
+                onSaveWebhook={handleSaveWebhook}
+                onDeleteWebhook={handleDeleteWebhook}
+                onShowExample={() => setShowWebhookExample(true)}
+                hasExistingWebhook={!!firstWebhook}
+                isSaving={
+                  createWebhookMutation.isPending ||
+                  updateWebhookMutation.isPending
+                }
+                isDeleting={deleteWebhookMutation.isPending}
+                t={t}
+              />
+            </TabsContent>
+
+            <TabsContent value="slack" className="mt-0 min-h-[400px]">
+              <SlackTab
+                slackWebhookUrl={slackWebhookUrl}
+                setSlackWebhookUrl={setSlackWebhookUrl}
+                slackEnabled={slackEnabled}
+                onToggleSlack={handleToggleSlack}
+                onSaveSlack={handleSaveSlack}
+                onDeleteSlack={handleDeleteSlack}
+                hasExistingSlack={!!firstSlack}
+                isSaving={
+                  createSlackConfigMutation.isPending ||
+                  updateSlackConfigMutation.isPending
+                }
+                isDeleting={deleteSlackConfigMutation.isPending}
+                t={t}
+              />
+            </TabsContent>
           </div>
+        </Tabs>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 p-6 pt-4 border-t">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={updateSettingsMutation.isPending}
+          >
+            {t("modal.close")}
+          </Button>
         </div>
       </DialogContent>
 
       {/* Webhook Example Payload Modal */}
-      <Dialog open={showWebhookExample} onOpenChange={setShowWebhookExample}>
-        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>{t("modal.webhookPayloadExample")}</DialogTitle>
-            <DialogDescription>
-              {t("modal.webhookPayloadExampleDescription")}
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Label
-                htmlFor="webhook-version"
-                className="text-sm font-semibold"
-              >
-                {t("modal.version")}
-              </Label>
-              <select
-                id="webhook-version"
-                value={webhookExampleVersion}
-                onChange={(e) => setWebhookExampleVersion(e.target.value)}
-                className="px-3 py-1.5 text-sm border rounded-md bg-background"
-              >
-                <option value="v1">v1</option>
-              </select>
-              <span className="text-xs text-muted-foreground">
-                {t("modal.onlyV1Available")}
-              </span>
-            </div>
-
-            <div className="space-y-2">
-              <Label className="text-sm font-semibold">
-                {t("modal.httpHeaders")}
-              </Label>
-              <div className="p-4 bg-muted rounded-lg">
-                <pre className="text-xs overflow-x-auto">
-                  {`Content-Type: application/json
-User-Agent: Qarote-Webhook/1.0
-X-Qarote-Event: alert.notification
-X-Qarote-Version: ${webhookExampleVersion}
-X-Qarote-Timestamp: 2024-01-15T10:30:00.000Z
-X-Qarote-Signature: sha256=abc123... (if secret is configured)`}
-                </pre>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label className="text-sm font-semibold">
-                {t("modal.jsonPayload")}
-              </Label>
-              <div className="p-4 bg-muted rounded-lg">
-                <pre className="text-xs overflow-x-auto">
-                  {JSON.stringify(
-                    {
-                      version: webhookExampleVersion,
-                      event: "alert.notification",
-                      timestamp: "2024-01-15T10:30:00.000Z",
-                      workspace: {
-                        id: "workspace-123",
-                        name: "My Workspace",
-                      },
-                      server: {
-                        id: "server-456",
-                        name: "Production RabbitMQ",
-                      },
-                      alerts: [
-                        {
-                          id: "alert-789",
-                          serverId: "server-456",
-                          serverName: "Production RabbitMQ",
-                          severity: "CRITICAL",
-                          category: "memory",
-                          title: "High Memory Usage",
-                          description:
-                            "Memory usage has exceeded the threshold of 80%",
-                          details: {
-                            current: "85%",
-                            threshold: 80,
-                            recommended:
-                              "Consider adding more memory or reducing queue sizes",
-                            affected: ["node1", "node2"],
-                          },
-                          timestamp: "2024-01-15T10:30:00.000Z",
-                          resolved: false,
-                          source: {
-                            type: "node",
-                            name: "rabbit@node1",
-                          },
-                        },
-                        {
-                          id: "alert-790",
-                          serverId: "server-456",
-                          serverName: "Production RabbitMQ",
-                          severity: "HIGH",
-                          category: "disk",
-                          title: "Disk Space Warning",
-                          description:
-                            "Disk usage is approaching the threshold of 90%",
-                          details: {
-                            current: "87%",
-                            threshold: 90,
-                            recommended:
-                              "Consider cleaning up old logs or increasing disk space",
-                          },
-                          timestamp: "2024-01-15T10:25:00.000Z",
-                          resolved: false,
-                          source: {
-                            type: "node",
-                            name: "rabbit@node1",
-                          },
-                        },
-                      ],
-                      summary: {
-                        total: 2,
-                        critical: 1,
-                        high: 1,
-                        medium: 0,
-                        low: 0,
-                        info: 0,
-                      },
-                    },
-                    null,
-                    2
-                  )}
-                </pre>
-              </div>
-            </div>
-
-            <div className="p-4 bg-blue-50 dark:bg-blue-950 rounded-lg">
-              <p
-                className="text-sm text-blue-900 dark:text-blue-100"
-                dangerouslySetInnerHTML={{
-                  __html: t("modal.webhookSignatureNote"),
-                }}
-              />
-            </div>
-          </div>
-
-          <div className="flex items-center justify-end gap-2 pt-4 border-t">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setShowWebhookExample(false)}
-            >
-              {t("modal.close")}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <WebhookExampleModal
+        open={showWebhookExample}
+        onOpenChange={setShowWebhookExample}
+        t={t}
+      />
     </Dialog>
   );
 }

--- a/apps/app/src/components/alerts/AlertNotificationSettingsModal.tsx
+++ b/apps/app/src/components/alerts/AlertNotificationSettingsModal.tsx
@@ -564,6 +564,12 @@ export function AlertNotificationSettingsModal({
     updateSlackConfigMutation.mutate(
       { id: firstSlack.id, enabled },
       {
+        onSuccess: () =>
+          toast.success(
+            enabled
+              ? t("modal.toastSlackEnabled")
+              : t("modal.toastSlackDisabled")
+          ),
         onError: (error: ApiError) => {
           toast.error(error.message || t("modal.toastSlackUpdateFailed"));
           setSlackEnabled(!enabled);

--- a/apps/app/src/components/alerts/notification-settings/BrowserTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/BrowserTab.tsx
@@ -1,0 +1,137 @@
+import { BellOff } from "lucide-react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+import { SeverityCheckboxGroup } from "./SeverityCheckboxGroup";
+import type { BrowserTabProps } from "./types";
+
+export function BrowserTab({
+  browserNotificationsEnabled,
+  setBrowserNotificationsEnabled,
+  browserNotificationSeverities,
+  setBrowserNotificationSeverities,
+  notificationPermission,
+  setNotificationPermission,
+  isPending,
+  t,
+}: BrowserTabProps) {
+  const handleToggle = (checked: boolean) => {
+    if (!checked) {
+      setBrowserNotificationsEnabled(false);
+      return;
+    }
+    if (!("Notification" in window)) {
+      setBrowserNotificationsEnabled(false);
+      setNotificationPermission("unsupported");
+      return;
+    }
+    if (Notification.permission === "granted") {
+      setBrowserNotificationsEnabled(true);
+      return;
+    }
+    if (Notification.permission === "denied") {
+      setBrowserNotificationsEnabled(false);
+      setNotificationPermission("denied");
+      return;
+    }
+    Notification.requestPermission().then((permission) => {
+      setNotificationPermission(permission);
+      setBrowserNotificationsEnabled(permission === "granted");
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Toggle */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label
+            htmlFor="browser-notifications"
+            className="text-base flex items-center gap-2"
+          >
+            {t("modal.browserNotifications")}
+            {notificationPermission === "granted" && (
+              <Badge
+                variant="secondary"
+                className="text-xs font-normal text-green-600"
+              >
+                {t("modal.permissionGranted")}
+              </Badge>
+            )}
+            {notificationPermission === "denied" && (
+              <Badge variant="destructive" className="text-xs font-normal">
+                {t("modal.permissionDenied")}
+              </Badge>
+            )}
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            {t("modal.browserNotificationsDescription")}
+          </p>
+        </div>
+        <Switch
+          id="browser-notifications"
+          checked={browserNotificationsEnabled}
+          onCheckedChange={handleToggle}
+          disabled={isPending}
+          className="data-[state=checked]:bg-gradient-button"
+        />
+      </div>
+
+      {/* Permission blocked alert */}
+      {"Notification" in window &&
+        browserNotificationsEnabled &&
+        notificationPermission === "denied" && (
+          <Alert variant="destructive">
+            <BellOff className="h-4 w-4" />
+            <AlertDescription>
+              {t("modal.browserNotificationsBlocked")}
+            </AlertDescription>
+          </Alert>
+        )}
+
+      {/* System hint */}
+      {browserNotificationsEnabled && notificationPermission === "granted" && (
+        <p className="text-xs text-muted-foreground">
+          {t("modal.browserNotificationsSystemHint")}
+        </p>
+      )}
+
+      {/* Browser Severities */}
+      {browserNotificationsEnabled && (
+        <div className="space-y-3 p-4 border rounded-lg">
+          <Label className="text-sm font-medium">
+            {t("modal.browserNotificationSeverities")}
+          </Label>
+          <p className="text-xs text-muted-foreground mb-3">
+            {t("modal.browserNotificationSeveritiesDescription")}
+          </p>
+          <SeverityCheckboxGroup
+            severities={browserNotificationSeverities}
+            onChange={setBrowserNotificationSeverities}
+            disabled={isPending}
+            idPrefix="browser-severity"
+            t={t}
+          />
+          {browserNotificationSeverities.length === 0 && (
+            <p className="text-xs text-red-500 mt-2">
+              {t("modal.selectAtLeastOneBrowserSeverity")}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Disabled Info */}
+      {!browserNotificationsEnabled && (
+        <Alert>
+          <BellOff className="h-4 w-4" />
+          <AlertDescription>
+            {t("modal.browserNotificationsDisabled")}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/components/alerts/notification-settings/EmailTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/EmailTab.tsx
@@ -1,0 +1,97 @@
+import { BellOff, Plus } from "lucide-react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+import type { EmailTabProps } from "./types";
+
+export function EmailTab({
+  emailNotificationsEnabled,
+  setEmailNotificationsEnabled,
+  contactEmail,
+  setContactEmail,
+  onSaveEmail,
+  isPending,
+  t,
+}: EmailTabProps) {
+  return (
+    <div className="space-y-4">
+      {/* Toggle */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label htmlFor="email-notifications" className="text-base">
+            {t("modal.emailNotifications")}
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            {t("modal.emailNotificationsDescription")}
+          </p>
+        </div>
+        <Switch
+          id="email-notifications"
+          checked={emailNotificationsEnabled}
+          onCheckedChange={setEmailNotificationsEnabled}
+          disabled={isPending}
+          className="data-[state=checked]:bg-gradient-button"
+        />
+      </div>
+
+      {/* Email Input */}
+      {emailNotificationsEnabled && (
+        <div className="space-y-2 p-4 border rounded-lg">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="contact-email">
+              {t("modal.notificationEmailAddress")}
+              <span className="text-red-500 ml-1">*</span>
+            </Label>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onSaveEmail}
+              disabled={isPending || !contactEmail.trim()}
+              className="bg-gradient-button hover:bg-gradient-button-hover text-white hover:text-white"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              {t("modal.update")}
+            </Button>
+          </div>
+          <Input
+            id="contact-email"
+            type="email"
+            placeholder="your-email@example.com"
+            value={contactEmail}
+            onChange={(e) => setContactEmail(e.target.value)}
+            onKeyDown={(e) => {
+              if (
+                e.key === "Enter" &&
+                contactEmail.trim() &&
+                emailNotificationsEnabled
+              ) {
+                e.preventDefault();
+                onSaveEmail();
+              }
+            }}
+            disabled={isPending}
+            required={emailNotificationsEnabled}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("modal.emailHelp")}
+          </p>
+        </div>
+      )}
+
+      {/* Disabled Info */}
+      {!emailNotificationsEnabled && (
+        <Alert>
+          <BellOff className="h-4 w-4" />
+          <AlertDescription>
+            {t("modal.emailNotificationsDisabled")}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
@@ -22,7 +22,6 @@ import type { GeneralTabProps } from "./types";
 
 export function GeneralTab({
   servers,
-  notificationServerIds: _notificationServerIds,
   setNotificationServerIds,
   selectedServers,
   filteredServers,

--- a/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
@@ -128,9 +128,11 @@ export function GeneralTab({
                           key={server.id}
                           value={`${server.name} ${server.host} ${server.port}`}
                           onSelect={() => {
-                            const currentIds = notificationServerIds || [];
-                            const newIds = [...currentIds, server.id];
-                            setNotificationServerIds(newIds);
+                            setNotificationServerIds((prev) => {
+                              const ids = new Set(prev || []);
+                              ids.add(server.id);
+                              return Array.from(ids);
+                            });
                             setServerSearchTerm("");
                           }}
                         >

--- a/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
@@ -22,7 +22,7 @@ import type { GeneralTabProps } from "./types";
 
 export function GeneralTab({
   servers,
-  notificationServerIds,
+  notificationServerIds: _notificationServerIds,
   setNotificationServerIds,
   selectedServers,
   filteredServers,
@@ -64,13 +64,12 @@ export function GeneralTab({
                     type="button"
                     aria-label={`Remove ${server.name || server.id}`}
                     onClick={() => {
-                      const currentIds = notificationServerIds || [];
-                      const newIds = currentIds.filter(
-                        (id) => id !== server.id
-                      );
-                      setNotificationServerIds(
-                        newIds.length > 0 ? newIds : null
-                      );
+                      setNotificationServerIds((prev) => {
+                        const newIds = (prev || []).filter(
+                          (id) => id !== server.id
+                        );
+                        return newIds.length > 0 ? newIds : null;
+                      });
                     }}
                     disabled={isPending}
                     className="ml-1 rounded-full hover:bg-destructive hover:text-destructive-foreground transition-colors"
@@ -192,7 +191,7 @@ export function GeneralTab({
           t={t}
         />
         {notificationSeverities.length === 0 && (
-          <p className="text-xs text-red-500 mt-2">
+          <p className="text-xs text-destructive mt-2">
             {t("modal.selectAtLeastOneSeverity")}
           </p>
         )}

--- a/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
@@ -62,6 +62,7 @@ export function GeneralTab({
                   </span>
                   <button
                     type="button"
+                    aria-label={`Remove ${server.name || server.id}`}
                     onClick={() => {
                       const currentIds = notificationServerIds || [];
                       const newIds = currentIds.filter(

--- a/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/GeneralTab.tsx
@@ -1,0 +1,199 @@
+import { Search, X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+import { SeverityCheckboxGroup } from "./SeverityCheckboxGroup";
+import type { GeneralTabProps } from "./types";
+
+export function GeneralTab({
+  servers,
+  notificationServerIds,
+  setNotificationServerIds,
+  selectedServers,
+  filteredServers,
+  selectedCount,
+  serverSearchOpen,
+  setServerSearchOpen,
+  serverSearchTerm,
+  setServerSearchTerm,
+  notificationSeverities,
+  setNotificationSeverities,
+  isPending,
+  t,
+}: GeneralTabProps) {
+  return (
+    <div className="space-y-6">
+      {/* Server Selection */}
+      {servers.length > 0 && (
+        <div className="space-y-3">
+          <div>
+            <Label className="text-base">{t("modal.servers")}</Label>
+            <p className="text-sm text-muted-foreground mt-1">
+              {t("modal.serversDescription")}
+            </p>
+          </div>
+
+          {/* Selected Servers as Tags */}
+          {selectedServers.length > 0 && (
+            <div className="flex flex-wrap gap-2 p-3 border rounded-md bg-muted/50">
+              {selectedServers.map((server) => (
+                <Badge
+                  key={server.id}
+                  variant="secondary"
+                  className="flex items-center gap-1.5 pr-1"
+                >
+                  <span className="text-xs">
+                    {server.name} ({server.host}:{server.port})
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const currentIds = notificationServerIds || [];
+                      const newIds = currentIds.filter(
+                        (id) => id !== server.id
+                      );
+                      setNotificationServerIds(
+                        newIds.length > 0 ? newIds : null
+                      );
+                    }}
+                    disabled={isPending}
+                    className="ml-1 rounded-full hover:bg-destructive hover:text-destructive-foreground transition-colors"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {/* Search Input with Popover */}
+          <div className="flex items-center gap-2">
+            <Popover open={serverSearchOpen} onOpenChange={setServerSearchOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  role="combobox"
+                  aria-controls="server-search-list"
+                  aria-expanded={serverSearchOpen}
+                  className="w-full justify-between"
+                  disabled={isPending}
+                >
+                  <div className="flex items-center gap-2">
+                    <Search className="h-4 w-4 text-muted-foreground" />
+                    <span className="text-muted-foreground">
+                      {selectedCount > 0
+                        ? t("modal.serversSelected", {
+                            count: selectedCount,
+                          })
+                        : t("modal.searchAndSelect")}
+                    </span>
+                  </div>
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[400px] p-0" align="start">
+                <Command>
+                  <CommandInput
+                    placeholder={t("modal.searchPlaceholder")}
+                    value={serverSearchTerm}
+                    onValueChange={setServerSearchTerm}
+                  />
+                  <CommandList id="server-search-list">
+                    <CommandEmpty>
+                      {serverSearchTerm
+                        ? t("modal.noServersFound", {
+                            term: serverSearchTerm,
+                          })
+                        : t("modal.noServersAvailable")}
+                    </CommandEmpty>
+                    <CommandGroup>
+                      {filteredServers.map((server) => (
+                        <CommandItem
+                          key={server.id}
+                          value={`${server.name} ${server.host} ${server.port}`}
+                          onSelect={() => {
+                            const currentIds = notificationServerIds || [];
+                            const newIds = [...currentIds, server.id];
+                            setNotificationServerIds(newIds);
+                            setServerSearchTerm("");
+                          }}
+                        >
+                          <div className="flex flex-col">
+                            <span className="font-medium">{server.name}</span>
+                            <span className="text-xs text-muted-foreground">
+                              {server.host}:{server.port}
+                            </span>
+                          </div>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+
+            {selectedCount > 0 && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setNotificationServerIds(null);
+                  setServerSearchOpen(false);
+                }}
+                disabled={isPending}
+              >
+                {t("modal.clearAll")}
+              </Button>
+            )}
+          </div>
+
+          {selectedCount > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {t("modal.serverSelectionCount", {
+                selected: selectedCount,
+                total: servers.length,
+                count: servers.length,
+              })}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Alert Severity Selection */}
+      <div className="space-y-3">
+        <Label className="text-base">{t("modal.alertSeverities")}</Label>
+        <p className="text-sm text-muted-foreground mb-3">
+          {t("modal.alertSeveritiesDescription")}
+        </p>
+        <SeverityCheckboxGroup
+          severities={notificationSeverities}
+          onChange={setNotificationSeverities}
+          disabled={isPending}
+          idPrefix="severity"
+          t={t}
+        />
+        {notificationSeverities.length === 0 && (
+          <p className="text-xs text-red-500 mt-2">
+            {t("modal.selectAtLeastOneSeverity")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/alerts/notification-settings/SeverityCheckboxGroup.tsx
+++ b/apps/app/src/components/alerts/notification-settings/SeverityCheckboxGroup.tsx
@@ -1,0 +1,73 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+
+import type { SeverityCheckboxGroupProps } from "./types";
+
+const SEVERITY_LEVELS = [
+  {
+    key: "CRITICAL",
+    color: "text-red-600",
+    labelKey: "modal.severityCritical",
+    descKey: "modal.severityCriticalDesc",
+  },
+  {
+    key: "HIGH",
+    color: "text-orange-600",
+    labelKey: "modal.severityHigh",
+    descKey: "modal.severityHighDesc",
+  },
+  {
+    key: "MEDIUM",
+    color: "text-yellow-600",
+    labelKey: "modal.severityMedium",
+    descKey: "modal.severityMediumDesc",
+  },
+  {
+    key: "LOW",
+    color: "text-blue-600",
+    labelKey: "modal.severityLow",
+    descKey: "modal.severityLowDesc",
+  },
+  {
+    key: "INFO",
+    color: "text-gray-600",
+    labelKey: "modal.severityInfo",
+    descKey: "modal.severityInfoDesc",
+  },
+] as const;
+
+export function SeverityCheckboxGroup({
+  severities,
+  onChange,
+  disabled = false,
+  idPrefix,
+  t,
+}: SeverityCheckboxGroupProps) {
+  return (
+    <div className="space-y-3">
+      {SEVERITY_LEVELS.map(({ key, color, labelKey, descKey }) => (
+        <div key={key} className="flex items-center space-x-2">
+          <Checkbox
+            id={`${idPrefix}-${key.toLowerCase()}`}
+            checked={severities.includes(key)}
+            onCheckedChange={(checked) => {
+              const newSeverities = checked
+                ? [...severities, key]
+                : severities.filter((s) => s !== key);
+              onChange(newSeverities);
+            }}
+            disabled={disabled}
+            className="data-[state=checked]:bg-gradient-button data-[state=checked]:border-gradient-button"
+          />
+          <Label
+            htmlFor={`${idPrefix}-${key.toLowerCase()}`}
+            className="flex items-center gap-2 cursor-pointer"
+          >
+            <span className={`${color} font-medium`}>{t(labelKey)}</span>
+            <span className="text-xs text-muted-foreground">{t(descKey)}</span>
+          </Label>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/app/src/components/alerts/notification-settings/SlackTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/SlackTab.tsx
@@ -1,0 +1,103 @@
+import { Loader2, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+import type { SlackTabProps } from "./types";
+
+export function SlackTab({
+  slackWebhookUrl,
+  setSlackWebhookUrl,
+  slackEnabled,
+  onToggleSlack,
+  onSaveSlack,
+  onDeleteSlack,
+  hasExistingSlack,
+  isSaving,
+  isDeleting,
+  t,
+}: SlackTabProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <Label className="text-base">{t("modal.slackNotifications")}</Label>
+        <p className="text-sm text-muted-foreground mt-1">
+          {t("modal.slackDescription")}
+        </p>
+      </div>
+
+      <div className="space-y-4 p-4 border rounded-lg">
+        <div className="space-y-2">
+          <Label htmlFor="slack-webhook-url">
+            {t("modal.slackWebhookUrl")}
+            <span className="text-red-500 ml-1">*</span>
+          </Label>
+          <Input
+            id="slack-webhook-url"
+            type="url"
+            placeholder="https://hooks.slack.com/services/..."
+            value={slackWebhookUrl}
+            onChange={(e) => setSlackWebhookUrl(e.target.value)}
+            disabled={isSaving}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("modal.slackWebhookHelp")}{" "}
+            <a
+              href="https://api.slack.com/messaging/webhooks"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline font-medium"
+            >
+              {t("modal.slackWebhookLink")}
+            </a>
+            .
+          </p>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={slackEnabled}
+              onCheckedChange={onToggleSlack}
+              disabled={isSaving}
+              className="data-[state=checked]:bg-gradient-button"
+            />
+            <Label htmlFor="slack-enabled">{t("modal.enabled")}</Label>
+          </div>
+          <div className="flex gap-2">
+            {hasExistingSlack && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={onDeleteSlack}
+                disabled={isDeleting}
+              >
+                <Trash2 className="h-4 w-4 text-red-600" />
+              </Button>
+            )}
+            <Button
+              type="button"
+              onClick={onSaveSlack}
+              disabled={isSaving || !slackWebhookUrl.trim()}
+              className="bg-gradient-button hover:bg-gradient-button-hover text-white hover:text-white"
+            >
+              {isSaving ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  {hasExistingSlack ? t("modal.updating") : t("modal.creating")}
+                </>
+              ) : hasExistingSlack ? (
+                t("modal.update")
+              ) : (
+                t("modal.save")
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/alerts/notification-settings/SlackTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/SlackTab.tsx
@@ -59,6 +59,7 @@ export function SlackTab({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Switch
+              id="slack-enabled"
               checked={slackEnabled}
               onCheckedChange={onToggleSlack}
               disabled={isSaving}
@@ -74,6 +75,7 @@ export function SlackTab({
                 size="sm"
                 onClick={onDeleteSlack}
                 disabled={isDeleting}
+                aria-label="Delete Slack integration"
               >
                 <Trash2 className="h-4 w-4 text-red-600" />
               </Button>

--- a/apps/app/src/components/alerts/notification-settings/WebhookExampleModal.tsx
+++ b/apps/app/src/components/alerts/notification-settings/WebhookExampleModal.tsx
@@ -9,6 +9,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface WebhookExampleModalProps {
   open: boolean;
@@ -38,14 +45,14 @@ export function WebhookExampleModal({
             <Label htmlFor="webhook-version" className="text-sm font-semibold">
               {t("modal.version")}
             </Label>
-            <select
-              id="webhook-version"
-              value={version}
-              onChange={(e) => setVersion(e.target.value)}
-              className="px-3 py-1.5 text-sm border rounded-md bg-background"
-            >
-              <option value="v1">v1</option>
-            </select>
+            <Select value={version} onValueChange={setVersion}>
+              <SelectTrigger id="webhook-version" className="w-20">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="v1">v1</SelectItem>
+              </SelectContent>
+            </Select>
             <span className="text-xs text-muted-foreground">
               {t("modal.onlyV1Available")}
             </span>

--- a/apps/app/src/components/alerts/notification-settings/WebhookExampleModal.tsx
+++ b/apps/app/src/components/alerts/notification-settings/WebhookExampleModal.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+
+interface WebhookExampleModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  t: (key: string) => string;
+}
+
+export function WebhookExampleModal({
+  open,
+  onOpenChange,
+  t,
+}: WebhookExampleModalProps) {
+  const [version, setVersion] = useState("v1");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t("modal.webhookPayloadExample")}</DialogTitle>
+          <DialogDescription>
+            {t("modal.webhookPayloadExampleDescription")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Label htmlFor="webhook-version" className="text-sm font-semibold">
+              {t("modal.version")}
+            </Label>
+            <select
+              id="webhook-version"
+              value={version}
+              onChange={(e) => setVersion(e.target.value)}
+              className="px-3 py-1.5 text-sm border rounded-md bg-background"
+            >
+              <option value="v1">v1</option>
+            </select>
+            <span className="text-xs text-muted-foreground">
+              {t("modal.onlyV1Available")}
+            </span>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-sm font-semibold">
+              {t("modal.httpHeaders")}
+            </Label>
+            <div className="p-4 bg-muted rounded-lg">
+              <pre className="text-xs overflow-x-auto">
+                {`Content-Type: application/json
+User-Agent: Qarote-Webhook/1.0
+X-Qarote-Event: alert.notification
+X-Qarote-Version: ${version}
+X-Qarote-Timestamp: 2024-01-15T10:30:00.000Z
+X-Qarote-Signature: sha256=abc123... (if secret is configured)`}
+              </pre>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-sm font-semibold">
+              {t("modal.jsonPayload")}
+            </Label>
+            <div className="p-4 bg-muted rounded-lg">
+              <pre className="text-xs overflow-x-auto">
+                {JSON.stringify(
+                  {
+                    version,
+                    event: "alert.notification",
+                    timestamp: "2024-01-15T10:30:00.000Z",
+                    workspace: {
+                      id: "workspace-123",
+                      name: "My Workspace",
+                    },
+                    server: {
+                      id: "server-456",
+                      name: "Production RabbitMQ",
+                    },
+                    alerts: [
+                      {
+                        id: "alert-789",
+                        serverId: "server-456",
+                        serverName: "Production RabbitMQ",
+                        severity: "CRITICAL",
+                        category: "memory",
+                        title: "High Memory Usage",
+                        description:
+                          "Memory usage has exceeded the threshold of 80%",
+                        details: {
+                          current: "85%",
+                          threshold: 80,
+                          recommended:
+                            "Consider adding more memory or reducing queue sizes",
+                          affected: ["node1", "node2"],
+                        },
+                        timestamp: "2024-01-15T10:30:00.000Z",
+                        resolved: false,
+                        source: {
+                          type: "node",
+                          name: "rabbit@node1",
+                        },
+                      },
+                      {
+                        id: "alert-790",
+                        serverId: "server-456",
+                        serverName: "Production RabbitMQ",
+                        severity: "HIGH",
+                        category: "disk",
+                        title: "Disk Space Warning",
+                        description:
+                          "Disk usage is approaching the threshold of 90%",
+                        details: {
+                          current: "87%",
+                          threshold: 90,
+                          recommended:
+                            "Consider cleaning up old logs or increasing disk space",
+                        },
+                        timestamp: "2024-01-15T10:25:00.000Z",
+                        resolved: false,
+                        source: {
+                          type: "node",
+                          name: "rabbit@node1",
+                        },
+                      },
+                    ],
+                    summary: {
+                      total: 2,
+                      critical: 1,
+                      high: 1,
+                      medium: 0,
+                      low: 0,
+                      info: 0,
+                    },
+                  },
+                  null,
+                  2
+                )}
+              </pre>
+            </div>
+          </div>
+
+          <div className="p-4 bg-blue-50 dark:bg-blue-950 rounded-lg">
+            <p
+              className="text-sm text-blue-900 dark:text-blue-100"
+              dangerouslySetInnerHTML={{
+                __html: t("modal.webhookSignatureNote"),
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-4 border-t">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            {t("modal.close")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/app/src/components/alerts/notification-settings/WebhookExampleModal.tsx
+++ b/apps/app/src/components/alerts/notification-settings/WebhookExampleModal.tsx
@@ -150,12 +150,14 @@ X-Qarote-Signature: sha256=abc123... (if secret is configured)`}
           </div>
 
           <div className="p-4 bg-blue-50 dark:bg-blue-950 rounded-lg">
-            <p
-              className="text-sm text-blue-900 dark:text-blue-100"
-              dangerouslySetInnerHTML={{
-                __html: t("modal.webhookSignatureNote"),
-              }}
-            />
+            <p className="text-sm text-blue-900 dark:text-blue-100">
+              <strong>{t("modal.webhookSignatureNoteLabel")}</strong>{" "}
+              {t("modal.webhookSignatureNoteText")}{" "}
+              <code className="text-xs bg-blue-100 dark:bg-blue-900 px-1 py-0.5 rounded">
+                X-Qarote-Signature
+              </code>{" "}
+              {t("modal.webhookSignatureNoteSuffix")}
+            </p>
           </div>
         </div>
 

--- a/apps/app/src/components/alerts/notification-settings/WebhookTab.tsx
+++ b/apps/app/src/components/alerts/notification-settings/WebhookTab.tsx
@@ -1,0 +1,142 @@
+import { Eye, EyeOff, Loader2, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+import type { WebhookTabProps } from "./types";
+
+export function WebhookTab({
+  webhookUrl,
+  setWebhookUrl,
+  webhookSecret,
+  setWebhookSecret,
+  webhookEnabled,
+  showSecret,
+  setShowSecret,
+  onToggleWebhook,
+  onSaveWebhook,
+  onDeleteWebhook,
+  onShowExample,
+  hasExistingWebhook,
+  isSaving,
+  isDeleting,
+  t,
+}: WebhookTabProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <Label className="text-base">{t("modal.webhookNotifications")}</Label>
+          <p className="text-sm text-muted-foreground mt-1">
+            {t("modal.webhookDescription")}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onShowExample}
+        >
+          {t("modal.viewExamplePayload")}
+        </Button>
+      </div>
+
+      <div className="p-4 border rounded-lg space-y-3">
+        <div className="space-y-2">
+          <Label htmlFor="webhook-url">
+            {t("modal.webhookUrl")}
+            <span className="text-red-500 ml-1">*</span>
+          </Label>
+          <Input
+            id="webhook-url"
+            type="url"
+            placeholder="https://your-endpoint.com/webhook"
+            value={webhookUrl}
+            onChange={(e) => setWebhookUrl(e.target.value)}
+            disabled={isSaving}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="webhook-secret">
+            {t("modal.webhookSecretOptional")}
+          </Label>
+          <div className="relative">
+            <Input
+              id="webhook-secret"
+              type={showSecret ? "text" : "password"}
+              placeholder={t("modal.webhookSecretPlaceholder")}
+              value={webhookSecret}
+              onChange={(e) => setWebhookSecret(e.target.value)}
+              disabled={isSaving}
+              className="pr-10"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
+              onClick={() => setShowSecret(!showSecret)}
+              disabled={isSaving}
+            >
+              {showSecret ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t("modal.webhookSecretHelp")}
+          </p>
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="webhook-enabled"
+              checked={webhookEnabled}
+              onCheckedChange={onToggleWebhook}
+              disabled={isSaving}
+              className="data-[state=checked]:bg-gradient-button"
+            />
+            <Label htmlFor="webhook-enabled">{t("modal.enabled")}</Label>
+          </div>
+          <div className="flex gap-2">
+            {hasExistingWebhook && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={onDeleteWebhook}
+                disabled={isDeleting}
+              >
+                <Trash2 className="h-4 w-4 text-red-600" />
+              </Button>
+            )}
+            <Button
+              type="button"
+              size="sm"
+              onClick={onSaveWebhook}
+              disabled={isSaving || !webhookUrl.trim()}
+              className="bg-gradient-button hover:bg-gradient-button-hover text-white hover:text-white"
+            >
+              {isSaving ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  {hasExistingWebhook
+                    ? t("modal.updating")
+                    : t("modal.creating")}
+                </>
+              ) : hasExistingWebhook ? (
+                t("modal.update")
+              ) : (
+                t("modal.save")
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/alerts/notification-settings/types.ts
+++ b/apps/app/src/components/alerts/notification-settings/types.ts
@@ -1,3 +1,5 @@
+import type { Dispatch, SetStateAction } from "react";
+
 export interface SeverityCheckboxGroupProps {
   severities: string[];
   onChange: (severities: string[]) => void;
@@ -16,7 +18,7 @@ export interface Server {
 export interface GeneralTabProps {
   servers: Server[];
   notificationServerIds: string[] | null;
-  setNotificationServerIds: (ids: string[] | null) => void;
+  setNotificationServerIds: Dispatch<SetStateAction<string[] | null>>;
   selectedServers: Server[];
   filteredServers: Server[];
   selectedCount: number;

--- a/apps/app/src/components/alerts/notification-settings/types.ts
+++ b/apps/app/src/components/alerts/notification-settings/types.ts
@@ -1,7 +1,11 @@
+import type { Server } from "@/lib/api/types";
+
 import type { Dispatch, SetStateAction } from "react";
 
 /** Shared translation function signature for all notification setting components */
 type TranslationFn = (key: string, options?: Record<string, unknown>) => string;
+
+export type { Server };
 
 export interface SeverityCheckboxGroupProps {
   severities: string[];
@@ -9,13 +13,6 @@ export interface SeverityCheckboxGroupProps {
   disabled?: boolean;
   idPrefix: string;
   t: TranslationFn;
-}
-
-export interface Server {
-  id: string;
-  name: string;
-  host: string;
-  port: number;
 }
 
 export interface GeneralTabProps {

--- a/apps/app/src/components/alerts/notification-settings/types.ts
+++ b/apps/app/src/components/alerts/notification-settings/types.ts
@@ -1,0 +1,85 @@
+export interface SeverityCheckboxGroupProps {
+  severities: string[];
+  onChange: (severities: string[]) => void;
+  disabled?: boolean;
+  idPrefix: string;
+  t: (key: string) => string;
+}
+
+export interface Server {
+  id: string;
+  name: string;
+  host: string;
+  port: number;
+}
+
+export interface GeneralTabProps {
+  servers: Server[];
+  notificationServerIds: string[] | null;
+  setNotificationServerIds: (ids: string[] | null) => void;
+  selectedServers: Server[];
+  filteredServers: Server[];
+  selectedCount: number;
+  serverSearchOpen: boolean;
+  setServerSearchOpen: (open: boolean) => void;
+  serverSearchTerm: string;
+  setServerSearchTerm: (term: string) => void;
+  notificationSeverities: string[];
+  setNotificationSeverities: (severities: string[]) => void;
+  isPending: boolean;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}
+
+export interface EmailTabProps {
+  emailNotificationsEnabled: boolean;
+  setEmailNotificationsEnabled: (enabled: boolean) => void;
+  contactEmail: string;
+  setContactEmail: (email: string) => void;
+  onSaveEmail: () => void;
+  isPending: boolean;
+  t: (key: string) => string;
+}
+
+export interface BrowserTabProps {
+  browserNotificationsEnabled: boolean;
+  setBrowserNotificationsEnabled: (enabled: boolean) => void;
+  browserNotificationSeverities: string[];
+  setBrowserNotificationSeverities: (severities: string[]) => void;
+  notificationPermission: NotificationPermission | "unsupported";
+  setNotificationPermission: (
+    permission: NotificationPermission | "unsupported"
+  ) => void;
+  isPending: boolean;
+  t: (key: string) => string;
+}
+
+export interface WebhookTabProps {
+  webhookUrl: string;
+  setWebhookUrl: (url: string) => void;
+  webhookSecret: string;
+  setWebhookSecret: (secret: string) => void;
+  webhookEnabled: boolean;
+  showSecret: boolean;
+  setShowSecret: (show: boolean) => void;
+  onToggleWebhook: (enabled: boolean) => void;
+  onSaveWebhook: () => void;
+  onDeleteWebhook: () => void;
+  onShowExample: () => void;
+  hasExistingWebhook: boolean;
+  isSaving: boolean;
+  isDeleting: boolean;
+  t: (key: string) => string;
+}
+
+export interface SlackTabProps {
+  slackWebhookUrl: string;
+  setSlackWebhookUrl: (url: string) => void;
+  slackEnabled: boolean;
+  onToggleSlack: (enabled: boolean) => void;
+  onSaveSlack: () => void;
+  onDeleteSlack: () => void;
+  hasExistingSlack: boolean;
+  isSaving: boolean;
+  isDeleting: boolean;
+  t: (key: string) => string;
+}

--- a/apps/app/src/components/alerts/notification-settings/types.ts
+++ b/apps/app/src/components/alerts/notification-settings/types.ts
@@ -1,11 +1,14 @@
 import type { Dispatch, SetStateAction } from "react";
 
+/** Shared translation function signature for all notification setting components */
+type TranslationFn = (key: string, options?: Record<string, unknown>) => string;
+
 export interface SeverityCheckboxGroupProps {
   severities: string[];
   onChange: (severities: string[]) => void;
   disabled?: boolean;
   idPrefix: string;
-  t: (key: string) => string;
+  t: TranslationFn;
 }
 
 export interface Server {
@@ -29,7 +32,7 @@ export interface GeneralTabProps {
   notificationSeverities: string[];
   setNotificationSeverities: (severities: string[]) => void;
   isPending: boolean;
-  t: (key: string, options?: Record<string, unknown>) => string;
+  t: TranslationFn;
 }
 
 export interface EmailTabProps {
@@ -39,7 +42,7 @@ export interface EmailTabProps {
   setContactEmail: (email: string) => void;
   onSaveEmail: () => void;
   isPending: boolean;
-  t: (key: string) => string;
+  t: TranslationFn;
 }
 
 export interface BrowserTabProps {
@@ -52,7 +55,7 @@ export interface BrowserTabProps {
     permission: NotificationPermission | "unsupported"
   ) => void;
   isPending: boolean;
-  t: (key: string) => string;
+  t: TranslationFn;
 }
 
 export interface WebhookTabProps {
@@ -70,7 +73,7 @@ export interface WebhookTabProps {
   hasExistingWebhook: boolean;
   isSaving: boolean;
   isDeleting: boolean;
-  t: (key: string) => string;
+  t: TranslationFn;
 }
 
 export interface SlackTabProps {
@@ -83,5 +86,5 @@ export interface SlackTabProps {
   hasExistingSlack: boolean;
   isSaving: boolean;
   isDeleting: boolean;
-  t: (key: string) => string;
+  t: TranslationFn;
 }

--- a/apps/app/src/components/profile/PlansSummaryTab.tsx
+++ b/apps/app/src/components/profile/PlansSummaryTab.tsx
@@ -2,7 +2,16 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router";
 
-import { ArrowRight, Crown, Key, Loader2, Users, Zap } from "lucide-react";
+import {
+  ArrowRight,
+  Crown,
+  ExternalLink,
+  Key,
+  Loader2,
+  Server,
+  Users,
+  Zap,
+} from "lucide-react";
 
 import { UserRole } from "@/lib/api";
 import { isSelfHostedMode } from "@/lib/featureFlags";
@@ -313,6 +322,32 @@ export const PlansSummaryTab: React.FC<PlansSummaryTabProps> = ({
             </>
           )}
         </div>
+      )}
+
+      {/* Self-host callout - Only show in cloud mode */}
+      {!selfHosted && (
+        <a
+          href={`${import.meta.env.VITE_PORTAL_URL}/documentation`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Card className="cursor-pointer hover:border-primary/30 transition-colors">
+            <CardContent className="flex items-center justify-between py-4">
+              <div className="flex items-center gap-3">
+                <Server className="h-5 w-5 text-muted-foreground shrink-0" />
+                <div>
+                  <p className="font-medium">
+                    {t("plansSummary.preferSelfHost")}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {t("plansSummary.preferSelfHostDesc")}
+                  </p>
+                </div>
+              </div>
+              <ExternalLink className="h-5 w-5 text-muted-foreground shrink-0" />
+            </CardContent>
+          </Card>
+        </a>
       )}
     </div>
   );

--- a/apps/app/src/components/settings/SettingsSidebar.tsx
+++ b/apps/app/src/components/settings/SettingsSidebar.tsx
@@ -16,9 +16,14 @@ import {
 import { UserRole } from "@/lib/api";
 import { isCloudMode } from "@/lib/featureFlags";
 
+import { Badge } from "@/components/ui/badge";
+
 import { useAuth } from "@/contexts/AuthContextDefinition";
 
 import { useIsMobile } from "@/hooks/ui/useMobile";
+import { useUser } from "@/hooks/ui/useUser";
+
+import { UserPlan } from "@/types/plans";
 
 interface NavItem {
   key: string;
@@ -28,6 +33,7 @@ interface NavItem {
   adminOnly?: boolean;
   selfHostedOnly?: boolean;
   cloudOnly?: boolean;
+  enterpriseOnly?: boolean;
 }
 
 interface NavGroup {
@@ -99,6 +105,7 @@ const navGroups: NavGroup[] = [
         icon: Shield,
         labelKey: "settings:nav.sso",
         adminOnly: true,
+        enterpriseOnly: true,
       },
       {
         key: "license",
@@ -138,7 +145,9 @@ export const SettingsSidebar = () => {
   const location = useLocation();
   const { user } = useAuth();
   const isMobile = useIsMobile();
+  const { userPlan } = useUser();
   const isAdmin = user?.role === UserRole.ADMIN;
+  const isEnterprise = userPlan === UserPlan.ENTERPRISE;
   const cloudMode = isCloudMode();
 
   const filterItem = (item: NavItem) => {
@@ -176,6 +185,18 @@ export const SettingsSidebar = () => {
             >
               <item.icon className="h-3.5 w-3.5" />
               {t(item.labelKey)}
+              {item.enterpriseOnly && !isEnterprise && (
+                <Badge
+                  variant="outline"
+                  className={`text-[10px] px-1.5 py-0 font-medium ${
+                    isActive
+                      ? "border-white/40 text-white/90"
+                      : "border-purple-300 text-purple-600 dark:border-purple-500 dark:text-purple-400"
+                  }`}
+                >
+                  {t("settings:nav.enterprise")}
+                </Badge>
+              )}
             </Link>
           );
         })}
@@ -210,7 +231,19 @@ export const SettingsSidebar = () => {
                       }`}
                     >
                       <item.icon className="h-4 w-4" />
-                      {t(item.labelKey)}
+                      <span className="flex-1">{t(item.labelKey)}</span>
+                      {item.enterpriseOnly && !isEnterprise && (
+                        <Badge
+                          variant="outline"
+                          className={`text-[10px] px-1.5 py-0 font-medium ${
+                            isActive
+                              ? "border-white/40 text-white/90"
+                              : "border-purple-300 text-purple-600 dark:border-purple-500 dark:text-purple-400"
+                          }`}
+                        >
+                          {t("settings:nav.enterprise")}
+                        </Badge>
+                      )}
                     </Link>
                   </li>
                 );

--- a/apps/app/src/components/ui/PageHeader.tsx
+++ b/apps/app/src/components/ui/PageHeader.tsx
@@ -1,13 +1,11 @@
 import { ReactNode } from "react";
 
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 
 interface PageHeaderProps {
   title: string;
   subtitle?: string;
   actions?: ReactNode;
-  showPlanBadge?: boolean;
   showSidebarTrigger?: boolean;
 }
 
@@ -15,7 +13,6 @@ export function PageHeader({
   title,
   subtitle,
   actions,
-  showPlanBadge = true,
   showSidebarTrigger = true,
 }: PageHeaderProps) {
   return (
@@ -27,10 +24,7 @@ export function PageHeader({
           {subtitle && <p className="text-gray-600 mt-1">{subtitle}</p>}
         </div>
       </div>
-      <div className="flex items-center gap-3">
-        {showPlanBadge && <PlanBadge />}
-        {actions}
-      </div>
+      <div className="flex items-center gap-3">{actions}</div>
     </div>
   );
 }

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -280,7 +280,7 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
-      className={cn("h-7 w-7", className)}
+      className={cn("h-7 w-7 md:hidden", className)}
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();

--- a/apps/app/src/lib/api/authTypes.ts
+++ b/apps/app/src/lib/api/authTypes.ts
@@ -25,6 +25,7 @@ export interface User {
   updatedAt: string;
   authProvider?: "google" | "password";
   hasPassword?: boolean;
+  image?: string | null;
 }
 
 interface Workspace {

--- a/apps/app/src/pages/Alerts.tsx
+++ b/apps/app/src/pages/Alerts.tsx
@@ -18,7 +18,6 @@ import { PageLoader } from "@/components/PageLoader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -195,7 +194,6 @@ const Alerts = () => {
                   </div>
                 </div>
                 <div className="flex items-center gap-3">
-                  <PlanBadge />
                   {alertsLoading && (
                     <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
                   )}

--- a/apps/app/src/pages/Connections.tsx
+++ b/apps/app/src/pages/Connections.tsx
@@ -25,7 +25,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
 import { useServerContext } from "@/contexts/ServerContext";
@@ -186,7 +185,6 @@ const Connections = () => {
                   <p className="text-muted-foreground">{t("pageSubtitle")}</p>
                 </div>
               </div>
-              <PlanBadge />
             </div>
 
             {/* Overview Cards */}

--- a/apps/app/src/pages/Exchanges.tsx
+++ b/apps/app/src/pages/Exchanges.tsx
@@ -40,7 +40,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -254,7 +253,6 @@ const Exchanges = () => {
                 </div>
               </div>
               <div className="flex items-center gap-4">
-                <PlanBadge />
                 {isAdmin && (
                   <AddExchangeButton
                     onAddClick={() => setShowCreateExchangeModal(true)}

--- a/apps/app/src/pages/HelpSupport.tsx
+++ b/apps/app/src/pages/HelpSupport.tsx
@@ -20,6 +20,8 @@ import {
   MessageSquare,
 } from "lucide-react";
 
+import { isCloudMode } from "@/lib/featureFlags";
+
 import { AppSidebar } from "@/components/AppSidebar";
 import { DiscordLink } from "@/components/DiscordLink";
 import { Button } from "@/components/ui/button";
@@ -167,34 +169,36 @@ function HelpSupport() {
                   </CardContent>
                 </Card>
 
-                {/* Live Chat */}
-                <Card className="border-0 shadow-md bg-card">
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <MessageCircle className="w-5 h-5" />
-                      {t("chat.title")}
-                    </CardTitle>
-                    <CardDescription>{t("chat.description")}</CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <Button
-                      onClick={() => {
-                        if (window.Tawk_API?.maximize) {
-                          window.Tawk_API.maximize();
-                        } else {
-                          toast({
-                            title: t("chat.unavailable"),
-                            variant: "destructive",
-                          });
-                        }
-                      }}
-                      className="w-full bg-gradient-button hover:bg-gradient-button-hover text-white"
-                    >
-                      <MessageCircle className="w-4 h-4 mr-2" />
-                      {t("chat.startChat")}
-                    </Button>
-                  </CardContent>
-                </Card>
+                {/* Live Chat - only shown in cloud mode where Tawk.to widget is mounted */}
+                {isCloudMode() && (
+                  <Card className="border-0 shadow-md bg-card">
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2">
+                        <MessageCircle className="w-5 h-5" />
+                        {t("chat.title")}
+                      </CardTitle>
+                      <CardDescription>{t("chat.description")}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <Button
+                        onClick={() => {
+                          if (window.Tawk_API?.maximize) {
+                            window.Tawk_API.maximize();
+                          } else {
+                            toast({
+                              title: t("chat.unavailable"),
+                              variant: "destructive",
+                            });
+                          }
+                        }}
+                        className="w-full bg-gradient-button hover:bg-gradient-button-hover text-white"
+                      >
+                        <MessageCircle className="w-4 h-4 mr-2" />
+                        {t("chat.startChat")}
+                      </Button>
+                    </CardContent>
+                  </Card>
+                )}
 
                 {/* Community Support */}
                 <Card className="border-0 shadow-md bg-card">

--- a/apps/app/src/pages/HelpSupport.tsx
+++ b/apps/app/src/pages/HelpSupport.tsx
@@ -35,7 +35,7 @@ function HelpSupport() {
   const { t } = useTranslation("help");
   const [openFaq, setOpenFaq] = useState<number | null>(null);
   const { toast } = useToast();
-  const { user: user } = useAuth();
+  const { user } = useAuth();
 
   const faqs = [
     {

--- a/apps/app/src/pages/HelpSupport.tsx
+++ b/apps/app/src/pages/HelpSupport.tsx
@@ -35,7 +35,7 @@ function HelpSupport() {
   const { t } = useTranslation("help");
   const [openFaq, setOpenFaq] = useState<number | null>(null);
   const { toast } = useToast();
-  const { user: _user } = useAuth();
+  const { user: user } = useAuth();
 
   const faqs = [
     {
@@ -96,18 +96,6 @@ function HelpSupport() {
     }
   };
 
-  const handleEmailClick = (e: React.MouseEvent) => {
-    // For better UX, we'll always try mailto first
-    // but provide a fallback copy option
-    try {
-      // The browser will handle this - no need to intercept
-      // Just let the normal mailto: behavior work
-    } catch {
-      e.preventDefault();
-      handleEmailCopy();
-    }
-  };
-
   return (
     <SidebarProvider>
       <div className="page-layout">
@@ -148,7 +136,6 @@ function HelpSupport() {
                         <a
                           href="mailto:support@qarote.io?subject=Qarote Support Request"
                           className="text-sm text-blue-600 hover:text-blue-700"
-                          onClick={handleEmailClick}
                         >
                           support@qarote.io
                         </a>
@@ -217,7 +204,7 @@ function HelpSupport() {
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <DiscordLink userId={_user?.id} userEmail={_user?.email} />
+                    <DiscordLink userId={user?.id} userEmail={user?.email} />
                   </CardContent>
                 </Card>
               </div>

--- a/apps/app/src/pages/HelpSupport.tsx
+++ b/apps/app/src/pages/HelpSupport.tsx
@@ -9,8 +9,8 @@ import {
   Copy,
   ExternalLink,
   Mail,
+  MessageCircle,
   MessageSquare,
-  Zap,
 } from "lucide-react";
 
 import { AppSidebar } from "@/components/AppSidebar";
@@ -47,38 +47,44 @@ function HelpSupport() {
       answer: t("faqs.connectServer.answer"),
     },
     {
-      question: t("faqs.cantSeeQueues.question"),
-      answer: t("faqs.cantSeeQueues.answer"),
+      question: t("faqs.credentialsSecurity.question"),
+      answer: t("faqs.credentialsSecurity.answer"),
     },
     {
-      question: t("faqs.dataStorage.question"),
-      answer: t("faqs.dataStorage.answer"),
+      question: t("faqs.readOnly.question"),
+      answer: t("faqs.readOnly.answer"),
+    },
+    {
+      question: t("faqs.compatibility.question"),
+      answer: t("faqs.compatibility.answer"),
+    },
+    {
+      question: t("faqs.multipleServers.question"),
+      answer: t("faqs.multipleServers.answer"),
+    },
+    {
+      question: t("faqs.refreshRate.question"),
+      answer: t("faqs.refreshRate.answer"),
+    },
+    {
+      question: t("faqs.availability.question"),
+      answer: t("faqs.availability.answer"),
     },
     {
       question: t("faqs.setupAlerts.question"),
       answer: t("faqs.setupAlerts.answer"),
     },
     {
-      question: t("faqs.managePermissions.question"),
-      answer: t("faqs.managePermissions.answer"),
+      question: t("faqs.teamMembers.question"),
+      answer: t("faqs.teamMembers.answer"),
+    },
+    {
+      question: t("faqs.plans.question"),
+      answer: t("faqs.plans.answer"),
     },
   ];
 
   const quickLinks = [
-    {
-      title: t("quickLinks.dashboard.title"),
-      description: t("quickLinks.dashboard.description"),
-      icon: Zap,
-      link: "/",
-      external: false,
-    },
-    {
-      title: t("quickLinks.queueManagement.title"),
-      description: t("quickLinks.queueManagement.description"),
-      icon: MessageSquare,
-      link: "/queues",
-      external: false,
-    },
     {
       title: t("quickLinks.rabbitMQDocs.title"),
       description: t("quickLinks.rabbitMQDocs.description"),
@@ -235,6 +241,41 @@ function HelpSupport() {
                         {t("contact.responseTime")}
                       </p>
                     </div>
+                  </CardContent>
+                </Card>
+
+                {/* Live Chat */}
+                <Card className="border-0 shadow-md bg-card">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <MessageCircle className="w-5 h-5" />
+                      {t("chat.title")}
+                    </CardTitle>
+                    <CardDescription>{t("chat.description")}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Button
+                      onClick={() => {
+                        // Try to open Tawk.to chat widget
+                        const w = window as Record<string, unknown>;
+                        if (
+                          w.Tawk_API &&
+                          typeof (w.Tawk_API as Record<string, unknown>)
+                            .maximize === "function"
+                        ) {
+                          (w.Tawk_API as { maximize: () => void }).maximize();
+                        } else {
+                          toast({
+                            title: t("chat.unavailable"),
+                            variant: "destructive",
+                          });
+                        }
+                      }}
+                      className="w-full bg-gradient-button hover:bg-gradient-button-hover text-white"
+                    >
+                      <MessageCircle className="w-4 h-4 mr-2" />
+                      {t("chat.startChat")}
+                    </Button>
                   </CardContent>
                 </Card>
 

--- a/apps/app/src/pages/HelpSupport.tsx
+++ b/apps/app/src/pages/HelpSupport.tsx
@@ -1,6 +1,16 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+interface TawkAPI {
+  maximize: () => void;
+}
+
+declare global {
+  interface Window {
+    Tawk_API?: TawkAPI;
+  }
+}
+
 import {
   ChevronDown,
   ChevronRight,
@@ -169,14 +179,8 @@ function HelpSupport() {
                   <CardContent>
                     <Button
                       onClick={() => {
-                        // Try to open Tawk.to chat widget
-                        const w = window as Record<string, unknown>;
-                        if (
-                          w.Tawk_API &&
-                          typeof (w.Tawk_API as Record<string, unknown>)
-                            .maximize === "function"
-                        ) {
-                          (w.Tawk_API as { maximize: () => void }).maximize();
+                        if (window.Tawk_API?.maximize) {
+                          window.Tawk_API.maximize();
                         } else {
                           toast({
                             title: t("chat.unavailable"),

--- a/apps/app/src/pages/HelpSupport.tsx
+++ b/apps/app/src/pages/HelpSupport.tsx
@@ -1,13 +1,10 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router";
 
 import {
-  Book,
   ChevronDown,
   ChevronRight,
   Copy,
-  ExternalLink,
   Mail,
   MessageCircle,
   MessageSquare,
@@ -28,7 +25,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
 import { useAuth } from "@/contexts/AuthContextDefinition";
@@ -84,16 +80,6 @@ function HelpSupport() {
     },
   ];
 
-  const quickLinks = [
-    {
-      title: t("quickLinks.rabbitMQDocs.title"),
-      description: t("quickLinks.rabbitMQDocs.description"),
-      icon: Book,
-      link: "https://www.rabbitmq.com/documentation.html",
-      external: true,
-    },
-  ];
-
   const handleEmailCopy = async () => {
     try {
       await navigator.clipboard.writeText("support@qarote.io");
@@ -137,71 +123,11 @@ function HelpSupport() {
                   <p className="text-muted-foreground">{t("subtitle")}</p>
                 </div>
               </div>
-              <PlanBadge />
             </div>
 
             <div className="grid lg:grid-cols-5 gap-6">
-              {/* Quick Help Links */}
+              {/* Support Options */}
               <div className="lg:col-span-2 space-y-6">
-                <div>
-                  <h2 className="text-xl font-semibold mb-4 text-foreground">
-                    {t("quickLinksTitle")}
-                  </h2>
-                  <div className="grid gap-3">
-                    {quickLinks.map((link, index) => {
-                      const Icon = link.icon;
-
-                      return (
-                        <div key={index}>
-                          {link.external ? (
-                            <a
-                              href={link.link}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="block"
-                            >
-                              <Card className="border-0 shadow-md bg-card hover:shadow-lg transition-shadow cursor-pointer">
-                                <CardContent className="p-4">
-                                  <div className="flex items-start gap-3">
-                                    <Icon className="w-5 h-5 text-blue-600 mt-0.5" />
-                                    <div className="flex-1">
-                                      <h3 className="font-medium">
-                                        {link.title}
-                                      </h3>
-                                      <p className="text-sm text-muted-foreground mt-1">
-                                        {link.description}
-                                      </p>
-                                    </div>
-                                    <ExternalLink className="w-4 h-4 text-muted-foreground" />
-                                  </div>
-                                </CardContent>
-                              </Card>
-                            </a>
-                          ) : (
-                            <Link to={link.link} className="block">
-                              <Card className="border-0 shadow-md bg-card hover:shadow-lg transition-shadow cursor-pointer">
-                                <CardContent className="p-4">
-                                  <div className="flex items-start gap-3">
-                                    <Icon className="w-5 h-5 text-blue-600 mt-0.5" />
-                                    <div className="flex-1">
-                                      <h3 className="font-medium">
-                                        {link.title}
-                                      </h3>
-                                      <p className="text-sm text-muted-foreground mt-1">
-                                        {link.description}
-                                      </p>
-                                    </div>
-                                  </div>
-                                </CardContent>
-                              </Card>
-                            </Link>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-
                 {/* Contact */}
                 <Card className="border-0 shadow-md bg-card">
                   <CardHeader>

--- a/apps/app/src/pages/Index.tsx
+++ b/apps/app/src/pages/Index.tsx
@@ -21,7 +21,6 @@ import { ResourceUsage } from "@/components/ResourceUsage";
 import { SecondaryMetricsCards } from "@/components/SecondaryMetricsCards";
 import { TimeRange } from "@/components/TimeRangeSelector";
 import { Card, CardContent } from "@/components/ui/card";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
 import { useAuth } from "@/contexts/AuthContextDefinition";
@@ -96,7 +95,6 @@ const Index = () => {
                     <p className="text-gray-500">{t("selectServerPrompt")}</p>
                   </div>
                 </div>
-                <PlanBadge />
               </div>
               <Card className="border-0 shadow-md bg-card">
                 <CardContent className="p-6">
@@ -132,7 +130,6 @@ const Index = () => {
                   <h1 className="title-page">{t("pageTitle")}</h1>
                 </div>
                 <div className="flex items-center gap-3">
-                  <PlanBadge />
                   {user?.role === UserRole.ADMIN && <AddServerButton />}
                 </div>
               </div>

--- a/apps/app/src/pages/Nodes.tsx
+++ b/apps/app/src/pages/Nodes.tsx
@@ -4,7 +4,6 @@ import { AppSidebar } from "@/components/AppSidebar";
 import { EnhancedNodesOverview } from "@/components/nodes/EnhancedNodesOverview";
 import { EnhancedNodesTable } from "@/components/nodes/EnhancedNodesTable";
 import { NoServerConfigured } from "@/components/NoServerConfigured";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
 import { useServerContext } from "@/contexts/ServerContext";
@@ -88,7 +87,6 @@ const Nodes = () => {
                   <p className="text-gray-500">{t("pageSubtitle")}</p>
                 </div>
               </div>
-              <PlanBadge />
             </div>
 
             {/* Cluster Overview */}

--- a/apps/app/src/pages/Plans.tsx
+++ b/apps/app/src/pages/Plans.tsx
@@ -8,7 +8,6 @@ import { AppSidebar } from "@/components/AppSidebar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
 import { useAllPlans } from "@/hooks/queries/usePlans";
@@ -346,7 +345,6 @@ export const PlansPage: React.FC<PlansPageProps> = ({
                   <p className="text-muted-foreground">{t("plans.subtitle")}</p>
                 </div>
               </div>
-              <PlanBadge />
             </div>
 
             {/* Pricing Section */}

--- a/apps/app/src/pages/Topology.tsx
+++ b/apps/app/src/pages/Topology.tsx
@@ -25,7 +25,6 @@ import { PageLoader } from "@/components/PageLoader";
 import { ExchangeNode } from "@/components/topology/ExchangeNode";
 import { QueueNode } from "@/components/topology/QueueNode";
 import { Card, CardContent } from "@/components/ui/card";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
 import { useServerContext } from "@/contexts/ServerContext";
@@ -153,7 +152,6 @@ const Topology = () => {
                     <p className="text-muted-foreground">{t("pageSubtitle")}</p>
                   </div>
                 </div>
-                <PlanBadge />
               </div>
 
               <Card className="border-0 shadow-md bg-card">

--- a/apps/app/src/pages/UsersPage.tsx
+++ b/apps/app/src/pages/UsersPage.tsx
@@ -225,7 +225,6 @@ export default function UsersPage() {
                     {users.length}
                   </Badge>
                 </div>
-                <div className="flex items-center gap-3"></div>
               </div>
 
               {/* Filter */}

--- a/apps/app/src/pages/UsersPage.tsx
+++ b/apps/app/src/pages/UsersPage.tsx
@@ -25,7 +25,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import {
   Table,
@@ -226,9 +225,7 @@ export default function UsersPage() {
                     {users.length}
                   </Badge>
                 </div>
-                <div className="flex items-center gap-3">
-                  <PlanBadge />
-                </div>
+                <div className="flex items-center gap-3"></div>
               </div>
 
               {/* Filter */}

--- a/apps/app/src/pages/VHostsPage.tsx
+++ b/apps/app/src/pages/VHostsPage.tsx
@@ -219,7 +219,6 @@ export default function VHostsPage() {
                   {vhosts.length}
                 </Badge>
               </div>
-              <div className="flex items-center gap-3"></div>
             </div>
 
             {/* Filter */}

--- a/apps/app/src/pages/VHostsPage.tsx
+++ b/apps/app/src/pages/VHostsPage.tsx
@@ -26,7 +26,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { PlanBadge } from "@/components/ui/PlanBadge";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import {
   Table,
@@ -220,9 +219,7 @@ export default function VHostsPage() {
                   {vhosts.length}
                 </Badge>
               </div>
-              <div className="flex items-center gap-3">
-                <PlanBadge />
-              </div>
+              <div className="flex items-center gap-3"></div>
             </div>
 
             {/* Filter */}

--- a/apps/app/src/pages/settings/SSOSection.tsx
+++ b/apps/app/src/pages/settings/SSOSection.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
 
 import {
   AlertCircle,
   CheckCircle,
   Copy,
   Loader2,
+  Lock,
   Shield,
   Trash2,
   Wifi,
@@ -54,6 +56,9 @@ import {
   useTestSsoConnection,
   useUpdateSsoProvider,
 } from "@/hooks/queries/useSsoProvider";
+import { useUser } from "@/hooks/ui/useUser";
+
+import { UserPlan } from "@/types/plans";
 
 const REDACTED = "••••••••";
 
@@ -696,17 +701,108 @@ function SetupForm({ onRefetch }: { onRefetch: () => void }) {
 
 // ─── SSOSection (main export) ─────────────────────────────────────────────────
 
+function SSOUpgradePrompt() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const cloud = isCloudMode();
+
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Card className="w-full max-w-md border-2">
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Lock className="h-5 w-5 text-muted-foreground" />
+            <CardTitle>{t("settings:sso.upgradeTitle")}</CardTitle>
+          </div>
+          <CardDescription>
+            {t("settings:sso.upgradeDescription")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-start gap-3 rounded-lg border bg-muted/50 p-4">
+            <AlertCircle className="h-5 w-5 text-muted-foreground mt-0.5" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium">
+                {t("settings:sso.upgradeRequirement")}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {cloud
+                  ? t("settings:sso.upgradeCloudHint")
+                  : t("settings:sso.upgradeSelfHostedHint")}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+        <CardFooter className="flex gap-2">
+          {cloud ? (
+            <>
+              <Button
+                className="flex-1 bg-gradient-button hover:bg-gradient-button-hover text-white"
+                onClick={() => navigate("/plans")}
+              >
+                {t("settings:sso.viewPlans")}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() =>
+                  window.open(
+                    "https://qarote.io/contact",
+                    "_blank",
+                    "noopener,noreferrer"
+                  )
+                }
+              >
+                {t("settings:sso.contactSales")}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                className="flex-1 bg-gradient-button hover:bg-gradient-button-hover text-white"
+                onClick={() => navigate("/settings/license")}
+              >
+                {t("settings:sso.activateLicense")}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() =>
+                  window.open(
+                    `${import.meta.env.VITE_PORTAL_URL}/purchase`,
+                    "_blank",
+                    "noopener,noreferrer"
+                  )
+                }
+              >
+                {t("settings:sso.purchaseLicense")}
+              </Button>
+            </>
+          )}
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
 const SSOSection = () => {
   const { user } = useAuth();
+  const { userPlan } = useUser();
+
+  const isEnterprise = userPlan === UserPlan.ENTERPRISE;
 
   const {
     data: providerConfig,
     isLoading,
     refetch,
-  } = useSsoProviderConfig({ enabled: user?.role === UserRole.ADMIN });
+  } = useSsoProviderConfig({
+    enabled: user?.role === UserRole.ADMIN && isEnterprise,
+  });
 
   if (user?.role !== UserRole.ADMIN) {
     return null;
+  }
+
+  if (!isEnterprise) {
+    return <SSOUpgradePrompt />;
   }
 
   if (isLoading) {

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -29,8 +29,8 @@ module.exports = {
     "type-empty": [2, "never"],
     // Scope must be lowercase
     "scope-case": [2, "always", "lower-case"],
-    // Subject must be lowercase (conventional commits standard)
-    "subject-case": [2, "always", "lower-case"],
+    // Allow any case in subject
+    "subject-case": [0],
     // Header must not exceed 100 characters
     "header-max-length": [2, "always", 100],
     // Body must have a blank line before it

--- a/docs/adr/001-add-organization-entity.md
+++ b/docs/adr/001-add-organization-entity.md
@@ -1,4 +1,4 @@
-yes# ADR-001: Add Organization Entity
+# ADR-001: Add Organization Entity
 
 **Status:** Proposed
 **Date:** 2026-03-15

--- a/docs/adr/001-add-organization-entity.md
+++ b/docs/adr/001-add-organization-entity.md
@@ -1,0 +1,93 @@
+yes# ADR-001: Add Organization Entity
+
+**Status:** Proposed
+**Date:** 2026-03-15
+**Author:** Brice
+
+## Context
+
+Qarote currently models billing as user-scoped (`Subscription.userId @unique`) and SSO as workspace-scoped (`WorkspaceSsoConfig`). Workspace ownership is tracked via `Workspace.ownerId`.
+
+This creates friction for companies that need multiple workspaces (e.g., prod/staging/dev):
+
+- **Billing:** Tied to the workspace owner's personal Stripe customer. One subscription per user, plan limits checked against the owner. No way to share a single subscription across multiple workspaces.
+- **SSO:** Currently workspace-scoped (`WorkspaceSsoConfig`) and only deployed to staging, not production. The workspace-scoped design would require a company with three workspaces to configure SSO three times with the same IdP.
+- **Ownership:** `Workspace.ownerId` is a single user. No concept of shared administrative control or role hierarchy above workspace level.
+
+## Decision
+
+Introduce an **Organization** entity that sits above workspaces. An organization owns billing (Stripe customer/subscription), SSO configuration, and workspace membership. Users belong to organizations via `OrganizationMember` with roles (OWNER, ADMIN, MEMBER).
+
+## Alternatives Considered
+
+### 1. Extend User-owns-Workspace model
+
+Add multi-workspace billing by allowing a user's subscription to cover multiple workspaces. Keep SSO per-workspace.
+
+- **Pros:** Minimal schema change, no new entity.
+- **Cons:** Billing remains personal (tied to one user's account). No path to shared admin control. SSO duplication remains. Does not model the real-world concept of a company/team.
+
+**Rejected because** it solves billing partially but leaves SSO fragmented and has no clean model for shared ownership.
+
+### 2. Use better-auth's built-in Organization plugin
+
+better-auth ships an organization concept with `SsoProvider.organizationId` already in the schema.
+
+- **Pros:** Less custom code, follows the auth library's conventions.
+- **Cons:** Tightly coupled to better-auth's opinionated model. Limited control over role hierarchy, billing integration, and migration strategy. The existing `SsoProvider.organizationId` field was added by the plugin but is unused — adopting it fully would require conforming to better-auth's org lifecycle, which does not align with our billing and workspace model.
+
+**Rejected because** we need full control over org lifecycle, billing integration, and the migration path. The better-auth plugin field (`SsoProvider.organizationId`) should be acknowledged and either repurposed or removed to avoid confusion.
+
+### 3. "Team" model scoped under workspaces
+
+Add a Team entity within a workspace for grouping users, but keep billing and SSO as-is.
+
+- **Pros:** Simpler change, useful for RBAC within a workspace.
+- **Cons:** Does not solve the cross-workspace billing or SSO problems at all.
+
+**Rejected because** it solves a different problem (intra-workspace RBAC) and does not address the core need.
+
+## Approach
+
+Four independently deployable phases:
+
+1. **Schema + Data Migration** — Add Organization/OrganizationMember models, migrate existing data, no runtime behavior change.
+2. **Move Billing to Organization** — Subscription, plan limits, and Stripe become org-scoped. Split into read-path (2a) and write-path (2b) for safety.
+3. **Build SSO as Org-Scoped** — Since SSO is only on staging (no production data), build it org-scoped from the start. Drop `WorkspaceSsoConfig` directly instead of migrating. No dual-write or backward-compat needed.
+4. **Frontend + Cleanup** — Org UI, remove deprecated fields.
+
+## Trade-offs Accepted
+
+### What we gain
+
+- Single billing relationship per company, shared across all their workspaces
+- SSO configured once per organization, not per workspace
+- Role hierarchy (Org OWNER/ADMIN/MEMBER) above workspace-level roles
+- Clean model for multi-workspace companies
+- Foundation for future org-level features (audit logs, org-wide policies)
+
+### What we give up
+
+- **Simplicity:** Every plan check now resolves through an org join. `getUserPlan(userId)` becomes a two-step lookup (user -> org -> subscription).
+- **Migration risk:** Large data migration touching billing and workspace ownership. Mitigated by phasing and dual-write strategy. SSO risk is minimal since it has no production data — it can be rebuilt org-scoped directly.
+- **Self-hosted complexity:** Even single-tenant deployments get an implicit "Default" org, adding a layer of indirection that does not benefit them.
+
+## Risks and Mitigations
+
+| Risk                                                                | Mitigation                                                                                                                          |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Phase 2 Stripe webhook failures during dual-write transition        | Feature flag (`USE_ORG_BILLING`) for per-tenant rollout. Keep User.stripeCustomerId as read-only lookup during transition.          |
+| Users with subscriptions but no workspaces missed by migration      | Second migration pass: create orgs for users with Subscription but no owned workspaces.                                             |
+| Multi-org membership creates ambiguous resource counting            | Define policy: resource limits are per-org, not per-user. A user in two orgs consumes quota in each independently.                  |
+| `ownerId` referenced in 21+ files; removal is high-risk             | Keep `Workspace.ownerId` as denormalized audit field. Authorization moves to OrgMember roles, but ownerId stays for history.        |
+| `SsoProvider.organizationId` already exists from better-auth plugin | Audit usage. If unused, remove in Phase 3 or repurpose it to point to our Organization model.                                       |
+| No verification before destructive Phase 4 cleanup                  | Add Phase 3.5 verification gate: assert every workspace has org, every org has subscription, no code path uses deprecated fields.   |
+| SSO staging-only data may conflict with new org-scoped schema       | Drop `WorkspaceSsoConfig` and staging SSO data in Phase 3. Rebuild SSO config as `OrgSsoConfig` from scratch — no migration needed. |
+
+## Rollback Strategy
+
+- **Phase 1:** Drop new tables and column. No runtime code changed, so rollback is a reverse migration.
+- **Phase 2a (read path):** Revert `getUserPlan` to direct user lookup. Feature flag off.
+- **Phase 2b (write path):** Stop writing to org Stripe fields. Stripe customer stays on User. Feature flag off.
+- **Phase 3:** Revert SSO router and drop `OrgSsoConfig`. Since SSO has no production data, rollback is just removing the new code — no data migration needed in either direction.
+- **Phase 4:** No rollback — this is the point of no return. Only execute after Phase 3.5 verification passes in production.


### PR DESCRIPTION
## Summary

- Refactor notification settings modal to vertical tab layout for better UX
- Gate SSO settings behind enterprise plan with upgrade prompt
- Improve help page with live chat, tawk.to integration, and expanded FAQ
- Add self-host callout card to subscription settings
- Reuse verified server in users router to avoid redundant db lookups
- Add organization entity ADR and Claude launch config
- Remove plan badge from all page headers
- Fix help & support sidebar active state
- Hide sidebar trigger on desktop and remove quick links
- Add CLAUDE.md for project context

## Test plan

- [ ] Verify notification settings modal opens with vertical tab layout
- [ ] Verify SSO settings show upgrade prompt for non-enterprise plans
- [ ] Verify help page renders FAQ and live chat widget
- [ ] Verify self-host callout card shows on subscription settings
- [ ] Verify sidebar active states are correct on all pages
- [ ] Verify page headers no longer show plan badges
- [ ] Run `pnpm type-check` and `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabbed notification settings (General, Email, Browser, Webhook, Slack) including webhook example, severity selection, Slack enable/disable, email autosave, and browser permission flows.
  * Live chat added to Help; SSO now shows enterprise upgrade prompt for non‑enterprise users.

* **Documentation**
  * New project CLAUDE.md and ADR; expanded FAQs and consolidated repo commands; updated billing/help/alerts locales.

* **UI Improvements**
  * Sidebar shows profile images when present; added self‑host callout and removed PlanBadge from headers; responsive sidebar trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->