### PR TITLE
fix(api): use BigInt for overflow-prone integer columns

### DIFF
--- a/apps/api/prisma/migrations/20260402000000_int_to_bigint_overflow_fix/migration.sql
+++ b/apps/api/prisma/migrations/20260402000000_int_to_bigint_overflow_fix/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable: Alert.duration Int -> BigInt
+ALTER TABLE "Alert" ALTER COLUMN "duration" SET DATA TYPE bigint;
+
+-- AlterTable: Queue message counters Int -> BigInt
+ALTER TABLE "Queue" ALTER COLUMN "messages" SET DATA TYPE bigint;
+ALTER TABLE "Queue" ALTER COLUMN "messagesReady" SET DATA TYPE bigint;
+ALTER TABLE "Queue" ALTER COLUMN "messagesUnack" SET DATA TYPE bigint;
+
+-- AlterTable: QueueMetric message counters Int -> BigInt
+ALTER TABLE "QueueMetric" ALTER COLUMN "messages" SET DATA TYPE bigint;
+ALTER TABLE "QueueMetric" ALTER COLUMN "messagesReady" SET DATA TYPE bigint;
+ALTER TABLE "QueueMetric" ALTER COLUMN "messagesUnack" SET DATA TYPE bigint;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -33,7 +33,7 @@ model Alert {
   sourceType     String?
   sourceName     String?
   details        Json?
-  duration       Int?
+  duration       BigInt?
   alertRule      AlertRule?      @relation(fields: [alertRuleId], references: [id])
   user           User?           @relation(fields: [createdById], references: [id])
   server         RabbitMQServer? @relation(fields: [serverId], references: [id], onDelete: Cascade)
@@ -165,9 +165,9 @@ model Queue {
   name          String
   vhost         String
   serverId      String
-  messages      Int
-  messagesReady Int
-  messagesUnack Int
+  messages      BigInt
+  messagesReady BigInt
+  messagesUnack BigInt
   lastFetched   DateTime
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
@@ -181,9 +181,9 @@ model QueueMetric {
   id            String   @id @default(uuid())
   queueId       String
   timestamp     DateTime @default(now())
-  messages      Int
-  messagesReady Int
-  messagesUnack Int
+  messages      BigInt
+  messagesReady BigInt
+  messagesUnack BigInt
   publishRate   Float
   consumeRate   Float
   queue         Queue    @relation(fields: [queueId], references: [id], onDelete: Cascade)

--- a/apps/api/src/services/alerts/__tests__/alert.service.getResolvedAlerts.test.ts
+++ b/apps/api/src/services/alerts/__tests__/alert.service.getResolvedAlerts.test.ts
@@ -88,7 +88,7 @@ function makeResolvedAlert(
     sourceName: "rabbit@node1",
     firstSeenAt: new Date("2026-01-01T00:00:00Z"),
     resolvedAt: new Date("2026-01-01T01:00:00Z"),
-    duration: 3_600_000,
+    duration: BigInt(3_600_000),
     createdAt: new Date("2026-01-01T00:00:00Z"),
     ...overrides,
   };

--- a/apps/api/src/services/alerts/alert.notification.ts
+++ b/apps/api/src/services/alerts/alert.notification.ts
@@ -361,19 +361,19 @@ class AlertNotificationService {
         alertsToResolve
           .filter((alert) => !activeFingerprints.has(alert.fingerprint!))
           .map(async (alert) => {
-            const duration =
+            const durationMs =
               now.getTime() - (alert.firstSeenAt ?? now).getTime();
             await prisma.alert.updateMany({
               where: { fingerprint: alert.fingerprint, status: "ACTIVE" },
               data: {
                 status: "RESOLVED",
                 resolvedAt: now,
-                duration,
+                duration: BigInt(durationMs),
                 fingerprint: null, // Release partial unique index slot for re-firing
               },
             });
             logger.debug(
-              `Resolved alert: ${alert.fingerprint} (${Math.round(duration / 1000 / 60)} min)`
+              `Resolved alert: ${alert.fingerprint} (${Math.round(durationMs / 1000 / 60)} min)`
             );
           })
       );

--- a/apps/api/src/services/alerts/alert.service.ts
+++ b/apps/api/src/services/alerts/alert.service.ts
@@ -254,7 +254,7 @@ class AlertService {
       source: { type: string; name: string };
       firstSeenAt: string;
       resolvedAt: string;
-      duration: number | null;
+      duration: number | null; // BigInt from DB, converted to number for API
     }>;
     total: number;
   }> {
@@ -332,7 +332,7 @@ class AlertService {
           alert.resolvedAt
         ).toISOString(),
         resolvedAt: alert.resolvedAt!.toISOString(),
-        duration: alert.duration,
+        duration: alert.duration != null ? Number(alert.duration) : null,
       })),
       total,
     };

--- a/apps/api/src/trpc/routers/rabbitmq/queues.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/queues.ts
@@ -57,9 +57,9 @@ async function persistQueueData(
       const queueData = {
         name: queue.name,
         vhost: queue.vhost,
-        messages: queue.messages || 0,
-        messagesReady: queue.messages_ready || 0,
-        messagesUnack: queue.messages_unacknowledged || 0,
+        messages: BigInt(queue.messages || 0),
+        messagesReady: BigInt(queue.messages_ready || 0),
+        messagesUnack: BigInt(queue.messages_unacknowledged || 0),
         lastFetched: new Date(),
         serverId,
       };
@@ -79,9 +79,9 @@ async function persistQueueData(
       await tx.queueMetric.create({
         data: {
           queueId: upsertedQueue.id,
-          messages: queue.messages || 0,
-          messagesReady: queue.messages_ready || 0,
-          messagesUnack: queue.messages_unacknowledged || 0,
+          messages: BigInt(queue.messages || 0),
+          messagesReady: BigInt(queue.messages_ready || 0),
+          messagesUnack: BigInt(queue.messages_unacknowledged || 0),
           publishRate: queue.message_stats?.publish_details?.rate || 0,
           consumeRate: queue.message_stats?.deliver_details?.rate || 0,
         },
@@ -417,9 +417,9 @@ export const queuesRouter = router({
         const newQueueData = {
           name: name,
           vhost: server.vhost || "/", // Use server vhost or default
-          messages: 0, // New queue starts with 0 messages
-          messagesReady: 0,
-          messagesUnack: 0,
+          messages: 0n, // New queue starts with 0 messages
+          messagesReady: 0n,
+          messagesUnack: 0n,
           lastFetched: new Date(),
           serverId: serverId,
         };
@@ -443,9 +443,9 @@ export const queuesRouter = router({
           await prisma.queueMetric.create({
             data: {
               queueId: queueRecord.id,
-              messages: 0,
-              messagesReady: 0,
-              messagesUnack: 0,
+              messages: 0n,
+              messagesReady: 0n,
+              messagesUnack: 0n,
               publishRate: 0,
               consumeRate: 0,
             },


### PR DESCRIPTION
## Summary

- Migrates `Alert.duration`, `Queue.messages/messagesReady/messagesUnack`, and `QueueMetric.messages/messagesReady/messagesUnack` from `Int` to `BigInt` in Prisma schema
- Fixes production Prisma error: `value "6323986820" is out of range for type integer` — triggered when an alert stays active for >24.8 days (the 32-bit integer limit in milliseconds)
- Updates all read/write paths with `BigInt()` wrapping and `Number()` conversion for API responses
- Non-destructive migration — existing data is safely widened by PostgreSQL

## Test plan

- [x] Type-check passes across all workspaces
- [x] All 682 tests pass
- [x] Knip (unused code check) passes
- [ ] Deploy migration to staging and verify `prisma migrate deploy` succeeds
- [ ] Verify alert resolution works for long-lived alerts (>25 days)
- [ ] Verify queue data persistence works for high message counts


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential overflow issues with Alert duration values and Queue message counters that could cause data loss or inaccuracies in high-traffic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->