### PR TITLE
fix: load GTM only in production

### DIFF
--- a/.github/workflows/deploy-landing-production.yml
+++ b/.github/workflows/deploy-landing-production.yml
@@ -84,6 +84,7 @@ jobs:
         env:
           VITE_APP_BASE_URL: ${{ vars.VITE_APP_BASE_URL }}
           VITE_PORTAL_URL: ${{ vars.VITE_PORTAL_URL }}
+          VITE_ENVIRONMENT: production
           NODE_ENV: production
         run: pnpm run build
 

--- a/.github/workflows/deploy-portal-production.yml
+++ b/.github/workflows/deploy-portal-production.yml
@@ -86,6 +86,7 @@ jobs:
           VITE_PORTAL_URL: ${{ vars.VITE_PORTAL_URL }}
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           VITE_DEPLOYMENT_MODE: ${{ vars.DEPLOYMENT_MODE }}
+          VITE_ENVIRONMENT: production
           NODE_ENV: production
         run: pnpm run build
 

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -20,38 +20,24 @@
     <!-- Runtime config for self-hosted binary (served dynamically by backend) -->
     <script src="/config.js"></script>
 
-    <!-- Google Tag Manager (cloud mode only) -->
+    <!-- Google Tag Manager (production only) -->
     <script>
       (function () {
-        var cfg = window.__QAROTE_CONFIG__;
-        if (!cfg || cfg.deploymentMode !== "cloud") return;
-
-        (function (w, d, s, l, i) {
-          w[l] = w[l] || [];
-          w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-          var f = d.getElementsByTagName(s)[0],
-            j = d.createElement(s),
-            dl = l != "dataLayer" ? "&l=" + l : "";
-          j.async = true;
-          j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-          f.parentNode.insertBefore(j, f);
-        })(window, document, "script", "dataLayer", "GTM-52CRNTFK");
+        if ("%VITE_ENVIRONMENT%" !== "production") return;
+        var w = window, d = document, l = "dataLayer", i = "GTM-52CRNTFK";
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName("script")[0],
+          j = d.createElement("script");
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i;
+        f.parentNode.insertBefore(j, f);
       })();
     </script>
     <!-- End Google Tag Manager -->
   </head>
 
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-52CRNTFK"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe
-    ></noscript>
-    <!-- End Google Tag Manager (noscript) -->
 
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -38,6 +38,15 @@
   </head>
 
   <body>
+    <!-- Google Tag Manager (noscript) - production only -->
+    <script>
+      if ("%VITE_ENVIRONMENT%" === "production") {
+        document.write(
+          '<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-52CRNTFK" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>'
+        );
+      }
+    </script>
+    <!-- End Google Tag Manager (noscript) -->
 
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/apps/app/src/types/vite-env.d.ts
+++ b/apps/app/src/types/vite-env.d.ts
@@ -1,6 +1,13 @@
 /// <reference types="vite/client" />
 
-// Google Tag Manager type definitions
+interface ImportMetaEnv {
+  readonly VITE_ENVIRONMENT?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 interface Window {
   dataLayer?: unknown[];
   __QAROTE_CONFIG__?: {

--- a/apps/portal/index.html
+++ b/apps/portal/index.html
@@ -10,32 +10,23 @@
     />
     <link rel="icon" type="image/svg+xml" href="images/new_icon.svg" />
 
-    <!-- Google Tag Manager -->
+    <!-- Google Tag Manager (production only) -->
     <script>
-      (function (w, d, s, l, i) {
+      (function () {
+        if ("%VITE_ENVIRONMENT%" !== "production") return;
+        var w = window, d = document, l = "dataLayer", i = "GTM-52CRNTFK";
         w[l] = w[l] || [];
         w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
+        var f = d.getElementsByTagName("script")[0],
+          j = d.createElement("script");
         j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i;
         f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-52CRNTFK");
+      })();
     </script>
     <!-- End Google Tag Manager -->
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-52CRNTFK"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe
-    ></noscript>
-    <!-- End Google Tag Manager (noscript) -->
 
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/apps/portal/index.html
+++ b/apps/portal/index.html
@@ -27,6 +27,15 @@
     <!-- End Google Tag Manager -->
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) - production only -->
+    <script>
+      if ("%VITE_ENVIRONMENT%" === "production") {
+        document.write(
+          '<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-52CRNTFK" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>'
+        );
+      }
+    </script>
+    <!-- End Google Tag Manager (noscript) -->
 
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -145,6 +145,16 @@
     </script>
     <!-- End Google Tag Manager -->
 
+    <!-- Google Tag Manager (noscript) - production only -->
+    <script>
+      if ("%VITE_ENVIRONMENT%" === "production") {
+        document.write(
+          '<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-52CRNTFK" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>'
+        );
+      }
+    </script>
+    <!-- End Google Tag Manager (noscript) -->
+
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -129,33 +129,21 @@
         ]
       }
     </script>
-    <!-- Google Tag Manager -->
+    <!-- Google Tag Manager (production only) -->
     <script>
-      (function (w, d, s, l, i) {
+      (function () {
+        if ("%VITE_ENVIRONMENT%" !== "production") return;
+        var w = window, d = document, l = "dataLayer", i = "GTM-52CRNTFK";
         w[l] = w[l] || [];
         w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
+        var f = d.getElementsByTagName("script")[0],
+          j = d.createElement("script");
         j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i;
         f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-52CRNTFK");
+      })();
     </script>
     <!-- End Google Tag Manager -->
-  </head>
-
-  <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-52CRNTFK"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe
-    ></noscript>
-    <!-- End Google Tag Manager (noscript) -->
 
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
## Summary
- Replace hardcoded GTM snippets in all 3 apps (app, web, portal) with a `VITE_ENVIRONMENT` build-time check
- GTM only loads when `VITE_ENVIRONMENT === "production"` — zero requests in dev/staging
- Remove unnecessary `<noscript>` GTM iframes
- Add `VITE_ENVIRONMENT: production` to portal and landing production CI workflows (app already had it)

## Motivation
GTM was loading on staging and dev environments, polluting analytics data with test traffic. This change ensures clean production-only tracking.

## Test plan
- [ ] `pnpm dev` — verify no `googletagmanager.com` requests in Network tab
- [ ] Build with `VITE_ENVIRONMENT=production` — verify GTM loads correctly
- [ ] Deploy to staging — confirm no GTM
- [ ] Deploy to production — confirm GTM loads with `GTM-52CRNTFK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a build-time environment flag for production builds so the runtime can detect production at compile time.
  * Google Tag Manager now only loads in production and its bootstrap logic was simplified across web, portal, and app frontends.
  * Added a global type declaration to expose the build environment variable to the client-side type system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->