### PR TITLE
feat: add Google/SSO OAuth to org invitation page

### DIFF
--- a/apps/app/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/app/src/components/auth/GoogleLoginButton.tsx
@@ -8,12 +8,16 @@ import { Button } from "@/components/ui/button";
 
 interface GoogleLoginButtonProps {
   onError?: (error: string) => void;
+  onBeforeRedirect?: () => void;
+  callbackURL?: string;
   className?: string;
   mode?: "signin" | "signup";
 }
 
 export const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({
   onError,
+  onBeforeRedirect,
+  callbackURL,
   className,
   mode = "signin",
 }) => {
@@ -26,9 +30,11 @@ export const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({
 
   const handleGoogleLogin = async () => {
     try {
+      onBeforeRedirect?.();
       await authClient.signIn.social({
         provider: "google",
-        callbackURL: `${window.location.origin}/auth/sso/callback`,
+        callbackURL:
+          callbackURL || `${window.location.origin}/auth/sso/callback`,
       });
     } catch (error) {
       logger.error("Google login failed:", error);

--- a/apps/app/src/components/auth/SSOLoginButton.tsx
+++ b/apps/app/src/components/auth/SSOLoginButton.tsx
@@ -12,12 +12,16 @@ import { Input } from "@/components/ui/input";
 
 interface SSOLoginButtonProps {
   onError?: (error: string) => void;
+  onBeforeRedirect?: () => void;
+  callbackURL?: string;
   className?: string;
   mode?: "signin" | "signup";
 }
 
 export const SSOLoginButton: React.FC<SSOLoginButtonProps> = ({
   onError,
+  onBeforeRedirect,
+  callbackURL,
   className,
   mode = "signin",
 }) => {
@@ -36,9 +40,11 @@ export const SSOLoginButton: React.FC<SSOLoginButtonProps> = ({
     if (!config?.providerId) return;
     try {
       setIsPending(true);
+      onBeforeRedirect?.();
       await authClient.signIn.sso({
         providerId: config.providerId,
-        callbackURL: `${window.location.origin}/auth/sso/callback`,
+        callbackURL:
+          callbackURL || `${window.location.origin}/auth/sso/callback`,
       });
     } catch (error) {
       logger.error("SSO redirect failed:", error);
@@ -53,9 +59,11 @@ export const SSOLoginButton: React.FC<SSOLoginButtonProps> = ({
     if (!email.trim()) return;
     try {
       setIsPending(true);
+      onBeforeRedirect?.();
       await authClient.signIn.sso({
         email,
-        callbackURL: `${window.location.origin}/auth/sso/callback`,
+        callbackURL:
+          callbackURL || `${window.location.origin}/auth/sso/callback`,
       });
     } catch (error) {
       logger.error("SSO redirect failed:", error);

--- a/apps/app/src/pages/AcceptOrgInvitation.tsx
+++ b/apps/app/src/pages/AcceptOrgInvitation.tsx
@@ -248,6 +248,50 @@ const OrgInvitationForm = ({
   );
 };
 
+const OAuthSection = ({
+  mode,
+  callbackURL,
+  onBeforeRedirect,
+  onError,
+}: {
+  mode: "signin" | "signup";
+  callbackURL?: string;
+  onBeforeRedirect: () => void;
+  onError: (msg: string) => void;
+}) => {
+  const { t } = useTranslation("auth");
+  const { showAlternativeAuth } = useShowAlternativeAuth();
+
+  if (!showAlternativeAuth) return null;
+
+  return (
+    <div className="space-y-3">
+      <GoogleLoginButton
+        mode={mode}
+        callbackURL={callbackURL}
+        onBeforeRedirect={onBeforeRedirect}
+        onError={onError}
+      />
+      <SSOLoginButton
+        mode={mode}
+        callbackURL={callbackURL}
+        onBeforeRedirect={onBeforeRedirect}
+        onError={onError}
+      />
+      <div className="relative my-4">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-card px-2 text-muted-foreground">
+            {t("orContinueWith")}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const AcceptOrgInvitation = () => {
   const { t } = useTranslation("auth");
   const { token } = useParams<{ token: string }>();
@@ -272,7 +316,6 @@ const AcceptOrgInvitation = () => {
     firstWorkspaceId: string | null;
   } | null>(null);
 
-  const { showAlternativeAuth } = useShowAlternativeAuth();
   const oauthCallbackURL = token
     ? `${window.location.origin}/auth/sso/callback?orgInviteToken=${token}`
     : undefined;
@@ -525,32 +568,12 @@ const AcceptOrgInvitation = () => {
         <CardContent className="space-y-6">
           <OrgInvitationInfo invitation={invitation} />
 
-          {showAlternativeAuth && (
-            <div className="space-y-3">
-              <GoogleLoginButton
-                mode="signin"
-                callbackURL={oauthCallbackURL}
-                onBeforeRedirect={storeTokenFallback}
-                onError={(msg) => setMutationError(msg)}
-              />
-              <SSOLoginButton
-                mode="signin"
-                callbackURL={oauthCallbackURL}
-                onBeforeRedirect={storeTokenFallback}
-                onError={(msg) => setMutationError(msg)}
-              />
-              <div className="relative my-4">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t" />
-                </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-card px-2 text-muted-foreground">
-                    {t("orContinueWith")}
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
+          <OAuthSection
+            mode="signin"
+            callbackURL={oauthCallbackURL}
+            onBeforeRedirect={storeTokenFallback}
+            onError={(msg) => setMutationError(msg)}
+          />
 
           <Button
             className="w-full bg-gradient-button hover:bg-gradient-button-hover"
@@ -597,32 +620,12 @@ const AcceptOrgInvitation = () => {
           </Alert>
         )}
 
-        {showAlternativeAuth && (
-          <div className="space-y-3">
-            <GoogleLoginButton
-              mode="signup"
-              callbackURL={oauthCallbackURL}
-              onBeforeRedirect={storeTokenFallback}
-              onError={(msg) => setMutationError(msg)}
-            />
-            <SSOLoginButton
-              mode="signup"
-              callbackURL={oauthCallbackURL}
-              onBeforeRedirect={storeTokenFallback}
-              onError={(msg) => setMutationError(msg)}
-            />
-            <div className="relative my-4">
-              <div className="absolute inset-0 flex items-center">
-                <span className="w-full border-t" />
-              </div>
-              <div className="relative flex justify-center text-xs uppercase">
-                <span className="bg-card px-2 text-muted-foreground">
-                  {t("orContinueWith")}
-                </span>
-              </div>
-            </div>
-          </div>
-        )}
+        <OAuthSection
+          mode="signup"
+          callbackURL={oauthCallbackURL}
+          onBeforeRedirect={storeTokenFallback}
+          onError={(msg) => setMutationError(msg)}
+        />
 
         <OrgInvitationForm
           form={form}

--- a/apps/app/src/pages/AcceptOrgInvitation.tsx
+++ b/apps/app/src/pages/AcceptOrgInvitation.tsx
@@ -10,6 +10,8 @@ import { authClient } from "@/lib/auth-client";
 import { logger } from "@/lib/logger";
 import { trpc } from "@/lib/trpc/client";
 
+import { GoogleLoginButton } from "@/components/auth/GoogleLoginButton";
+import { SSOLoginButton } from "@/components/auth/SSOLoginButton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -41,6 +43,7 @@ import {
   type OrgInvitationDetails,
   useOrgInvitationDetails,
 } from "@/hooks/queries/useOrgInvitationDetails";
+import { useShowAlternativeAuth } from "@/hooks/queries/useSsoConfig";
 import { useSwitchWorkspace } from "@/hooks/queries/useWorkspaceApi";
 import { useToast } from "@/hooks/ui/useToast";
 
@@ -268,6 +271,14 @@ const AcceptOrgInvitation = () => {
     orgName: string;
     firstWorkspaceId: string | null;
   } | null>(null);
+
+  const { showAlternativeAuth } = useShowAlternativeAuth();
+  const oauthCallbackURL = token
+    ? `${window.location.origin}/auth/sso/callback?orgInviteToken=${token}`
+    : undefined;
+  const storeTokenFallback = () => {
+    if (token) sessionStorage.setItem("pendingOrgInviteToken", token);
+  };
 
   const error =
     mutationError ??
@@ -514,6 +525,33 @@ const AcceptOrgInvitation = () => {
         <CardContent className="space-y-6">
           <OrgInvitationInfo invitation={invitation} />
 
+          {showAlternativeAuth && (
+            <div className="space-y-3">
+              <GoogleLoginButton
+                mode="signin"
+                callbackURL={oauthCallbackURL}
+                onBeforeRedirect={storeTokenFallback}
+                onError={(msg) => setMutationError(msg)}
+              />
+              <SSOLoginButton
+                mode="signin"
+                callbackURL={oauthCallbackURL}
+                onBeforeRedirect={storeTokenFallback}
+                onError={(msg) => setMutationError(msg)}
+              />
+              <div className="relative my-4">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-card px-2 text-muted-foreground">
+                    {t("orContinueWith")}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+
           <Button
             className="w-full bg-gradient-button hover:bg-gradient-button-hover"
             onClick={() =>
@@ -557,6 +595,33 @@ const AcceptOrgInvitation = () => {
           <Alert variant="destructive">
             <AlertDescription>{error}</AlertDescription>
           </Alert>
+        )}
+
+        {showAlternativeAuth && (
+          <div className="space-y-3">
+            <GoogleLoginButton
+              mode="signup"
+              callbackURL={oauthCallbackURL}
+              onBeforeRedirect={storeTokenFallback}
+              onError={(msg) => setMutationError(msg)}
+            />
+            <SSOLoginButton
+              mode="signup"
+              callbackURL={oauthCallbackURL}
+              onBeforeRedirect={storeTokenFallback}
+              onError={(msg) => setMutationError(msg)}
+            />
+            <div className="relative my-4">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-card px-2 text-muted-foreground">
+                  {t("orContinueWith")}
+                </span>
+              </div>
+            </div>
+          </div>
         )}
 
         <OrgInvitationForm

--- a/apps/app/src/pages/AcceptOrgInvitation.tsx
+++ b/apps/app/src/pages/AcceptOrgInvitation.tsx
@@ -317,10 +317,14 @@ const AcceptOrgInvitation = () => {
   } | null>(null);
 
   const oauthCallbackURL = token
-    ? `${window.location.origin}/auth/sso/callback?orgInviteToken=${token}`
+    ? `${window.location.origin}/auth/sso/callback?orgInviteToken=${encodeURIComponent(token)}`
     : undefined;
   const storeTokenFallback = () => {
-    if (token) sessionStorage.setItem("pendingOrgInviteToken", token);
+    try {
+      if (token) sessionStorage.setItem("pendingOrgInviteToken", token);
+    } catch {
+      // Best-effort — Safari private browsing may throw
+    }
   };
 
   const error =

--- a/apps/app/src/pages/SSOCallback.tsx
+++ b/apps/app/src/pages/SSOCallback.tsx
@@ -39,14 +39,30 @@ const SSOCallback: React.FC = () => {
     if (error || isLoading) return;
 
     if (isAuthenticated) {
-      // Authenticated: go to dashboard if user has workspace, otherwise workspace creation
+      // Check for pending org invitation (query param first, sessionStorage fallback)
+      const orgInviteToken =
+        searchParams.get("orgInviteToken") ||
+        sessionStorage.getItem("pendingOrgInviteToken");
+      if (orgInviteToken) {
+        sessionStorage.removeItem("pendingOrgInviteToken");
+        navigate(`/org-invite/${orgInviteToken}`, { replace: true });
+        return;
+      }
+
       const target = user?.workspaceId ? "/" : "/workspace";
       navigate(target, { replace: true });
     } else {
       // Session cookie was expected but auth check found nothing — redirect to sign-in
       navigate("/auth/sign-in", { replace: true });
     }
-  }, [error, isLoading, isAuthenticated, user?.workspaceId, navigate]);
+  }, [
+    error,
+    isLoading,
+    isAuthenticated,
+    user?.workspaceId,
+    navigate,
+    searchParams,
+  ]);
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary

- Add `onBeforeRedirect` and `callbackURL` props to `GoogleLoginButton` and `SSOLoginButton` for customizable OAuth flows
- Update `SSOCallback` to check for `orgInviteToken` query param (with `sessionStorage` fallback) and redirect to invitation page after OAuth
- Add Google/SSO buttons to both "existing user sign-in" and "new user registration" states on the org invitation page

## How it works

1. User on `/org-invite/:token` clicks "Sign in/up with Google"
2. Token is passed via `callbackURL` query param (`?orgInviteToken=...`) + stored in `sessionStorage` as fallback
3. OAuth completes → redirects to `/auth/sso/callback?orgInviteToken=...`
4. `SSOCallback` reads token, redirects to `/org-invite/:token`
5. User is now authenticated → auto-accept flow

## Test plan

- [ ] New user: invitation link → Google signup → callback → redirect → accept
- [ ] Existing user: invitation link → Google sign-in → callback → redirect → accept
- [ ] Regular Google signup (no invitation) still works unchanged
- [ ] Regular email/password invitation flow still works unchanged
- [ ] SSO button follows same pattern as Google button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google and SSO buttons as alternative auth options on the organization-invitation flow.
  * Allow callers to run a callback just before redirecting to OAuth/SSO and to override the OAuth callback URL when needed.
  * Preserve and restore organization invite tokens during social-auth redirects, ensuring users land back on the invite acceptance flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->