### PR TITLE
fix: show placeholder data in queued messages chart when no queues exist

### DIFF
--- a/apps/app/src/components/QueuedMessagesChart.tsx
+++ b/apps/app/src/components/QueuedMessagesChart.tsx
@@ -72,7 +72,13 @@ export const QueuedMessagesChart = ({
     );
   }
 
-  const chartData = queueTotals?.map((point) => ({
+  const emptyPoint = {
+    total: 0,
+    ready: 0,
+    unacked: 0,
+  };
+
+  const mappedData = queueTotals?.map((point) => ({
     timestamp: point.timestamp,
     time: new Date(point.timestamp).toLocaleTimeString([], {
       hour: "2-digit",
@@ -90,6 +96,23 @@ export const QueuedMessagesChart = ({
     ready: point.messages_ready || 0,
     unacked: point.messages_unacknowledged || 0,
   }));
+
+  // Generate placeholder data when no queues exist so the chart renders axes/grid
+  const chartData =
+    mappedData && mappedData.length > 0
+      ? mappedData
+      : Array.from({ length: 7 }, (_, i) => {
+          const ts = Date.now() - (6 - i) * 10000;
+          return {
+            ...emptyPoint,
+            timestamp: ts,
+            time: new Date(ts).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            }),
+            dateTime: "",
+          };
+        });
 
   return (
     <Card className="border-0 shadow-md bg-card backdrop-blur-xs">

--- a/apps/app/src/components/QueuedMessagesChart.tsx
+++ b/apps/app/src/components/QueuedMessagesChart.tsx
@@ -97,22 +97,25 @@ export const QueuedMessagesChart = ({
     unacked: point.messages_unacknowledged || 0,
   }));
 
-  // Generate placeholder data when no queues exist so the chart renders axes/grid
+  // Only generate placeholder data when queueTotals is a defined empty array
+  // (no queues exist). When undefined, data is unavailable — don't fake zeros.
   const chartData =
-    mappedData && mappedData.length > 0
-      ? mappedData
-      : Array.from({ length: 7 }, (_, i) => {
-          const ts = Date.now() - (6 - i) * 10000;
-          return {
-            ...emptyPoint,
-            timestamp: ts,
-            time: new Date(ts).toLocaleTimeString([], {
-              hour: "2-digit",
-              minute: "2-digit",
-            }),
-            dateTime: "",
-          };
-        });
+    mappedData === undefined
+      ? undefined
+      : mappedData.length > 0
+        ? mappedData
+        : Array.from({ length: 7 }, (_, i) => {
+            const ts = Date.now() - (6 - i) * 10000;
+            return {
+              ...emptyPoint,
+              timestamp: ts,
+              time: new Date(ts).toLocaleTimeString([], {
+                hour: "2-digit",
+                minute: "2-digit",
+              }),
+              dateTime: "",
+            };
+          });
 
   return (
     <Card className="border-0 shadow-md bg-card backdrop-blur-xs">

--- a/apps/app/src/components/QueuedMessagesChart.tsx
+++ b/apps/app/src/components/QueuedMessagesChart.tsx
@@ -99,13 +99,14 @@ export const QueuedMessagesChart = ({
 
   // Only generate placeholder data when queueTotals is a defined empty array
   // (no queues exist). When undefined, data is unavailable — don't fake zeros.
+  const now = Date.now();
   const chartData =
     mappedData === undefined
       ? undefined
       : mappedData.length > 0
         ? mappedData
         : Array.from({ length: 7 }, (_, i) => {
-            const ts = Date.now() - (6 - i) * 10000;
+            const ts = now - (6 - i) * 10000;
             return {
               ...emptyPoint,
               timestamp: ts,


### PR DESCRIPTION
## Summary
- Generate zero-value placeholder data points in the Queued Messages chart when no queue data exists, so the chart renders with proper axes and grid instead of a blank area
- Matches the existing pattern used by the Message Rates chart

## Test plan
- [ ] Verify the Queued Messages chart shows a flat line at 0 with axes/grid when no queues exist
- [ ] Verify the chart still renders real data correctly when queues are present


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queued messages chart now shows a series of placeholder data points when no queues are present, ensuring the chart maintains its visual structure, renders consistently, and preserves tooltip/interaction behavior even with empty data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->