### PR TITLE
docs: restructure README and move dev content to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,9 @@ Want to contribute to this repository? Follow the development documentation belo
    pnpm run dev:app    # Frontend app (port 8080)
    ```
 
-### Project Structure
+### Architecture
+
+Qarote is built as a modern monorepo:
 
 ```
 qarote/
@@ -81,6 +83,47 @@ qarote/
 ├── docker/           # Docker configurations
 └── scripts/          # Utility scripts
 ```
+
+### Tech Stack
+
+- **Frontend**: React, TypeScript, Vite, Tailwind CSS
+- **Backend**: Node.js, Hono.js, tRPC, Prisma
+- **Database**: PostgreSQL
+- **Message Queue**: RabbitMQ
+- **Package Manager**: pnpm
+- **Monorepo**: Turborepo
+
+### Docker Development
+
+The repository includes Docker Compose configuration for a complete development environment.
+
+```bash
+# Start all services
+docker compose up -d
+
+# View logs
+docker compose logs -f
+
+# Stop services
+docker compose down
+```
+
+#### Services
+
+| Service             | Port  | Access                                    |
+| ------------------- | ----- | ----------------------------------------- |
+| PostgreSQL          | 5432  | `postgres:password@localhost:5432/qarote` |
+| RabbitMQ            | 5672  | `amqp://admin:admin123@localhost:5672`    |
+| RabbitMQ Management | 15672 | http://localhost:15672                    |
+
+#### Pre-configured Data
+
+The development environment includes:
+
+- **Users**: admin, guest, producer, consumer
+- **Virtual Hosts**: `/`, `/production`, `/staging`
+- **Exchanges**: notifications, events, analytics, alerts
+- **Queues**: Email, SMS, user events, order processing, analytics
 
 ### Making Changes
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 <div align="center">
 
-# 🥕 Qarote
+# Qarote
 
-**A modern, user-friendly dashboard for monitoring and managing RabbitMQ servers**
+**Open-source RabbitMQ monitoring dashboard. Free for one server, self-hosted, no credit card.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node.js](https://img.shields.io/badge/Node.js-24.x-green.svg)](https://nodejs.org/)
-[![pnpm](https://img.shields.io/badge/pnpm-9.0.0-orange.svg)](https://pnpm.io/)
-[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/getqarote/Qarote?utm_source=oss&utm_medium=github&utm_campaign=getqarote%2FQarote&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+[![GitHub Stars](https://img.shields.io/github/stars/getqarote/Qarote?style=flat)](https://github.com/getqarote/Qarote/stargazers)
 
-[Features](#-features) • [Editions](#-editions) • [Quick Start](#-quick-start) • [Documentation](#-documentation) • [Contributing](#-contributing)
+[Features](#features) · [Quick Start](#quick-start) · [Editions](#editions) · [Documentation](#documentation) · [Contributing](#contributing)
 
 [![Animated demo showing Qarote's dashboard monitoring RabbitMQ queues, exchanges, and system metrics](assets/demo.gif)](https://www.youtube.com/watch?v=g9Coi3niYIY)
 
@@ -17,40 +15,40 @@
 
 ---
 
-## ✨ Features
+## Why Qarote?
 
-- 🎯 **Real-time Monitoring** - Live visibility into queues, exchanges, connections, and system health
-- 📊 **Beautiful Dashboard** - Modern, intuitive interface built with React and TypeScript
-- 🔔 **Alerting System** - Get notified about queue depths, message rates, and system issues (Enterprise)
-- 👥 **Workspace Management** - Multi-user workspaces with role-based access control (Enterprise)
-- 🔌 **Integrations** - Slack, webhooks, and custom integrations (Enterprise)
-- 📤 **Data Export** - Export queue metrics and analytics (Enterprise)
-- 🚀 **Self-Hosted** - Deploy on your own infrastructure with Docker Compose or Dokku
-- 🔒 **Enterprise Security** - Offline license validation for air-gapped deployments
+- **Zero-config monitoring** — connect and see queues in seconds
+- **Free forever for one server** — MIT, no gates, no credit card
+- **Self-hosted by design** — Docker, Compose, Dokku, or binary; credentials never leave your network
+- **Enterprise-ready when you need it** — workspaces, alerting, SSO unlock with a license key
 
-## 🎭 Editions
+## Features
 
-Qarote is available in two editions. Every deployment starts with Community features — activate a license key in **Settings → License** to unlock Enterprise. No restart needed.
+- **Real-time Monitoring** — Live visibility into queues, exchanges, connections, and system health
+- **Beautiful Dashboard** — Modern, intuitive interface built with React and TypeScript
+- **Alerting System** — Get notified about queue depths, message rates, and system issues (Enterprise)
+- **Workspace Management** — Multi-user workspaces with role-based access control (Enterprise)
+- **Integrations** — Slack, webhooks, and custom integrations (Enterprise)
+- **Data Export** — Export queue metrics and analytics (Enterprise)
+- **Self-Hosted** — Deploy on your own infrastructure with Docker Compose or Dokku
+- **Enterprise Security** — Offline license validation for air-gapped deployments
 
-| | Community (Free) | Enterprise (Licensed) |
-|---|---|---|
-| Core monitoring (queues, exchanges, vhosts, users) | ✅ | ✅ |
-| Real-time metrics and charts | ✅ | ✅ |
-| Server management | ✅ | ✅ |
-| Workspace Management | - | ✅ |
-| Advanced Alerting (Slack/webhook) | - | ✅ |
-| Data Export (CSV/JSON) | - | ✅ |
-| Priority Support | - | ✅ |
+## Quick Start
 
-📖 **[Community Guide](docs/COMMUNITY_EDITION.md)** • **[Enterprise Guide](docs/ENTERPRISE_EDITION.md)** • **[Compare Features](docs/FEATURE_COMPARISON.md)** • **[🎟️ Get License](https://portal.qarote.io)**
+### Docker Compose (recommended)
 
-## 🚀 Quick Start
+```bash
+# 1. Clone the repository
+git clone https://github.com/getqarote/Qarote.git && cd Qarote
 
-All deployment methods work for both editions. Pick the one that fits your infrastructure:
+# 2. Generate .env with secure secrets
+./setup.sh
 
-### 📦 Binary (simplest — no Docker needed)
+# 3. Start services (PostgreSQL included)
+docker compose -f docker-compose.selfhosted.yml up -d
+```
 
-Download a single binary, run the setup wizard, and start. Only requires PostgreSQL.
+### Binary (no Docker needed)
 
 ```bash
 # 1. Download (auto-detects OS and architecture)
@@ -64,210 +62,65 @@ curl -L "https://github.com/getqarote/Qarote/releases/latest/download/qarote-${P
 ./qarote
 ```
 
-### 🐳 Docker Compose
+| Method | Guide |
+| --- | --- |
+| Dokku | [Deployment Guide — Dokku](docs/SELF_HOSTED_DEPLOYMENT.md#dokku) |
+| Docker Compose | [Deployment Guide — Docker Compose](docs/SELF_HOSTED_DEPLOYMENT.md#docker-compose) |
+| Binary | [Deployment Guide — Binary](docs/SELF_HOSTED_DEPLOYMENT.md#binary) |
 
-```bash
-# 1. Generate .env with secure secrets
-./setup.sh
+## Editions
 
-# 2. Start services (PostgreSQL included)
-docker compose -f docker-compose.selfhosted.yml up -d
-```
+Every deployment starts with Community features. Activate a license key in **Settings > License** to unlock Enterprise — no restart needed.
 
-### 🚢 Dokku
+| | Community (Free) | Enterprise (Licensed) |
+|---|---|---|
+| Core monitoring (queues, exchanges, vhosts, users) | ✅ | ✅ |
+| Real-time metrics and charts | ✅ | ✅ |
+| Server management | ✅ | ✅ |
+| Workspace Management | | ✅ |
+| Advanced Alerting (Slack/webhook) | | ✅ |
+| Data Export (CSV/JSON) | | ✅ |
+| Priority Support | | ✅ |
 
-```bash
-# 1. Create app and database
-ssh dokku@your-server apps:create qarote
-dokku postgres:create qarote-db && dokku postgres:link qarote-db qarote
+[Community Guide](docs/COMMUNITY_EDITION.md) · [Enterprise Guide](docs/ENTERPRISE_EDITION.md) · [Compare Features](docs/FEATURE_COMPARISON.md) · [Get License](https://portal.qarote.io)
 
-# 2. Set environment variables
-dokku config:set qarote JWT_SECRET=$(openssl rand -hex 64) ENCRYPTION_KEY=$(openssl rand -hex 64)
+## Documentation
 
-# 3. Deploy
-git remote add dokku dokku@your-server:qarote
-git push dokku main
-```
+[Documentation Hub](docs/README.md) · [Online Documentation](https://portal.qarote.io/documentation)
 
-📖 **[Complete Deployment Guide](docs/SELF_HOSTED_DEPLOYMENT.md)**
+## Community
 
-### 🛠️ Development Setup
+- [GitHub Discussions](https://github.com/getqarote/Qarote/discussions) — Ask questions and share ideas
+- [GitHub Issues](https://github.com/getqarote/Qarote/issues) — Report bugs and request features
+- Enterprise support: [support@qarote.io](mailto:support@qarote.io) · [Customer Portal](https://portal.qarote.io)
 
-1. **Clone the repository:**
+## Contributing
 
-   ```bash
-   git clone https://github.com/getqarote/Qarote.git
-   cd qarote
-   ```
+We welcome contributions! Fork the repo, create a branch, and open a pull request.
 
-2. **Install dependencies:**
+[Contributing Guide](CONTRIBUTING.md) · [Development Documentation](docs/README.md)
 
-   ```bash
-   pnpm install
-   ```
+## Security
 
-3. **Start local services (PostgreSQL, RabbitMQ):**
+**Please do not create public issues for security vulnerabilities.** Email **security@qarote.io** with a description, reproduction steps, and impact assessment.
 
-   ```bash
-   docker compose up -d
-   ```
+[Security Policy](SECURITY.md)
 
-4. **Run database migrations:**
+## License
 
-   ```bash
-   cd apps/api
-   pnpm run db:migrate:dev
-   ```
+- **Community Edition**: [MIT License](LICENSE) — free and open source
+- **Enterprise Edition**: Commercial License — see [Enterprise Guide](docs/ENTERPRISE_EDITION.md)
 
-5. **Start development servers:**
+## Star History
 
-   ```bash
-   # From project root
-   pnpm run dev
-
-   # Or start individual services:
-   pnpm run dev:api    # Backend API (port 3000)
-   pnpm run dev:app    # Frontend app (port 8080)
-   ```
-
-📖 **[Contributing Guide](CONTRIBUTING.md)** • **[Development Documentation](docs/README.md)**
-
-## 📚 Documentation
-
-<div align="center">
-
-**[📖 Documentation Hub](docs/README.md)** • **[🌐 Online Documentation](https://portal.qarote.io/documentation)**
-
-</div>
-
-## 🏗️ Architecture
-
-Qarote is built as a modern monorepo with the following structure:
-
-```
-qarote/
-├── 🎨 apps/
-│   ├── api/          # Backend API (Hono.js, tRPC, Prisma)
-│   ├── app/          # Main frontend application (React, Vite)
-│   ├── web/          # Landing page
-│   └── portal/       # Customer portal
-├── 📖 docs/          # Documentation
-├── 🐳 docker/        # Docker configurations
-└── 🔧 scripts/       # Utility scripts
-```
-
-### 🛠️ Tech Stack
-
-- **Frontend**: React, TypeScript, Vite, Tailwind CSS
-- **Backend**: Node.js, Hono.js, tRPC, Prisma
-- **Database**: PostgreSQL
-- **Message Queue**: RabbitMQ
-- **Package Manager**: pnpm
-- **Monorepo**: Turborepo
-
-## 🐳 Docker Development
-
-This repository includes Docker Compose configuration for a complete development environment.
-
-### 🚀 Quick Start
-
-```bash
-# Start all services
-docker compose up -d
-
-# View logs
-docker compose logs -f
-
-# Stop services
-docker compose down
-```
-
-### 📊 Services
-
-| Service                | Port  | Access                                    |
-| ---------------------- | ----- | ----------------------------------------- |
-| 🐘 PostgreSQL          | 5432  | `postgres:password@localhost:5432/qarote` |
-| 🐰 RabbitMQ            | 5672  | `amqp://admin:admin123@localhost:5672`    |
-| 🌐 RabbitMQ Management | 15672 | http://localhost:15672                    |
-
-### 📝 Pre-configured Data
-
-The development environment includes:
-
-- 👥 **Users**: admin, guest, producer, consumer
-- 📁 **Virtual Hosts**: `/`, `/production`, `/staging`
-- 📨 **Exchanges**: notifications, events, analytics, alerts
-- 📬 **Queues**: Email, SMS, user events, order processing, analytics
-
-📖 **[Full Development Setup Guide](CONTRIBUTING.md#development-setup)**
-
-## 🤝 Contributing
-
-We welcome contributions from the community! Here's how you can help:
-
-1. 🍴 **Fork the repository**
-2. 🌿 **Create a feature branch** (`git checkout -b feature/amazing-feature`)
-3. ✏️ **Make your changes** and test locally
-4. ✅ **Run linting and tests** (`pnpm run lint && pnpm run test`)
-5. 💾 **Commit your changes** (follow [Conventional Commits](https://www.conventionalcommits.org/))
-6. 📤 **Push to your branch** (`git push origin feature/amazing-feature`)
-7. 🔄 **Open a Pull Request**
-
-📖 **[Complete Contributing Guide](CONTRIBUTING.md)**
-
-### 🎯 Contribution Areas
-
-- 🐛 Bug fixes
-- ✨ New features (Community Edition)
-- 📝 Documentation improvements
-- 🧪 Test coverage
-- 🎨 UI/UX enhancements
-- 🌐 Translations
-
-## 🔒 Security
-
-**Please do not create public issues for security vulnerabilities.**
-
-Instead, email **security@qarote.io** with:
-
-- A detailed description of the vulnerability
-- Steps to reproduce (if applicable)
-- Potential impact
-- Suggested fix (if you have one)
-
-📖 **[Security Policy](SECURITY.md)**
-
-## 📞 Support
-
-### 💬 Community Support
-
-- **[GitHub Discussions](https://github.com/getqarote/Qarote/discussions)** - Ask questions and share ideas
-- **[GitHub Issues](https://github.com/getqarote/Qarote/issues)** - Report bugs and request features
-
-### 💼 Enterprise Support
-
-- **Email**: [support@qarote.io](mailto:support@qarote.io)
-- **Customer Portal**: [portal.qarote.io](https://portal.qarote.io)
-
-## 📄 License
-
-- **Community Edition**: [MIT License](LICENSE) - Free and open source
-- **Enterprise Edition**: Commercial License - See [Enterprise Edition Guide](docs/ENTERPRISE_EDITION.md)
-
-## 🌟 Star History
-
-<div align="center">
-
-If you find Qarote useful, please consider giving it a ⭐ on GitHub!
-
-</div>
+[![Star History Chart](https://api.star-history.com/svg?repos=getqarote/Qarote&type=Date)](https://star-history.com/#getqarote/Qarote&Date)
 
 ---
 
 <div align="center">
 
-**Made with ❤️ by [La Griffe](https://github.com/LaGriffe)**
+Built by the [Qarote team](https://qarote.io/about/)
 
-[Website](https://qarote.io) • [Documentation](docs/README.md) • [Contributing](CONTRIBUTING.md) • [Security](SECURITY.md)
+[Website](https://qarote.io) · [Features](https://qarote.io/features/) · [Documentation](docs/README.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 [![Animated demo showing Qarote's dashboard monitoring RabbitMQ queues, exchanges, and system metrics](assets/demo.gif)](https://www.youtube.com/watch?v=g9Coi3niYIY)
 
+**[Try the Live Demo →](https://demo.qarote.io/)**
+*Read-only instance — no login required*
+
 </div>
 
 ---

--- a/apps/web/public/locales/en/landing.json
+++ b/apps/web/public/locales/en/landing.json
@@ -12,7 +12,9 @@
     "startMonitoringForFree": "Start monitoring for free",
     "selfHostedSolution": "Self-Hosted Solution",
     "contactUs": "Contact us",
-    "tryLiveDemo": "or try the live demo",
+    "tryLiveDemo": "Try the live demo",
+    "seeItInAction": "See it in action —",
+    "tryTheLiveDemo": "try the live demo",
     "opensInNewTab": "(opens in new tab)"
   },
   "comparison": {

--- a/apps/web/public/locales/en/landing.json
+++ b/apps/web/public/locales/en/landing.json
@@ -12,7 +12,8 @@
     "startMonitoringForFree": "Start monitoring for free",
     "selfHostedSolution": "Self-Hosted Solution",
     "contactUs": "Contact us",
-    "tryLiveDemo": "or try the live demo"
+    "tryLiveDemo": "or try the live demo",
+    "opensInNewTab": "(opens in new tab)"
   },
   "comparison": {
     "title": "Managing RabbitMQ servers",

--- a/apps/web/public/locales/en/landing.json
+++ b/apps/web/public/locales/en/landing.json
@@ -11,7 +11,8 @@
     "howItWorks": "How it works",
     "startMonitoringForFree": "Start monitoring for free",
     "selfHostedSolution": "Self-Hosted Solution",
-    "contactUs": "Contact us"
+    "contactUs": "Contact us",
+    "tryLiveDemo": "or try the live demo"
   },
   "comparison": {
     "title": "Managing RabbitMQ servers",

--- a/apps/web/public/locales/en/nav.json
+++ b/apps/web/public/locales/en/nav.json
@@ -6,5 +6,6 @@
   "tryForFree": "Try for free",
   "whatsNew": "Changelog",
   "liveDemo": "Live Demo",
+  "opensInNewTab": "(opens in new tab)",
   "openMenu": "Open menu"
 }

--- a/apps/web/public/locales/en/nav.json
+++ b/apps/web/public/locales/en/nav.json
@@ -5,5 +5,6 @@
   "login": "Login",
   "tryForFree": "Try for free",
   "whatsNew": "Changelog",
+  "liveDemo": "Live Demo",
   "openMenu": "Open menu"
 }

--- a/apps/web/public/locales/es/landing.json
+++ b/apps/web/public/locales/es/landing.json
@@ -12,7 +12,8 @@
     "startMonitoringForFree": "Comienza a monitorear gratis",
     "selfHostedSolution": "Solución autoalojada",
     "contactUs": "Contáctanos",
-    "tryLiveDemo": "o prueba la demo en vivo"
+    "tryLiveDemo": "o prueba la demo en vivo",
+    "opensInNewTab": "(se abre en una pestaña nueva)"
   },
   "comparison": {
     "title": "Gestionar servidores RabbitMQ",

--- a/apps/web/public/locales/es/landing.json
+++ b/apps/web/public/locales/es/landing.json
@@ -11,7 +11,8 @@
     "howItWorks": "Cómo funciona",
     "startMonitoringForFree": "Comienza a monitorear gratis",
     "selfHostedSolution": "Solución autoalojada",
-    "contactUs": "Contáctanos"
+    "contactUs": "Contáctanos",
+    "tryLiveDemo": "o prueba la demo en vivo"
   },
   "comparison": {
     "title": "Gestionar servidores RabbitMQ",

--- a/apps/web/public/locales/es/landing.json
+++ b/apps/web/public/locales/es/landing.json
@@ -12,7 +12,9 @@
     "startMonitoringForFree": "Comienza a monitorear gratis",
     "selfHostedSolution": "Solución autoalojada",
     "contactUs": "Contáctanos",
-    "tryLiveDemo": "o prueba la demo en vivo",
+    "tryLiveDemo": "Prueba la demo en vivo",
+    "seeItInAction": "Descúbrelo en acción —",
+    "tryTheLiveDemo": "prueba la demo en vivo",
     "opensInNewTab": "(se abre en una pestaña nueva)"
   },
   "comparison": {

--- a/apps/web/public/locales/es/nav.json
+++ b/apps/web/public/locales/es/nav.json
@@ -6,5 +6,6 @@
   "tryForFree": "Probar gratis",
   "whatsNew": "Changelog",
   "liveDemo": "Demo en vivo",
+  "opensInNewTab": "(se abre en una pestaña nueva)",
   "openMenu": "Abrir menú"
 }

--- a/apps/web/public/locales/es/nav.json
+++ b/apps/web/public/locales/es/nav.json
@@ -5,5 +5,6 @@
   "login": "Iniciar sesión",
   "tryForFree": "Probar gratis",
   "whatsNew": "Changelog",
+  "liveDemo": "Demo en vivo",
   "openMenu": "Abrir menú"
 }

--- a/apps/web/public/locales/fr/landing.json
+++ b/apps/web/public/locales/fr/landing.json
@@ -12,7 +12,8 @@
     "startMonitoringForFree": "Commencer le monitoring gratuitement",
     "selfHostedSolution": "Solution auto-hébergée",
     "contactUs": "Nous contacter",
-    "tryLiveDemo": "ou essayer la démo en ligne"
+    "tryLiveDemo": "ou essayer la démo en ligne",
+    "opensInNewTab": "(s'ouvre dans un nouvel onglet)"
   },
   "comparison": {
     "title": "Gérer des serveurs RabbitMQ",

--- a/apps/web/public/locales/fr/landing.json
+++ b/apps/web/public/locales/fr/landing.json
@@ -12,7 +12,9 @@
     "startMonitoringForFree": "Commencer le monitoring gratuitement",
     "selfHostedSolution": "Solution auto-hébergée",
     "contactUs": "Nous contacter",
-    "tryLiveDemo": "ou essayer la démo en ligne",
+    "tryLiveDemo": "Essayer la démo en ligne",
+    "seeItInAction": "Voyez par vous-même —",
+    "tryTheLiveDemo": "essayez la démo en ligne",
     "opensInNewTab": "(s'ouvre dans un nouvel onglet)"
   },
   "comparison": {

--- a/apps/web/public/locales/fr/landing.json
+++ b/apps/web/public/locales/fr/landing.json
@@ -11,7 +11,8 @@
     "howItWorks": "Comment ça marche",
     "startMonitoringForFree": "Commencer le monitoring gratuitement",
     "selfHostedSolution": "Solution auto-hébergée",
-    "contactUs": "Nous contacter"
+    "contactUs": "Nous contacter",
+    "tryLiveDemo": "ou essayer la démo en ligne"
   },
   "comparison": {
     "title": "Gérer des serveurs RabbitMQ",

--- a/apps/web/public/locales/fr/nav.json
+++ b/apps/web/public/locales/fr/nav.json
@@ -6,5 +6,6 @@
   "tryForFree": "Démarrer",
   "whatsNew": "Changelog",
   "liveDemo": "Démo en ligne",
+  "opensInNewTab": "(s'ouvre dans un nouvel onglet)",
   "openMenu": "Ouvrir le menu"
 }

--- a/apps/web/public/locales/fr/nav.json
+++ b/apps/web/public/locales/fr/nav.json
@@ -5,5 +5,6 @@
   "login": "Connexion",
   "tryForFree": "Démarrer",
   "whatsNew": "Changelog",
+  "liveDemo": "Démo en ligne",
   "openMenu": "Ouvrir le menu"
 }

--- a/apps/web/public/locales/zh/landing.json
+++ b/apps/web/public/locales/zh/landing.json
@@ -12,7 +12,9 @@
     "startMonitoringForFree": "免费开始监控",
     "selfHostedSolution": "私有化部署方案",
     "contactUs": "联系我们",
-    "tryLiveDemo": "或体验在线演示",
+    "tryLiveDemo": "体验在线演示",
+    "seeItInAction": "亲自体验 —",
+    "tryTheLiveDemo": "试试在线演示",
     "opensInNewTab": "（在新标签页中打开）"
   },
   "comparison": {

--- a/apps/web/public/locales/zh/landing.json
+++ b/apps/web/public/locales/zh/landing.json
@@ -12,7 +12,8 @@
     "startMonitoringForFree": "免费开始监控",
     "selfHostedSolution": "私有化部署方案",
     "contactUs": "联系我们",
-    "tryLiveDemo": "或体验在线演示"
+    "tryLiveDemo": "或体验在线演示",
+    "opensInNewTab": "（在新标签页中打开）"
   },
   "comparison": {
     "title": "管理 RabbitMQ 服务器",

--- a/apps/web/public/locales/zh/landing.json
+++ b/apps/web/public/locales/zh/landing.json
@@ -11,7 +11,8 @@
     "howItWorks": "工作原理",
     "startMonitoringForFree": "免费开始监控",
     "selfHostedSolution": "私有化部署方案",
-    "contactUs": "联系我们"
+    "contactUs": "联系我们",
+    "tryLiveDemo": "或体验在线演示"
   },
   "comparison": {
     "title": "管理 RabbitMQ 服务器",

--- a/apps/web/public/locales/zh/nav.json
+++ b/apps/web/public/locales/zh/nav.json
@@ -6,5 +6,6 @@
   "tryForFree": "免费试用",
   "whatsNew": "Changelog",
   "liveDemo": "在线演示",
+  "opensInNewTab": "（在新标签页中打开）",
   "openMenu": "打开菜单"
 }

--- a/apps/web/public/locales/zh/nav.json
+++ b/apps/web/public/locales/zh/nav.json
@@ -5,5 +5,6 @@
   "login": "登录",
   "tryForFree": "免费试用",
   "whatsNew": "Changelog",
+  "liveDemo": "在线演示",
   "openMenu": "打开菜单"
 }

--- a/apps/web/src/components/StickyNav.tsx
+++ b/apps/web/src/components/StickyNav.tsx
@@ -86,6 +86,14 @@ const StickyNav = () => {
             >
               {t("whatsNew", "What's New")}
             </a>
+            <a
+              href="https://demo.qarote.io/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-4 py-2 text-base font-medium text-primary hover:text-primary/80 transition-colors"
+            >
+              {t("liveDemo", "Live Demo")}
+            </a>
           </div>
 
           <div className="flex items-center justify-end gap-1 sm:gap-2">
@@ -174,6 +182,14 @@ const StickyNav = () => {
               className="px-4 py-3 text-base font-medium text-foreground hover:text-primary hover:bg-muted rounded-md transition-colors"
             >
               {t("whatsNew", "What's New")}
+            </a>
+            <a
+              href="https://demo.qarote.io/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-4 py-3 text-base font-medium text-primary hover:text-primary/80 hover:bg-muted rounded-md transition-colors"
+            >
+              {t("liveDemo", "Live Demo")}
             </a>
             <div className="border-t border-border my-2" />
             <a

--- a/apps/web/src/components/StickyNav.tsx
+++ b/apps/web/src/components/StickyNav.tsx
@@ -92,8 +92,8 @@ const StickyNav = () => {
               rel="noopener noreferrer"
               className="px-4 py-2 text-base font-medium text-primary hover:text-primary/80 transition-colors"
             >
-              {t("liveDemo", "Live Demo")}
-              <span className="sr-only">(opens in new tab)</span>
+              {t("liveDemo", "Live Demo")}{" "}
+              <span className="sr-only">{t("opensInNewTab")}</span>
             </a>
           </div>
 
@@ -190,8 +190,8 @@ const StickyNav = () => {
               rel="noopener noreferrer"
               className="px-4 py-3 text-base font-medium text-primary hover:text-primary/80 hover:bg-muted rounded-md transition-colors"
             >
-              {t("liveDemo", "Live Demo")}
-              <span className="sr-only">(opens in new tab)</span>
+              {t("liveDemo", "Live Demo")}{" "}
+              <span className="sr-only">{t("opensInNewTab")}</span>
             </a>
             <div className="border-t border-border my-2" />
             <a

--- a/apps/web/src/components/StickyNav.tsx
+++ b/apps/web/src/components/StickyNav.tsx
@@ -93,6 +93,7 @@ const StickyNav = () => {
               className="px-4 py-2 text-base font-medium text-primary hover:text-primary/80 transition-colors"
             >
               {t("liveDemo", "Live Demo")}
+              <span className="sr-only">(opens in new tab)</span>
             </a>
           </div>
 
@@ -190,6 +191,7 @@ const StickyNav = () => {
               className="px-4 py-3 text-base font-medium text-primary hover:text-primary/80 hover:bg-muted rounded-md transition-colors"
             >
               {t("liveDemo", "Live Demo")}
+              <span className="sr-only">(opens in new tab)</span>
             </a>
             <div className="border-t border-border my-2" />
             <a

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -50,8 +50,8 @@ const HeroSection = () => {
                 rel="noopener noreferrer"
                 className="text-primary hover:text-primary/80 underline underline-offset-2 transition-colors"
               >
-                {t("cta.tryLiveDemo")}
-                <span className="sr-only">(opens in new tab)</span>
+                {t("cta.tryLiveDemo")}{" "}
+                <span className="sr-only">{t("cta.opensInNewTab")}</span>
               </a>
             </p>
           </div>

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { ExternalLink } from "lucide-react";
+
 import AuthButtons from "@/components/AuthButtons";
 
 const HeroSection = () => {
@@ -40,19 +42,23 @@ const HeroSection = () => {
 
           <div className="mb-12">
             <AuthButtons />
-            <p className="text-xs sm:text-sm text-muted-foreground mt-3 px-4">
-              {t("hero.noCreditCard")}
-            </p>
-            <p className="text-xs sm:text-sm text-muted-foreground mt-2 px-4">
+            <div className="flex justify-center mt-3 px-4">
               <a
                 href="https://demo.qarote.io/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-primary hover:text-primary/80 underline underline-offset-2 transition-colors"
+                className="border border-border text-foreground hover:bg-muted px-4 py-3 sm:px-7 sm:py-3 text-base sm:text-lg rounded-full inline-flex items-center justify-center gap-2 transition-colors duration-200"
               >
-                {t("cta.tryLiveDemo")}{" "}
+                {t("cta.tryLiveDemo")}
+                <ExternalLink
+                  className="h-4 w-4 opacity-60"
+                  aria-hidden="true"
+                />
                 <span className="sr-only">{t("cta.opensInNewTab")}</span>
               </a>
+            </div>
+            <p className="text-xs sm:text-sm text-muted-foreground mt-3 px-4">
+              {t("hero.noCreditCard")}
             </p>
           </div>
         </div>
@@ -106,6 +112,19 @@ const HeroSection = () => {
             </div>
           )}
         </div>
+        <p className="text-center text-sm sm:text-base text-muted-foreground mt-6">
+          {t("cta.seeItInAction")}{" "}
+          <a
+            href="https://demo.qarote.io/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:text-primary/80 font-medium underline underline-offset-4 decoration-primary/30 hover:decoration-primary/60 transition-colors inline-flex items-center gap-1"
+          >
+            {t("cta.tryTheLiveDemo")}
+            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+            <span className="sr-only">{t("cta.opensInNewTab")}</span>
+          </a>
+        </p>
       </div>
     </header>
   );

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -51,6 +51,7 @@ const HeroSection = () => {
                 className="text-primary hover:text-primary/80 underline underline-offset-2 transition-colors"
               >
                 {t("cta.tryLiveDemo")}
+                <span className="sr-only">(opens in new tab)</span>
               </a>
             </p>
           </div>

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -43,6 +43,16 @@ const HeroSection = () => {
             <p className="text-xs sm:text-sm text-muted-foreground mt-3 px-4">
               {t("hero.noCreditCard")}
             </p>
+            <p className="text-xs sm:text-sm text-muted-foreground mt-2 px-4">
+              <a
+                href="https://demo.qarote.io/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:text-primary/80 underline underline-offset-2 transition-colors"
+              >
+                {t("cta.tryLiveDemo")}
+              </a>
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Restructured README with new tagline, "Why Qarote?" value-prop section, Docker Compose as primary quick start, emoji-free headers, real Star History chart, and consolidated footer
- Moved Architecture, Tech Stack, Docker Development, Services table, and Pre-configured Data sections to CONTRIBUTING.md where they belong
- Replaced badges: removed Node.js/pnpm/CodeRabbit, added GitHub Stars

## Test plan

- [ ] Verify README renders correctly on GitHub (headers, badges, links, demo GIF, Star History chart)
- [ ] Verify CONTRIBUTING.md renders correctly with new Architecture/Docker sections
- [ ] Confirm all internal links resolve (docs/, SECURITY.md, CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed “Project Structure” to “Architecture”; expanded contribution guide with tech stack, Docker development steps, services table, and pre-configured data; streamlined README and updated branding and quick-start content.
* **New Features**
  * Added a prominent "Try the Live Demo" CTA on the landing hero and a "Live Demo" navigation link that opens the demo in a new tab.
* **Localization**
  * Added/updated English, Spanish, French, and Chinese translations for the new live-demo CTA and nav labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->