### PR TITLE
feat: add language switcher to appearance settings

### DIFF
--- a/apps/app/public/locales/en/appearance.json
+++ b/apps/app/public/locales/en/appearance.json
@@ -5,5 +5,7 @@
   "themeDescription": "Select your preferred color scheme.",
   "light": "Light",
   "dark": "Dark",
-  "system": "System"
+  "system": "System",
+  "languageTitle": "Language",
+  "languageDescription": "Select your preferred language."
 }

--- a/apps/app/public/locales/es/appearance.json
+++ b/apps/app/public/locales/es/appearance.json
@@ -5,5 +5,7 @@
   "themeDescription": "Selecciona tu esquema de colores preferido.",
   "light": "Claro",
   "dark": "Oscuro",
-  "system": "Sistema"
+  "system": "Sistema",
+  "languageTitle": "Idioma",
+  "languageDescription": "Selecciona tu idioma preferido."
 }

--- a/apps/app/public/locales/es/common.json
+++ b/apps/app/public/locales/es/common.json
@@ -59,6 +59,7 @@
   "learnMore": "M\u00e1s informaci\u00f3n",
   "getStarted": "Comenzar",
   "tryAgain": "Intentar de nuevo",
+  "serverConnectionError": "No se puede conectar con el servidor RabbitMQ. Verifique que el servidor esté en ejecución y que los datos de conexión sean correctos.",
   "errorContactSupport": "Si el problema persiste, contáctenos en",
   "goBack": "Volver",
   "termsOfService": "T\u00e9rminos de servicio",

--- a/apps/app/public/locales/fr/appearance.json
+++ b/apps/app/public/locales/fr/appearance.json
@@ -5,5 +5,7 @@
   "themeDescription": "Sélectionnez votre schéma de couleurs préféré.",
   "light": "Clair",
   "dark": "Sombre",
-  "system": "Système"
+  "system": "Système",
+  "languageTitle": "Langue",
+  "languageDescription": "Sélectionnez votre langue préférée."
 }

--- a/apps/app/public/locales/fr/common.json
+++ b/apps/app/public/locales/fr/common.json
@@ -59,6 +59,7 @@
   "learnMore": "En savoir plus",
   "getStarted": "Commencer",
   "tryAgain": "Réessayer",
+  "serverConnectionError": "Impossible de joindre le serveur RabbitMQ. Veuillez vérifier que le serveur est en cours d'exécution et que les informations de connexion sont correctes.",
   "errorContactSupport": "Si le problème persiste, contactez-nous à",
   "goBack": "Retour",
   "termsOfService": "Conditions d'utilisation",

--- a/apps/app/public/locales/zh/appearance.json
+++ b/apps/app/public/locales/zh/appearance.json
@@ -5,5 +5,7 @@
   "themeDescription": "选择您偏好的配色方案。",
   "light": "浅色",
   "dark": "深色",
-  "system": "跟随系统"
+  "system": "跟随系统",
+  "languageTitle": "语言",
+  "languageDescription": "选择您偏好的语言。"
 }

--- a/apps/app/public/locales/zh/common.json
+++ b/apps/app/public/locales/zh/common.json
@@ -59,6 +59,7 @@
   "learnMore": "了解更多",
   "getStarted": "开始使用",
   "tryAgain": "重试",
+  "serverConnectionError": "无法连接到 RabbitMQ 服务器。请检查服务器是否正在运行以及连接信息是否正确。",
   "errorContactSupport": "如果问题仍然存在，请联系我们",
   "goBack": "返回",
   "termsOfService": "服务条款",

--- a/apps/app/src/pages/settings/AppearanceSection.tsx
+++ b/apps/app/src/pages/settings/AppearanceSection.tsx
@@ -1,6 +1,12 @@
 import { useTranslation } from "react-i18next";
 
-import { Monitor, Moon, Sun } from "lucide-react";
+import {
+  LOCALE_FLAGS,
+  LOCALE_LABELS,
+  SUPPORTED_LOCALES,
+  type SupportedLocale,
+} from "@qarote/i18n";
+import { Globe, Monitor, Moon, Sun } from "lucide-react";
 
 import {
   Card,
@@ -9,6 +15,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 import { useTheme } from "@/contexts/ThemeContext";
 
@@ -19,8 +32,9 @@ const themes = [
 ];
 
 const AppearanceSection = () => {
-  const { t } = useTranslation("appearance");
+  const { t, i18n } = useTranslation("appearance");
   const { theme, setTheme } = useTheme();
+  const currentLocale = (i18n.language || "en") as SupportedLocale;
 
   return (
     <div className="space-y-6">
@@ -61,6 +75,40 @@ const AppearanceSection = () => {
               </button>
             ))}
           </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-0 shadow-md">
+        <CardHeader>
+          <CardTitle>{t("languageTitle")}</CardTitle>
+          <CardDescription>{t("languageDescription")}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Select
+            value={currentLocale}
+            onValueChange={(v) => i18n.changeLanguage(v)}
+          >
+            <SelectTrigger className="w-64">
+              <SelectValue>
+                <div className="flex items-center gap-2">
+                  <Globe className="h-4 w-4 shrink-0" />
+                  <span>
+                    {LOCALE_FLAGS[currentLocale]} {LOCALE_LABELS[currentLocale]}
+                  </span>
+                </div>
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {SUPPORTED_LOCALES.map((locale) => (
+                <SelectItem key={locale} value={locale}>
+                  <div className="flex items-center gap-2">
+                    <span>{LOCALE_FLAGS[locale]}</span>
+                    <span>{LOCALE_LABELS[locale]}</span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- Add a language selection dropdown to the Appearance settings page (Settings > Personal > Appearance)
- Users can switch between English, French, Spanish, and Chinese directly from settings
- i18n keys added for all 4 supported locales (en, fr, es, zh)

## Test plan
- [ ] Navigate to Settings > Appearance
- [ ] Verify "Language" card appears below "Theme" card
- [ ] Select each language and confirm the UI updates immediately
- [ ] Verify dropdown shows flag + language name for all locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a language selector in Appearance settings so users can switch app language with locale indicators.
  * Added English, Spanish, French, and Chinese localization entries for the language selector.

* **Chores**
  * Added translated "server connection error" messages in Spanish, French, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->