### PR TITLE
fix(web): resolve SEO audit issues from Screaming Frog crawl

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "/bin/zsh",
       "runtimeArgs": ["-c", "source ~/.nvm/nvm.sh && nvm use && pnpm run dev"],
       "port": 8080
+    },
+    {
+      "name": "web",
+      "runtimeExecutable": "/bin/zsh",
+      "runtimeArgs": ["-c", "source ~/.nvm/nvm.sh && nvm use && pnpm --filter @qarote/i18n build && pnpm --filter ./apps/web dev"],
+      "port": 4321
     }
   ]
 }

--- a/apps/web/public/locales/en/landing.json
+++ b/apps/web/public/locales/en/landing.json
@@ -117,6 +117,6 @@
   },
   "seo": {
     "title": "Qarote - RabbitMQ Monitoring Dashboard",
-    "description": "Monitor your RabbitMQ queues, track performance, and manage your message broker with Qarote. Free core monitoring with alerting, multi-server support, and team workspaces."
+    "description": "Monitor your RabbitMQ queues, track performance, and manage your message broker with Qarote. Free monitoring with alerting and multi-server support."
   }
 }

--- a/apps/web/public/locales/fr/landing.json
+++ b/apps/web/public/locales/fr/landing.json
@@ -117,6 +117,6 @@
   },
   "seo": {
     "title": "Qarote - Tableau de bord de monitoring RabbitMQ",
-    "description": "Surveillez vos files RabbitMQ, suivez les performances et gérez votre broker de messages avec Qarote. Monitoring gratuit avec alertes, support multi-serveurs et espaces de travail."
+    "description": "Surveillez vos files RabbitMQ, suivez les performances et gérez votre broker de messages avec Qarote. Monitoring gratuit avec alertes et support multi-serveurs."
   }
 }

--- a/apps/web/src/components/landing/ConnectionSection.tsx
+++ b/apps/web/src/components/landing/ConnectionSection.tsx
@@ -54,7 +54,10 @@ const ConnectionSection = () => {
                     >
                       <img
                         src="/images/email.svg"
-                        alt="Email"
+                        alt=""
+                        aria-hidden="true"
+                        width="14"
+                        height="14"
                         className="image-crisp w-auto h-3.5"
                       />
                       <span className="text-sm font-medium text-foreground">
@@ -80,7 +83,10 @@ const ConnectionSection = () => {
                     >
                       <img
                         src="/images/google.svg"
-                        alt="Google"
+                        alt=""
+                        aria-hidden="true"
+                        width="14"
+                        height="14"
                         className="image-crisp w-auto h-3.5"
                       />
                       <span className="text-sm font-medium text-foreground">
@@ -116,7 +122,10 @@ const ConnectionSection = () => {
                       <div className="flex-shrink-0">
                         <img
                           src="/images/server.svg"
-                          alt="Server"
+                          alt=""
+                          aria-hidden="true"
+                          width="24"
+                          height="24"
                           className="w-6 h-6 image-crisp"
                         />
                       </div>
@@ -133,7 +142,10 @@ const ConnectionSection = () => {
                       <div className="flex-shrink-0">
                         <img
                           src="/images/server.svg"
-                          alt="Server"
+                          alt=""
+                          aria-hidden="true"
+                          width="24"
+                          height="24"
                           className="w-6 h-6 image-crisp"
                         />
                       </div>
@@ -150,7 +162,10 @@ const ConnectionSection = () => {
                       <div className="flex-shrink-0">
                         <img
                           src="/images/server.svg"
-                          alt="Server"
+                          alt=""
+                          aria-hidden="true"
+                          width="24"
+                          height="24"
                           className="w-6 h-6 image-crisp"
                         />
                       </div>
@@ -234,6 +249,8 @@ const ConnectionSection = () => {
                             src="/images/check.svg"
                             alt=""
                             aria-hidden="true"
+                            width="11"
+                            height="11"
                             className="image-crisp w-auto h-[0.7rem]"
                           />
                           <span className="text-sm text-foreground">

--- a/apps/web/src/pages/[locale]/changelog.astro
+++ b/apps/web/src/pages/[locale]/changelog.astro
@@ -12,7 +12,7 @@ const resources = loadAllTranslations(locale);
 ---
 
 <BaseLayout
-  title={`${t(common, "changelog.title")} - Qarote`}
+  title={`${t(common, "changelog.title")} - Qarote RabbitMQ Dashboard`}
   description={t(common, "changelog.subtitle")}
   locale={locale}
   canonicalPath="/changelog/"

--- a/apps/web/src/pages/[locale]/privacy-policy.astro
+++ b/apps/web/src/pages/[locale]/privacy-policy.astro
@@ -9,7 +9,7 @@ export const getStaticPaths = getLocaleStaticPaths;
 const { locale } = Astro.params;
 const legal = loadTranslations(locale, "legal");
 const resources = loadAllTranslations(locale);
-const title = `${t(legal, "privacyPolicy.title")} - Qarote`;
+const title = `${t(legal, "privacyPolicy.title")} - Qarote RabbitMQ Monitoring`;
 const description = t(legal, "privacyPolicy.description");
 ---
 

--- a/apps/web/src/pages/[locale]/terms-of-service.astro
+++ b/apps/web/src/pages/[locale]/terms-of-service.astro
@@ -9,7 +9,7 @@ export const getStaticPaths = getLocaleStaticPaths;
 const { locale } = Astro.params;
 const legal = loadTranslations(locale, "legal");
 const resources = loadAllTranslations(locale);
-const title = `${t(legal, "termsOfService.title")} - Qarote`;
+const title = `${t(legal, "termsOfService.title")} - Qarote RabbitMQ Monitoring`;
 const description = t(legal, "termsOfService.description");
 ---
 

--- a/apps/web/src/pages/changelog.astro
+++ b/apps/web/src/pages/changelog.astro
@@ -7,7 +7,7 @@ const resources = loadAllTranslations("en");
 ---
 
 <BaseLayout
-  title="Changelog - Qarote"
+  title="Changelog - Qarote RabbitMQ Dashboard"
   description="See what's new in Qarote. Browse the latest features, improvements, and bug fixes."
   canonicalPath="/changelog/"
 >

--- a/apps/web/src/pages/privacy-policy.astro
+++ b/apps/web/src/pages/privacy-policy.astro
@@ -7,7 +7,7 @@ const resources = loadAllTranslations("en");
 ---
 
 <BaseLayout
-  title="Privacy Policy - Qarote"
+  title="Privacy Policy - Qarote RabbitMQ Monitoring"
   description="Privacy Policy for Qarote - Learn how we collect, use, and protect your data."
   canonicalPath="/privacy-policy/"
 >

--- a/apps/web/src/pages/terms-of-service.astro
+++ b/apps/web/src/pages/terms-of-service.astro
@@ -7,7 +7,7 @@ const resources = loadAllTranslations("en");
 ---
 
 <BaseLayout
-  title="Terms of Service - Qarote"
+  title="Terms of Service - Qarote RabbitMQ Monitoring"
   description="Terms of Service for Qarote - Learn about your rights and responsibilities when using our service."
   canonicalPath="/terms-of-service/"
 >


### PR DESCRIPTION
## Summary
- Lengthen page titles for changelog, privacy policy, and terms of service pages to exceed 30 characters (EN + FR locale pages)
- Shorten homepage meta description from 171 to 150 characters to stay under the 155-char SERP limit (EN + FR)
- Add missing `width`/`height` attributes to 6 decorative images in ConnectionSection to prevent CLS
- Fix decorative image alt text: changed from descriptive `alt` to `alt="" aria-hidden="true"` for email, Google, and server icons
- Add `web` dev server configuration to `.claude/launch.json`

## Test plan
- [x] `pnpm build` for web app passes
- [x] `astro check` type checks pass (0 errors)
- [x] Knip unused code check passes
- [x] Verified built HTML output has correct titles and meta descriptions
- [ ] Re-crawl with Screaming Frog after deployment to confirm issues resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined landing page search engine optimization descriptions in English and French to better reflect current product features
  * Updated website page titles to include comprehensive RabbitMQ monitoring product branding

* **Accessibility**
  * Enhanced screen reader compatibility by properly marking decorative elements as non-essential content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->