### PR TITLE
feat(web): simplify landing CTAs and consolidate to Button component

### DIFF
--- a/apps/web/src/components/AuthButtons.tsx
+++ b/apps/web/src/components/AuthButtons.tsx
@@ -6,9 +6,10 @@ import { Button } from "@/components/ui/button";
 
 interface AuthButtonsProps {
   align?: "left" | "center" | "right";
+  describedById?: string;
 }
 
-const AuthButtons = ({ align = "center" }: AuthButtonsProps) => {
+const AuthButtons = ({ align = "center", describedById }: AuthButtonsProps) => {
   const { t } = useTranslation("landing");
   const authBaseUrl = import.meta.env.VITE_APP_BASE_URL || "";
 
@@ -40,7 +41,7 @@ const AuthButtons = ({ align = "center" }: AuthButtonsProps) => {
         variant="gradient"
         size="pill"
         onClick={handleSignUp}
-        aria-describedby="hero-no-credit-card"
+        aria-describedby={describedById}
         className="w-full sm:w-auto"
       >
         <span className="whitespace-nowrap">{t("cta.getStartedForFree")}</span>

--- a/apps/web/src/components/AuthButtons.tsx
+++ b/apps/web/src/components/AuthButtons.tsx
@@ -2,6 +2,8 @@ import { useTranslation } from "react-i18next";
 
 import { trackSignUpClick } from "@/lib/gtm";
 
+import { Button } from "@/components/ui/button";
+
 interface AuthButtonsProps {
   align?: "left" | "center" | "right";
 }
@@ -18,9 +20,6 @@ const AuthButtons = ({ align = "center" }: AuthButtonsProps) => {
     window.location.href = `${authBaseUrl}/auth/sign-up`;
   };
 
-  const primaryButtonStyles =
-    "bg-gradient-button hover:bg-gradient-button-hover text-white";
-
   const alignClass =
     align === "left"
       ? "justify-start"
@@ -36,10 +35,13 @@ const AuthButtons = ({ align = "center" }: AuthButtonsProps) => {
     <div
       className={`flex ${alignClass} items-center gap-6 ${widthClass} ${marginClass} ${paddingClass}`}
     >
-      <button
+      <Button
         type="button"
+        variant="gradient"
+        size="pill"
         onClick={handleSignUp}
-        className={`${primaryButtonStyles} px-4 py-3 sm:px-7 sm:py-3 transition-colors duration-200 flex items-center justify-center gap-3 text-base sm:text-lg w-full sm:w-auto rounded-full`}
+        aria-describedby="hero-no-credit-card"
+        className="w-full sm:w-auto"
       >
         <span className="whitespace-nowrap">{t("cta.getStartedForFree")}</span>
         <img
@@ -50,7 +52,7 @@ const AuthButtons = ({ align = "center" }: AuthButtonsProps) => {
           height={13}
           className="h-[0.8em] w-auto align-middle image-crisp"
         />
-      </button>
+      </Button>
     </div>
   );
 };

--- a/apps/web/src/components/StickyNav.tsx
+++ b/apps/web/src/components/StickyNav.tsx
@@ -6,6 +6,7 @@ import { Menu } from "lucide-react";
 import { trackSignUpClick } from "@/lib/gtm";
 
 import { GithubStarBadge } from "@/components/GithubStarBadge";
+import { Button } from "@/components/ui/button";
 import {
   Sheet,
   SheetContent,
@@ -86,15 +87,6 @@ const StickyNav = () => {
             >
               {t("whatsNew", "What's New")}
             </a>
-            <a
-              href="https://demo.qarote.io/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="px-4 py-2 text-base font-medium text-primary hover:text-primary/80 transition-colors"
-            >
-              {t("liveDemo", "Live Demo")}{" "}
-              <span className="sr-only">{t("opensInNewTab")}</span>
-            </a>
           </div>
 
           <div className="flex items-center justify-end gap-1 sm:gap-2">
@@ -107,8 +99,10 @@ const StickyNav = () => {
             >
               {t("login")}
             </a>
-            <button
+            <Button
               type="button"
+              variant="gradient"
+              size="pillSm"
               onClick={() => {
                 trackSignUpClick({
                   source: "sticky_nav",
@@ -116,7 +110,7 @@ const StickyNav = () => {
                 });
                 window.location.href = `${authBaseUrl}/auth/sign-up`;
               }}
-              className="hidden lg:inline-flex bg-gradient-button hover:bg-gradient-button-hover text-white px-2 sm:px-4 py-2 text-sm sm:text-base transition-colors whitespace-nowrap rounded-full items-center justify-center gap-2"
+              className="hidden lg:inline-flex"
             >
               <span>{t("tryForFree")}</span>
               <img
@@ -127,7 +121,7 @@ const StickyNav = () => {
                 height={13}
                 className="h-[0.8em] w-auto align-middle image-crisp"
               />
-            </button>
+            </Button>
             <button
               type="button"
               onClick={() => setOpen(true)}
@@ -184,15 +178,6 @@ const StickyNav = () => {
             >
               {t("whatsNew", "What's New")}
             </a>
-            <a
-              href="https://demo.qarote.io/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="px-4 py-3 text-base font-medium text-primary hover:text-primary/80 hover:bg-muted rounded-md transition-colors"
-            >
-              {t("liveDemo", "Live Demo")}{" "}
-              <span className="sr-only">{t("opensInNewTab")}</span>
-            </a>
             <div className="border-t border-border my-2" />
             <a
               href={`${authBaseUrl}/auth/sign-in`}
@@ -200,8 +185,10 @@ const StickyNav = () => {
             >
               {t("login")}
             </a>
-            <button
+            <Button
               type="button"
+              variant="gradient"
+              size="pillMd"
               onClick={() => {
                 trackSignUpClick({
                   source: "mobile_nav",
@@ -209,7 +196,7 @@ const StickyNav = () => {
                 });
                 window.location.href = `${authBaseUrl}/auth/sign-up`;
               }}
-              className="mx-4 mt-2 bg-gradient-button hover:bg-gradient-button-hover text-white px-4 py-3 text-base transition-colors whitespace-nowrap rounded-full inline-flex items-center justify-center gap-2"
+              className="mx-4 mt-2"
             >
               <span>{t("tryForFree")}</span>
               <img
@@ -220,7 +207,7 @@ const StickyNav = () => {
                 height={13}
                 className="h-[0.8em] w-auto align-middle image-crisp"
               />
-            </button>
+            </Button>
           </nav>
         </SheetContent>
       </Sheet>

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -42,7 +42,7 @@ const HeroSection = () => {
           </p>
 
           <div className="mb-12">
-            <AuthButtons />
+            <AuthButtons describedById="hero-no-credit-card" />
             <p
               id="hero-no-credit-card"
               className="text-xs sm:text-sm text-muted-foreground mt-3 px-4"

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { ExternalLink } from "lucide-react";
 
 import AuthButtons from "@/components/AuthButtons";
+import { Button } from "@/components/ui/button";
 
 const HeroSection = () => {
   const { t } = useTranslation("landing");
@@ -42,24 +43,28 @@ const HeroSection = () => {
 
           <div className="mb-12">
             <AuthButtons />
-            <div className="flex justify-center mt-3 px-4">
-              <a
-                href="https://demo.qarote.io/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="border border-border text-foreground hover:bg-muted px-4 py-3 sm:px-7 sm:py-3 text-base sm:text-lg rounded-full inline-flex items-center justify-center gap-2 transition-colors duration-200"
-              >
-                {t("cta.tryLiveDemo")}
-                <ExternalLink
-                  className="h-4 w-4 opacity-60"
-                  aria-hidden="true"
-                />
-                <span className="sr-only">{t("cta.opensInNewTab")}</span>
-              </a>
-            </div>
-            <p className="text-xs sm:text-sm text-muted-foreground mt-3 px-4">
+            <p
+              id="hero-no-credit-card"
+              className="text-xs sm:text-sm text-muted-foreground mt-3 px-4"
+            >
               {t("hero.noCreditCard")}
             </p>
+            <div className="flex justify-center mt-5 px-4">
+              <Button asChild variant="pillGhost" size="pillMd">
+                <a
+                  href="https://demo.qarote.io/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t("cta.tryLiveDemo")}
+                  <ExternalLink
+                    className="h-4 w-4 opacity-70"
+                    aria-hidden="true"
+                  />
+                  <span className="sr-only">{t("cta.opensInNewTab")}</span>
+                </a>
+              </Button>
+            </div>
           </div>
         </div>
       </div>
@@ -112,19 +117,6 @@ const HeroSection = () => {
             </div>
           )}
         </div>
-        <p className="text-center text-sm sm:text-base text-muted-foreground mt-6">
-          {t("cta.seeItInAction")}{" "}
-          <a
-            href="https://demo.qarote.io/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-primary hover:text-primary/80 font-medium underline underline-offset-4 decoration-primary/30 hover:decoration-primary/60 transition-colors inline-flex items-center gap-1"
-          >
-            {t("cta.tryTheLiveDemo")}
-            <ExternalLink className="h-3 w-3" aria-hidden="true" />
-            <span className="sr-only">{t("cta.opensInNewTab")}</span>
-          </a>
-        </p>
       </div>
     </header>
   );

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -6,25 +6,35 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "rounded-md bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "rounded-md hover:bg-accent hover:text-accent-foreground",
+        link: "rounded-md text-primary underline-offset-4 hover:underline",
+        // Landing-page pill variants — used for primary CTAs + demoted secondaries
+        gradient:
+          "rounded-full bg-gradient-button hover:bg-gradient-button-hover text-white",
+        pillGhost:
+          "rounded-full border border-primary/30 bg-transparent text-primary hover:bg-primary/5 hover:border-primary/50",
       },
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-9 px-3",
         lg: "h-11 px-8",
         icon: "h-10 w-10",
+        // Pill sizes — no fixed height, use with gradient/pillGhost variants
+        pill: "px-4 py-3 sm:px-7 sm:py-3 text-base sm:text-lg",
+        pillMd: "px-4 py-2.5 sm:px-6 sm:py-2.5 text-sm sm:text-base",
+        pillSm: "px-4 py-2 text-sm sm:text-base",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

Reduces CTA decision fatigue on the landing page and consolidates hand-rolled pill buttons into a shared `Button` component. Based on parallel UX + UI agent reviews.

### The problem
5 CTAs above the fold pointing at only 2 destinations, with 3 redundant demo links within ~600px of scroll. The "secondary" demo button was the same size as the primary signup — and since the demo is the lower-friction path, it cannibalized signups. Every pill button was also hand-rolled with duplicated Tailwind classes.

### Changes

**P0 — CTA reduction (3 demo links → 1)**
- Delete "Live Demo" nav link (desktop + mobile `StickyNav.tsx`)
- Delete "See it in action — try the live demo" paragraph under the video (`HeroSection.tsx`)
- Demote hero demo button from co-equal outlined pill to tinted `pillGhost` variant (`HeroSection.tsx`)
- Reorder: no-credit-card microcopy now sits directly under primary signup; demo link below

**P1 — Button component consolidation**
- Add `gradient` variant (primary signup) and `pillGhost` variant (demoted secondary) to `button.tsx`
- Add `pill`/`pillMd`/`pillSm` sizes for landing-page buttons (no fixed height, rounded-full from variant)
- Refactor `AuthButtons.tsx`, `StickyNav.tsx` (desktop + mobile), `HeroSection.tsx` to use `<Button>` instead of duplicated inline classes
- Added `aria-describedby="hero-no-credit-card"` on the primary signup button so screen readers associate the microcopy with the CTA

### Before / After

| Surface | Before | After |
|---|---|---|
| Sticky nav | "Live Demo" + "Try for free" | "Try for free" only |
| Hero | 2 equal pills (signup + demo) + no-cc text | Primary signup → no-cc text → demoted `pillGhost` demo |
| Under video | "See it in action — try the live demo" link | Removed |

Net: 5 hero-area CTAs collapsed to 2 visually distinct ones. Demo still discoverable from 2 surfaces but never competing head-to-head with signup.

### Files changed
- `apps/web/src/components/ui/button.tsx` — new variants + sizes
- `apps/web/src/components/AuthButtons.tsx` — use `<Button variant="gradient" size="pill">`
- `apps/web/src/components/StickyNav.tsx` — remove Live Demo links, refactor Try for free to `<Button>`
- `apps/web/src/components/landing/HeroSection.tsx` — demote demo button to `pillGhost`, remove "See it in action" paragraph

## Test plan

- [ ] Desktop hero: verify primary gradient button is dominant, demoted demo button sits below "no credit card" line
- [ ] Desktop nav: only "Try for free" button visible (no "Live Demo")
- [ ] Mobile nav drawer: "Live Demo" link removed, "Try for free" still works
- [ ] Hover states on both hero CTAs match existing behavior
- [ ] Under-video area: no orphaned "See it in action" paragraph
- [ ] Type-check + lint pass (`pnpm --filter qarote-web type-check && pnpm --filter qarote-web lint`)
- [ ] Visual QA on mobile viewport (320px, 375px, 768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated authentication, navigation, and CTA buttons to use new gradient and pill-shaped styles; refined call-to-action visuals.
* **Refactor**
  * Consolidated button usage across hero, sticky nav, and mobile sheet to a shared Button component for consistent look and behavior.
* **UX**
  * Added descriptive text for hero signup and removed separate external "live demo" links for a cleaner experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->