### PR TITLE
feat(web): add language switcher to landing page footer

### DIFF
--- a/apps/web/src/components/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from "react-i18next";
+
+import {
+  LOCALE_FLAGS,
+  LOCALE_LABELS,
+  SUPPORTED_LOCALES,
+  type SupportedLocale,
+} from "@qarote/i18n";
+import { Globe } from "lucide-react";
+
+export function LanguageSwitcher() {
+  const { i18n } = useTranslation();
+  const currentLocale = (i18n.language || "en") as SupportedLocale;
+
+  return (
+    <div className="relative inline-flex items-center gap-1.5">
+      <Globe
+        className="h-3.5 w-3.5 text-muted-foreground pointer-events-none"
+        aria-hidden="true"
+      />
+      <select
+        value={currentLocale}
+        onChange={(e) => i18n.changeLanguage(e.target.value)}
+        className="appearance-none bg-transparent text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer pr-4 focus:outline-none"
+        aria-label="Select language"
+      >
+        {SUPPORTED_LOCALES.map((locale) => (
+          <option key={locale} value={locale}>
+            {LOCALE_FLAGS[locale]} {LOCALE_LABELS[locale]}
+          </option>
+        ))}
+      </select>
+      <svg
+        className="h-3 w-3 text-muted-foreground pointer-events-none absolute right-0"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/FooterSection.tsx
+++ b/apps/web/src/components/landing/FooterSection.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from "react-i18next";
 
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+
 const FooterLinks = () => {
   const { t } = useTranslation("landing");
 
@@ -110,6 +112,7 @@ const FooterSection = () => {
 
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
             <FooterLinks />
+            <LanguageSwitcher />
           </div>
         </div>
 
@@ -129,6 +132,7 @@ const FooterSection = () => {
 
           <div className="flex items-center gap-6">
             <FooterLinks />
+            <LanguageSwitcher />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add a language selector dropdown to the landing page footer
- Supports English, French, Spanish, and Chinese with flag indicators
- Uses native `<select>` styled to match the footer aesthetic (no heavy UI lib needed)
- Placed in both mobile and desktop footer layouts

## Test plan
- [ ] Navigate to the landing page and scroll to the footer
- [ ] Verify language switcher appears next to social links
- [ ] Switch language and confirm all page text updates immediately
- [ ] Test on mobile viewport — switcher should wrap with footer links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a language switcher in the footer, enabling users to dynamically change the application language at runtime. The switcher displays supported languages with corresponding locale flags and labels, providing an intuitive selection interface available on both mobile and desktop layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->