### PR TITLE
style: standardize font family across all apps

### DIFF
--- a/apps/app/src/components/AppSidebar.tsx
+++ b/apps/app/src/components/AppSidebar.tsx
@@ -118,7 +118,9 @@ export function AppSidebar() {
         <div className="flex items-center gap-3">
           <img src="/images/new_icon.svg" alt="Qarote" className="w-6 h-6" />
           <div>
-            <h2 className="font-bold text-sidebar-foreground">Qarote</h2>
+            <h2 className="font-normal text-[1.2rem] text-sidebar-foreground">
+              Qarote
+            </h2>
           </div>
         </div>
 

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -17,6 +17,12 @@
 }
 
 @theme {
+  --font-sans: "Arial", ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
+  --font-mono: "Fragment Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));

--- a/apps/portal/src/styles/index.css
+++ b/apps/portal/src/styles/index.css
@@ -17,6 +17,12 @@
 }
 
 @theme {
+  --font-sans: "Arial", ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
+  --font-mono: "Fragment Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -21,6 +21,12 @@
 }
 
 @theme {
+  --font-sans: "Arial", ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
+  --font-mono: "Fragment Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));


### PR DESCRIPTION
## Summary
- Set **Arial** as the primary body font across all three frontend apps (app, web, portal)
- Add **Fragment Mono** as the monospace font for code elements
- Uses Tailwind CSS 4 `--font-sans` and `--font-mono` theme variables for consistency
- Matches the font approach used by Mistral AI (Arial-first system font stack)

## Test plan
- [ ] Verify app dashboard renders with Arial font
- [ ] Verify landing page (web) renders with Arial font
- [ ] Verify customer portal renders with Arial font
- [ ] Check monospace elements use Fragment Mono (if installed) or fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charts now show a 7-point placeholder series with synthetic timestamps and formatted times when queue data is missing.

* **Style**
  * Standardized font stacks across apps with enhanced sans-serif and monospace (emoji and system UI fallbacks).
  * Adjusted sidebar brand heading typography for a lighter weight and slightly larger text size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->