### PR TITLE
fix: skip payment confirmation email for $0 invoices

### DIFF
--- a/apps/api/src/services/stripe/webhook-handlers.ts
+++ b/apps/api/src/services/stripe/webhook-handlers.ts
@@ -740,8 +740,8 @@ export async function handleInvoicePaymentSucceeded(invoice: Invoice) {
       );
     }
 
-    // Send payment confirmation email
-    if (subscription.user) {
+    // Send payment confirmation email (skip $0 invoices from trials/free signups)
+    if (subscription.user && invoice.amount_paid > 0) {
       await EmailService.sendPaymentConfirmationEmail({
         to: subscription.user.email,
         userName: getUserDisplayName(subscription.user),


### PR DESCRIPTION
## Summary
- Skip sending "Payment Confirmed" email when `invoice.amount_paid` is `0`
- Fixes confusing "$0.00 payment confirmed" emails sent to new users on signup (trial/free tier creates a $0 Stripe invoice)

## Test plan
- [x] Existing webhook handler tests pass (10/10)
- [ ] Sign up with a new account — no payment confirmation email should be sent
- [ ] Complete an actual payment — confirmation email should still be sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed payment confirmation emails to only send when invoice amounts are actually paid, preventing false notifications.

* **Style**
  * Updated role badge styling with consistent theming across profile pages.
  * Redesigned team member information display for improved visual clarity.
  * Enhanced Security Settings visibility for password-authenticated accounts.
  * Removed redundant UI elements from upgrade prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->