### PR TITLE
feat(web): MDX documentation system with security and spy-on-queues pages

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -7,7 +7,13 @@ export default defineConfig({
   site: "https://qarote.io",
   output: "static",
   server: { port: 8082 },
-  integrations: [react(), mdx(), sitemap()],
+  integrations: [
+    react(),
+    mdx({
+      shikiConfig: { theme: "min-light" },
+    }),
+    sitemap(),
+  ],
   i18n: {
     defaultLocale: "en",
     locales: ["en", "fr", "es", "zh"],

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -1,3 +1,4 @@
+import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import { defineConfig } from "astro/config";
@@ -6,7 +7,7 @@ export default defineConfig({
   site: "https://qarote.io",
   output: "static",
   server: { port: 8082 },
-  integrations: [react(), sitemap()],
+  integrations: [react(), mdx(), sitemap()],
   i18n: {
     defaultLocale: "en",
     locales: ["en", "fr", "es", "zh"],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@astrojs/mdx": "^4.3.14",
     "@astrojs/react": "^5.0.2",
     "@astrojs/sitemap": "^3.7.2",
     "@qarote/i18n": "workspace:*",

--- a/apps/web/public/locales/en/nav.json
+++ b/apps/web/public/locales/en/nav.json
@@ -7,5 +7,6 @@
   "whatsNew": "Changelog",
   "liveDemo": "Live Demo",
   "opensInNewTab": "(opens in new tab)",
-  "openMenu": "Open menu"
+  "openMenu": "Open menu",
+  "docs": "Docs"
 }

--- a/apps/web/public/locales/es/nav.json
+++ b/apps/web/public/locales/es/nav.json
@@ -7,5 +7,6 @@
   "whatsNew": "Changelog",
   "liveDemo": "Demo en vivo",
   "opensInNewTab": "(se abre en una pestaña nueva)",
-  "openMenu": "Abrir menú"
+  "openMenu": "Abrir menú",
+  "docs": "Documentación"
 }

--- a/apps/web/public/locales/fr/nav.json
+++ b/apps/web/public/locales/fr/nav.json
@@ -7,5 +7,6 @@
   "whatsNew": "Changelog",
   "liveDemo": "Démo en ligne",
   "opensInNewTab": "(s'ouvre dans un nouvel onglet)",
-  "openMenu": "Ouvrir le menu"
+  "openMenu": "Ouvrir le menu",
+  "docs": "Documentation"
 }

--- a/apps/web/public/locales/zh/nav.json
+++ b/apps/web/public/locales/zh/nav.json
@@ -7,5 +7,6 @@
   "whatsNew": "Changelog",
   "liveDemo": "在线演示",
   "opensInNewTab": "（在新标签页中打开）",
-  "openMenu": "打开菜单"
+  "openMenu": "打开菜单",
+  "docs": "文档"
 }

--- a/apps/web/src/components/StickyNav.tsx
+++ b/apps/web/src/components/StickyNav.tsx
@@ -113,13 +113,13 @@ const StickyNav = ({ currentPage }: { currentPage?: string }) => {
               {t("features")}
             </a>
             <a
-              href="/docs/"
+              href={`${localePrefix}/docs/`}
               className={`px-4 py-2 text-base font-medium transition-colors ${currentPage === "docs" ? "text-primary" : "text-foreground hover:text-primary"}`}
               {...(currentPage === "docs"
                 ? { "aria-current": "page" as const }
                 : {})}
             >
-              Docs
+              {t("docs")}
             </a>
             <a
               href={`${localePrefix}/changelog/`}
@@ -219,13 +219,13 @@ const StickyNav = ({ currentPage }: { currentPage?: string }) => {
               {t("features")}
             </a>
             <a
-              href="/docs/"
+              href={`${localePrefix}/docs/`}
               className={`px-4 py-3 text-base font-medium hover:bg-muted rounded-md transition-colors ${currentPage === "docs" ? "text-primary" : "text-foreground hover:text-primary"}`}
               {...(currentPage === "docs"
                 ? { "aria-current": "page" as const }
                 : {})}
             >
-              Docs
+              {t("docs")}
             </a>
             <a
               href={`${localePrefix}/changelog/`}

--- a/apps/web/src/components/StickyNav.tsx
+++ b/apps/web/src/components/StickyNav.tsx
@@ -113,6 +113,15 @@ const StickyNav = ({ currentPage }: { currentPage?: string }) => {
               {t("features")}
             </a>
             <a
+              href="/docs/"
+              className={`px-4 py-2 text-base font-medium transition-colors ${currentPage === "docs" ? "text-primary" : "text-foreground hover:text-primary"}`}
+              {...(currentPage === "docs"
+                ? { "aria-current": "page" as const }
+                : {})}
+            >
+              Docs
+            </a>
+            <a
               href={`${localePrefix}/changelog/`}
               className={`px-4 py-2 text-base font-medium transition-colors ${currentPage === "changelog" ? "text-primary" : "text-foreground hover:text-primary"}`}
               {...(currentPage === "changelog"
@@ -208,6 +217,15 @@ const StickyNav = ({ currentPage }: { currentPage?: string }) => {
                 : {})}
             >
               {t("features")}
+            </a>
+            <a
+              href="/docs/"
+              className={`px-4 py-3 text-base font-medium hover:bg-muted rounded-md transition-colors ${currentPage === "docs" ? "text-primary" : "text-foreground hover:text-primary"}`}
+              {...(currentPage === "docs"
+                ? { "aria-current": "page" as const }
+                : {})}
+            >
+              Docs
             </a>
             <a
               href={`${localePrefix}/changelog/`}

--- a/apps/web/src/components/docs/DocsCallout.tsx
+++ b/apps/web/src/components/docs/DocsCallout.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+type CalloutType = "info" | "warning" | "danger" | "tip";
+
+interface CalloutProps {
+  type?: CalloutType;
+  title?: string;
+  children: ReactNode;
+}
+
+const styles: Record<CalloutType, string> = {
+  info: "bg-blue-50 border-blue-200 text-blue-950 dark:bg-blue-950/30 dark:border-blue-800 dark:text-blue-100",
+  tip: "bg-green-50 border-green-200 text-green-950 dark:bg-green-950/30 dark:border-green-800 dark:text-green-100",
+  warning:
+    "bg-amber-50 border-amber-200 text-amber-950 dark:bg-amber-950/30 dark:border-amber-800 dark:text-amber-100",
+  danger:
+    "bg-red-50 border-red-200 text-red-950 dark:bg-red-950/30 dark:border-red-800 dark:text-red-100",
+};
+
+const icons: Record<CalloutType, string> = {
+  info: "ℹ",
+  tip: "✓",
+  warning: "⚠",
+  danger: "✕",
+};
+
+const defaultTitles: Record<CalloutType, string> = {
+  info: "Note",
+  tip: "Tip",
+  warning: "Warning",
+  danger: "Important",
+};
+
+export const Callout = ({ type = "info", title, children }: CalloutProps) => (
+  <div className={`my-5 rounded-lg border px-4 py-3.5 text-sm ${styles[type]}`}>
+    <p className="font-semibold mb-1 flex items-center gap-1.5">
+      <span aria-hidden="true">{icons[type]}</span>
+      {title ?? defaultTitles[type]}
+    </p>
+    <div className="[&>p]:mt-0 [&>p]:mb-0">{children}</div>
+  </div>
+);

--- a/apps/web/src/components/docs/DocsCallout.tsx
+++ b/apps/web/src/components/docs/DocsCallout.tsx
@@ -17,11 +17,88 @@ const styles: Record<CalloutType, string> = {
     "bg-red-50 border-red-200 text-red-950 dark:bg-red-950/30 dark:border-red-800 dark:text-red-100",
 };
 
-const icons: Record<CalloutType, string> = {
-  info: "ℹ",
-  tip: "✓",
-  warning: "⚠",
-  danger: "✕",
+const iconColors: Record<CalloutType, string> = {
+  info: "text-blue-500",
+  tip: "text-green-500",
+  warning: "text-amber-500",
+  danger: "text-red-500",
+};
+
+const Icon = ({ type }: { type: CalloutType }) => {
+  if (type === "info")
+    return (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        className={`shrink-0 ${iconColors.info}`}
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="8.5" />
+        <line x1="12" y1="12" x2="12" y2="16" />
+      </svg>
+    );
+  if (type === "tip")
+    return (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        className={`shrink-0 ${iconColors.tip}`}
+      >
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+    );
+  if (type === "warning")
+    return (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        className={`shrink-0 ${iconColors.warning}`}
+      >
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+        <line x1="12" y1="9" x2="12" y2="13" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </svg>
+    );
+  // danger
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={`shrink-0 ${iconColors.danger}`}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="15" y1="9" x2="9" y2="15" />
+      <line x1="9" y1="9" x2="15" y2="15" />
+    </svg>
+  );
 };
 
 const defaultTitles: Record<CalloutType, string> = {
@@ -34,7 +111,7 @@ const defaultTitles: Record<CalloutType, string> = {
 export const Callout = ({ type = "info", title, children }: CalloutProps) => (
   <div className={`my-5 rounded-lg border px-4 py-3.5 text-sm ${styles[type]}`}>
     <p className="font-semibold mb-1 flex items-center gap-1.5">
-      <span aria-hidden="true">{icons[type]}</span>
+      <Icon type={type} />
       {title ?? defaultTitles[type]}
     </p>
     <div className="[&>p]:mt-0 [&>p]:mb-0">{children}</div>

--- a/apps/web/src/components/docs/DocsSidebar.tsx
+++ b/apps/web/src/components/docs/DocsSidebar.tsx
@@ -32,8 +32,8 @@ const SidebarNav = ({ currentSlug, onNavigate }: SidebarNavProps) => (
                   aria-current={isActive ? "page" : undefined}
                   className={`flex items-center px-3 py-1.5 text-sm transition-colors ${
                     isActive
-                      ? "bg-primary/10 text-primary font-medium"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                      ? "rounded-md bg-primary/10 text-primary font-medium"
+                      : "rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50"
                   }`}
                 >
                   {page.title}

--- a/apps/web/src/components/docs/DocsSidebar.tsx
+++ b/apps/web/src/components/docs/DocsSidebar.tsx
@@ -66,7 +66,14 @@ const DocsSidebar = ({ currentSlug }: DocsSidebarProps) => {
       <SidebarNav currentSlug={currentSlug} />
 
       {/* Mobile Sheet — portaled to body, triggered by custom event */}
-      <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+      <Sheet
+        open={mobileOpen}
+        onOpenChange={(open) => {
+          setMobileOpen(open);
+          if (!open)
+            document.dispatchEvent(new CustomEvent("close-docs-sidebar"));
+        }}
+      >
         <SheetContent side="left" className="w-72 p-0">
           <SheetHeader className="px-6 pt-6 pb-2">
             <SheetTitle className="text-base font-display font-normal">

--- a/apps/web/src/components/docs/DocsSidebar.tsx
+++ b/apps/web/src/components/docs/DocsSidebar.tsx
@@ -30,10 +30,10 @@ const SidebarNav = ({ currentSlug, onNavigate }: SidebarNavProps) => (
                   href={`/docs/${page.slug}/`}
                   onClick={onNavigate}
                   aria-current={isActive ? "page" : undefined}
-                  className={`flex items-center px-3 py-1.5 rounded-md text-sm transition-colors ${
+                  className={`flex items-center px-3 py-1.5 text-sm transition-colors ${
                     isActive
                       ? "bg-primary/10 text-primary font-medium"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
                   }`}
                 >
                   {page.title}

--- a/apps/web/src/components/docs/DocsSidebar.tsx
+++ b/apps/web/src/components/docs/DocsSidebar.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+
+import { docsNav } from "@/lib/docs-nav";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+
+interface SidebarNavProps {
+  currentSlug: string;
+  onNavigate?: () => void;
+}
+
+const SidebarNav = ({ currentSlug, onNavigate }: SidebarNavProps) => (
+  <nav>
+    {docsNav.map((section) => (
+      <div key={section.section} className="mb-6">
+        <p className="px-3 mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          {section.section}
+        </p>
+        <ul>
+          {section.pages.map((page) => {
+            const isActive = currentSlug === page.slug;
+            return (
+              <li key={page.slug}>
+                <a
+                  href={`/docs/${page.slug}/`}
+                  onClick={onNavigate}
+                  aria-current={isActive ? "page" : undefined}
+                  className={`flex items-center px-3 py-1.5 rounded-md text-sm transition-colors ${
+                    isActive
+                      ? "bg-primary/10 text-primary font-medium"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                  }`}
+                >
+                  {page.title}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    ))}
+  </nav>
+);
+
+interface DocsSidebarProps {
+  currentSlug: string;
+}
+
+const DocsSidebar = ({ currentSlug }: DocsSidebarProps) => {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setMobileOpen(true);
+    document.addEventListener("open-docs-sidebar", handler);
+    return () => document.removeEventListener("open-docs-sidebar", handler);
+  }, []);
+
+  return (
+    <>
+      {/* Desktop nav — visible because parent aside is lg:block */}
+      <SidebarNav currentSlug={currentSlug} />
+
+      {/* Mobile Sheet — portaled to body, triggered by custom event */}
+      <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+        <SheetContent side="left" className="w-72 p-0">
+          <SheetHeader className="px-6 pt-6 pb-2">
+            <SheetTitle className="text-base font-display font-normal">
+              Documentation
+            </SheetTitle>
+          </SheetHeader>
+          <div className="overflow-y-auto px-4 pb-8 pt-2">
+            <SidebarNav
+              currentSlug={currentSlug}
+              onNavigate={() => setMobileOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+};
+
+export default DocsSidebar;

--- a/apps/web/src/components/docs/DocsSidebar.tsx
+++ b/apps/web/src/components/docs/DocsSidebar.tsx
@@ -55,6 +55,11 @@ const DocsSidebar = ({ currentSlug }: DocsSidebarProps) => {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   useEffect(() => {
+    // Capture pre-hydration intent: button was clicked before React mounted
+    if (document.documentElement.dataset.docsSidebarOpen) {
+      delete document.documentElement.dataset.docsSidebarOpen;
+      setMobileOpen(true);
+    }
     const handler = () => setMobileOpen(true);
     document.addEventListener("open-docs-sidebar", handler);
     return () => document.removeEventListener("open-docs-sidebar", handler);

--- a/apps/web/src/components/docs/DocsToC.tsx
+++ b/apps/web/src/components/docs/DocsToC.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface DocsToCProps {
+  headings: Heading[];
+}
+
+const DocsToC = ({ headings }: DocsToCProps) => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
+
+  useEffect(() => {
+    if (tocHeadings.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        }
+      },
+      { rootMargin: "-56px 0px -70% 0px", threshold: 0 }
+    );
+
+    for (const heading of tocHeadings) {
+      const el = document.getElementById(heading.slug);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
+  if (tocHeadings.length === 0) return null;
+
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+        On this page
+      </p>
+      <ul className="space-y-0.5">
+        {tocHeadings.map((h) => (
+          <li key={h.slug}>
+            <a
+              href={`#${h.slug}`}
+              className={`block text-sm py-0.5 transition-colors leading-snug ${
+                h.depth === 3 ? "pl-3" : ""
+              } ${
+                activeId === h.slug
+                  ? "text-primary font-medium"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DocsToC;

--- a/apps/web/src/components/docs/DocsToC.tsx
+++ b/apps/web/src/components/docs/DocsToC.tsx
@@ -26,7 +26,7 @@ const DocsToC = ({ headings }: DocsToCProps) => {
           }
         }
       },
-      { rootMargin: "-56px 0px -70% 0px", threshold: 0 }
+      { rootMargin: "-56px 0px -40% 0px", threshold: 0 }
     );
 
     for (const heading of tocHeadings) {

--- a/apps/web/src/content.config.ts
+++ b/apps/web/src/content.config.ts
@@ -1,0 +1,13 @@
+import { glob } from "astro/loaders";
+import { defineCollection, z } from "astro:content";
+
+const docs = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/docs" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    section: z.string().optional(),
+  }),
+});
+
+export const collections = { docs };

--- a/apps/web/src/content/docs/getting-started.mdx
+++ b/apps/web/src/content/docs/getting-started.mdx
@@ -1,0 +1,46 @@
+---
+title: "Introduction"
+description: "Get started with Qarote — the open-source RabbitMQ monitoring dashboard. Learn what Qarote does, what it requires, and how it connects to your broker."
+section: "Getting started"
+---
+
+# Introduction
+
+Qarote is an open-source RabbitMQ monitoring and management dashboard. It gives you a clean, modern alternative to the built-in Management Plugin — with real-time metrics, better visualizations, and premium features like alerting, workspaces, and SSO available as you scale.
+
+## What Qarote can do
+
+- Monitor queue depths, message rates, and consumer counts in real time
+- Inspect exchange bindings and routing topologies
+- Spy on live queue traffic without consuming messages from real consumers
+- Set up threshold alerts (message depth, consumer count, dead-letter growth)
+- Manage multiple RabbitMQ servers from a single dashboard
+- Invite team members to shared workspaces with role-based access
+
+## How it connects to RabbitMQ
+
+Qarote uses two protocols to talk to your broker:
+
+**Management HTTP API** — used for most operations: reading queue/exchange/binding metadata, publishing test messages, purging queues, and fetching metrics history. This requires the `rabbitmq_management` plugin to be enabled.
+
+**AMQP** — used for features that need a live connection to the broker, such as [spying on live queues](/docs/queues/spy-on-live-queues/). Qarote opens a direct AMQP connection and closes it when the feature is no longer in use.
+
+## Requirements
+
+Before installing Qarote, make sure you have:
+
+- **RabbitMQ 3.8 or later** with the Management Plugin enabled:
+  ```sh
+  rabbitmq-plugins enable rabbitmq_management
+  ```
+- A RabbitMQ user with the `monitoring` or `administrator` tag
+- A server to host Qarote (Linux, Docker, or a platform like Dokku)
+- PostgreSQL 14+ for Qarote's own data (connections, users, alerts)
+
+<Callout type="tip" title="Community Edition is free">
+  Qarote's core monitoring features are free forever under the MIT license. No credit card required. Premium features (workspaces, alerting, SSO) are unlocked via a license key.
+</Callout>
+
+## Self-hosted by design
+
+Qarote runs entirely in your own infrastructure. Your RabbitMQ credentials, message contents, and cluster metrics never leave your network. See [Security and privacy](/docs/security-and-privacy/) for a full breakdown of how data flows through Qarote.

--- a/apps/web/src/content/docs/getting-started.mdx
+++ b/apps/web/src/content/docs/getting-started.mdx
@@ -21,9 +21,13 @@ Qarote is an open-source RabbitMQ monitoring and management dashboard. It gives 
 
 Qarote uses two protocols to talk to your broker:
 
-**Management HTTP API** — used for most operations: reading queue/exchange/binding metadata, publishing test messages, purging queues, and fetching metrics history. This requires the `rabbitmq_management` plugin to be enabled.
+### Management HTTP API
 
-**AMQP** — used for features that need a live connection to the broker, such as [spying on live queues](/docs/queues/spy-on-live-queues/). Qarote opens a direct AMQP connection and closes it when the feature is no longer in use.
+Used for most operations: reading queue/exchange/binding metadata, publishing test messages, purging queues, and fetching metrics history. This requires the `rabbitmq_management` plugin to be enabled.
+
+### AMQP
+
+Used for features that need a live connection to the broker, such as [spying on live queues](/docs/queues/spy-on-live-queues/). Qarote opens a direct AMQP connection and closes it when the feature is no longer in use.
 
 ## Requirements
 

--- a/apps/web/src/content/docs/queues/spy-on-live-queues.mdx
+++ b/apps/web/src/content/docs/queues/spy-on-live-queues.mdx
@@ -59,10 +59,21 @@ Each captured message shows:
 
 ## Limitations
 
-- **Auto-delete queues only** — if a queue has no exchange binding (e.g. published directly to the default exchange), spying is not supported.
-- **Transient data** — message bodies are displayed in your browser only. Nothing is persisted to Qarote's database.
-- **One session at a time** — you can only spy on one queue at a time per browser tab.
-- **AMQP required** — the spy feature requires a working AMQP connection. If Qarote can only reach your broker via the HTTP Management API (e.g. port 15672 is open but 5672 is not), spying will not be available.
+### Exchange binding required
+
+If a queue has no exchange binding (e.g. published directly to the default exchange), spying is not supported. You must have an exchange-to-queue binding for the shadow queue mechanism to work.
+
+### Transient data only
+
+Message bodies are displayed in your browser only. Nothing is persisted to Qarote's database. If you need to retain captured messages, copy them from the spy panel before closing the session.
+
+### One session at a time
+
+You can only spy on one queue at a time per browser tab. Open a second tab to observe multiple queues simultaneously.
+
+### AMQP connection required
+
+The spy feature requires a working AMQP connection. If Qarote can only reach your broker via the HTTP Management API (e.g. port `15672` is open but `5672` is not), spying will not be available. See [Requirements](#requirements) for the exact permissions needed.
 
 <Callout type="tip" title="Inspecting queued messages">
   To inspect messages that are already sitting in a queue (not just new arrivals), use the **Peek** feature instead. Peek fetches existing messages from the queue without removing them, using the Management HTTP API.

--- a/apps/web/src/content/docs/queues/spy-on-live-queues.mdx
+++ b/apps/web/src/content/docs/queues/spy-on-live-queues.mdx
@@ -1,0 +1,69 @@
+---
+title: "Spy on live queues"
+description: "Inspect messages flowing through a RabbitMQ queue in real time — without consuming them from your real consumers. Learn how Qarote's spy feature works and when to use it."
+section: "Queues"
+---
+
+# Spy on live queues
+
+Qarote lets you observe what is flowing through a queue — routing keys, headers, and payloads — **without stealing messages from your real consumers**. This is useful for debugging production issues, validating message formats, and understanding how your routing topology behaves under real traffic.
+
+<Callout type="info">
+  Spying is a read-only observation. Your actual consumers continue receiving messages as normal. The only overhead is the brief setup of a temporary AMQP binding and the bandwidth of duplicating messages to Qarote's inspection buffer.
+</Callout>
+
+## How it works
+
+When you start a spy session, Qarote opens a direct AMQP connection to your broker and creates a temporary binding from the target queue's exchange to a short-lived, auto-delete queue. RabbitMQ routes a copy of each message to both your real consumers and to Qarote's shadow queue.
+
+Qarote reads from the shadow queue and streams the messages to your browser. When you stop the spy session (or navigate away), Qarote cancels the consumer, deletes the shadow queue, and closes the AMQP connection. Nothing is left behind on the broker.
+
+<Callout type="warning" title="High-throughput queues">
+  On queues with very high message rates, spying may capture only a sample of messages rather than every one — Qarote limits its shadow queue depth to avoid buffer overflow. Use this feature for inspection and debugging, not as a reliable message tap for production pipelines.
+</Callout>
+
+## Requirements
+
+To use the spy feature, your RabbitMQ connection in Qarote must:
+
+- Have AMQP access enabled (host + port `5672`, or your custom AMQP port)
+- Use a user with permission to **read** from the target vhost and **configure** temporary queues:
+  ```
+  configure: ^qarote\.spy\..*$
+  write:     ^qarote\.spy\..*$
+  read:      .*
+  ```
+- Have the `rabbitmq_management` plugin enabled (for metadata lookup)
+
+## Starting a spy session
+
+1. Open the **Queues** view in your Qarote dashboard.
+2. Click on the queue you want to inspect.
+3. On the queue detail page, click **Spy** in the top action bar.
+4. Qarote opens the spy panel at the bottom of the page and begins streaming incoming messages.
+5. Each message shows its **routing key**, **exchange**, **headers**, and **body** (JSON is pretty-printed automatically).
+6. Click **Stop** when you are done. The session closes and the temporary queue is removed.
+
+## What you see
+
+Each captured message shows:
+
+| Field | Description |
+|---|---|
+| **Routing key** | The routing key the publisher used |
+| **Exchange** | The exchange the message was published to |
+| **Body** | The raw message payload (JSON auto-formatted) |
+| **Headers** | Any custom AMQP headers attached to the message |
+| **Properties** | Content-type, delivery-mode, priority, timestamp |
+| **Size** | Payload size in bytes |
+
+## Limitations
+
+- **Auto-delete queues only** — if a queue has no exchange binding (e.g. published directly to the default exchange), spying is not supported.
+- **Transient data** — message bodies are displayed in your browser only. Nothing is persisted to Qarote's database.
+- **One session at a time** — you can only spy on one queue at a time per browser tab.
+- **AMQP required** — the spy feature requires a working AMQP connection. If Qarote can only reach your broker via the HTTP Management API (e.g. port 15672 is open but 5672 is not), spying will not be available.
+
+<Callout type="tip" title="Inspecting queued messages">
+  To inspect messages that are already sitting in a queue (not just new arrivals), use the **Peek** feature instead. Peek fetches existing messages from the queue without removing them, using the Management HTTP API.
+</Callout>

--- a/apps/web/src/content/docs/security-and-privacy.mdx
+++ b/apps/web/src/content/docs/security-and-privacy.mdx
@@ -1,0 +1,63 @@
+---
+title: "Security and privacy"
+description: "How Qarote handles your RabbitMQ credentials, what data it stores, how it connects to your broker, and what leaves your network — which is nothing."
+section: "Security & Privacy"
+---
+
+# Security and privacy
+
+Qarote runs entirely within your own infrastructure. It acts as a proxy between your browser and your RabbitMQ broker — your cluster data never passes through Qarote's servers or any third-party service.
+
+## How Qarote connects to your broker
+
+Qarote uses two protocols depending on the operation:
+
+**Management HTTP API** reads queue and exchange metadata, metrics, bindings, and node stats. It invokes mutation endpoints when you perform management actions like purging a queue or publishing a message. This is RabbitMQ's built-in HTTP API — no plugins beyond `rabbitmq_management` are required.
+
+**AMQP** is used for features that require a live, low-level connection to the broker. The primary example is [spying on live queues](/docs/queues/spy-on-live-queues/): Qarote opens a direct AMQP connection to intercept a copy of in-flight messages. The connection is opened on demand and closed as soon as the spy session ends.
+
+Neither protocol routes traffic through Qarote's infrastructure. The connection goes:
+
+```
+Your browser → Qarote server (self-hosted) → Your RabbitMQ broker
+```
+
+There is no hop to any Qarote-operated service in this path.
+
+## What Qarote stores
+
+Qarote stores the following in its own PostgreSQL database:
+
+| Data | Purpose |
+|---|---|
+| RabbitMQ host, port, vhost | To establish connections |
+| RabbitMQ username & password | Stored encrypted at rest |
+| Qarote user accounts | Authentication to the dashboard |
+| Alert rules and notification channels | For the alerting feature |
+| Metrics snapshots | For trend charts (configurable retention) |
+
+Qarote does **not** store message bodies, routing keys, or queue contents. The only time message data appears in Qarote is transiently during a live spy session — it is displayed in your browser and never written to disk.
+
+<Callout type="warning" title="Protect your database">
+  The PostgreSQL database contains your RabbitMQ credentials. Apply standard database hardening: restrict network access, use a dedicated database user, and enable encryption at rest if your provider supports it.
+</Callout>
+
+## License validation
+
+Qarote's license system is designed to work fully offline. When you enter a license key, Qarote validates it locally using a public key baked into the binary — no network request is made to Qarote's servers. Your license key contains your tier and expiry date in a signed JWT; validation is a cryptographic check only.
+
+Qarote does not phone home, collect telemetry, or send usage data unless you explicitly opt in.
+
+## Recommended security practices
+
+**Enable HTTPS.** Always run Qarote behind a reverse proxy (Caddy, Nginx, Traefik) with a valid TLS certificate, especially if the dashboard is internet-accessible. Qarote's Docker and Dokku deployments include Caddy with automatic HTTPS by default.
+
+**Use a least-privilege RabbitMQ user.** Qarote only needs the `monitoring` tag for read-only access. If you use features like publishing messages or managing queues, grant `management` or `administrator` as appropriate — but avoid using your main admin credentials in Qarote.
+
+**Restrict Qarote's network access.** If Qarote doesn't need to be public, put it behind a VPN or firewall. The dashboard only needs to reach your RabbitMQ broker and your PostgreSQL instance.
+
+**Rotate credentials periodically.** RabbitMQ connection credentials can be updated in Qarote's Settings at any time without restarting the service.
+
+<Callout type="info" title="Ports used">
+  By default, Qarote connects to RabbitMQ on port `15672` (HTTP Management API) and `5672` (AMQP). If your broker uses different ports or TLS (e.g. `5671`), you can configure these per connection in the Qarote UI.
+</Callout>

--- a/apps/web/src/content/docs/security-and-privacy.mdx
+++ b/apps/web/src/content/docs/security-and-privacy.mdx
@@ -24,6 +24,10 @@ Your browser → Qarote server (self-hosted) → Your RabbitMQ broker
 
 There is no hop to any Qarote-operated service in this path.
 
+<Callout type="info" title="Ports used">
+  By default, Qarote connects to RabbitMQ on port `15672` (HTTP Management API) and `5672` (AMQP). If your broker uses different ports or TLS (e.g. `5671`), you can configure these per connection in the Qarote UI.
+</Callout>
+
 ## What Qarote stores
 
 Qarote stores the following in its own PostgreSQL database:
@@ -54,7 +58,7 @@ Qarote does not phone home, collect telemetry, or send usage data unless you exp
 
 Always run Qarote behind a reverse proxy (Caddy, Nginx, Traefik) with a valid TLS certificate, especially if the dashboard is internet-accessible. Qarote's Docker and Dokku deployments include Caddy with automatic HTTPS by default.
 
-### Use a least-privilege RabbitMQ user
+### Least-privilege RabbitMQ user
 
 Qarote only needs the `monitoring` tag for read-only access. If you use features like publishing messages or managing queues, grant `management` or `administrator` as appropriate — but avoid using your main admin credentials in Qarote.
 
@@ -65,7 +69,3 @@ If Qarote doesn't need to be public, put it behind a VPN or firewall. The dashbo
 ### Rotate credentials periodically
 
 RabbitMQ connection credentials can be updated in Qarote's Settings at any time without restarting the service.
-
-<Callout type="info" title="Ports used">
-  By default, Qarote connects to RabbitMQ on port `15672` (HTTP Management API) and `5672` (AMQP). If your broker uses different ports or TLS (e.g. `5671`), you can configure these per connection in the Qarote UI.
-</Callout>

--- a/apps/web/src/content/docs/security-and-privacy.mdx
+++ b/apps/web/src/content/docs/security-and-privacy.mdx
@@ -50,13 +50,21 @@ Qarote does not phone home, collect telemetry, or send usage data unless you exp
 
 ## Recommended security practices
 
-**Enable HTTPS.** Always run Qarote behind a reverse proxy (Caddy, Nginx, Traefik) with a valid TLS certificate, especially if the dashboard is internet-accessible. Qarote's Docker and Dokku deployments include Caddy with automatic HTTPS by default.
+### Enable HTTPS
 
-**Use a least-privilege RabbitMQ user.** Qarote only needs the `monitoring` tag for read-only access. If you use features like publishing messages or managing queues, grant `management` or `administrator` as appropriate — but avoid using your main admin credentials in Qarote.
+Always run Qarote behind a reverse proxy (Caddy, Nginx, Traefik) with a valid TLS certificate, especially if the dashboard is internet-accessible. Qarote's Docker and Dokku deployments include Caddy with automatic HTTPS by default.
 
-**Restrict Qarote's network access.** If Qarote doesn't need to be public, put it behind a VPN or firewall. The dashboard only needs to reach your RabbitMQ broker and your PostgreSQL instance.
+### Use a least-privilege RabbitMQ user
 
-**Rotate credentials periodically.** RabbitMQ connection credentials can be updated in Qarote's Settings at any time without restarting the service.
+Qarote only needs the `monitoring` tag for read-only access. If you use features like publishing messages or managing queues, grant `management` or `administrator` as appropriate — but avoid using your main admin credentials in Qarote.
+
+### Restrict Qarote's network access
+
+If Qarote doesn't need to be public, put it behind a VPN or firewall. The dashboard only needs to reach your RabbitMQ broker and your PostgreSQL instance.
+
+### Rotate credentials periodically
+
+RabbitMQ connection credentials can be updated in Qarote's Settings at any time without restarting the service.
 
 <Callout type="info" title="Ports used">
   By default, Qarote connects to RabbitMQ on port `15672` (HTTP Management API) and `5672` (AMQP). If your broker uses different ports or TLS (e.g. `5671`), you can configure these per connection in the Qarote UI.

--- a/apps/web/src/content/docs/self-hosted/deployment.mdx
+++ b/apps/web/src/content/docs/self-hosted/deployment.mdx
@@ -1,0 +1,452 @@
+---
+title: "Deploying Qarote"
+description: "Step-by-step instructions for deploying Qarote self-hosted using the standalone binary, Docker Compose, or Dokku."
+section: "Self-Hosted"
+---
+
+# Deploying Qarote
+
+Qarote ships as a self-contained application. Pick the deployment method that fits your environment — all three give you the same dashboard.
+
+| Method | Best for |
+|---|---|
+| [Binary](#binary) | Minimal footprint, existing PostgreSQL, VMs or bare metal |
+| [Docker Compose](#docker-compose) | Containerised setup, everything bundled including Postgres |
+| [Dokku](#dokku) | Git-push deploys, automatic HTTPS, Heroku-style PaaS on your own server |
+
+All deployments start with the **free tier** (core monitoring). Premium features — workspaces, alerting, integrations — unlock when you activate a license key in **Settings → License**. No restart needed.
+
+## Prerequisites
+
+- **Binary:** PostgreSQL 15+ already running (no Docker or Node.js needed)
+- **Docker Compose:** Docker and Docker Compose installed (PostgreSQL is bundled)
+- **Dokku:** Dokku installed on your server
+- Minimum 2 GB RAM, 10 GB disk space
+
+## Binary
+
+The binary embeds both the API and the frontend. Drop it on any Linux or macOS host that already has PostgreSQL — nothing else required.
+
+### 1. Set up PostgreSQL
+
+If PostgreSQL isn't already running:
+
+```bash
+# macOS
+brew install postgresql@15
+
+# Ubuntu / Debian / WSL2
+sudo apt install postgresql
+```
+
+Create a dedicated database user:
+
+```bash
+sudo -u postgres psql -c "CREATE USER qarote WITH PASSWORD 'your-secure-password';"
+sudo -u postgres psql -c "CREATE DATABASE qarote OWNER qarote;"
+
+# Recommended: set idle connection timeouts
+sudo -u postgres psql -c "ALTER SYSTEM SET idle_session_timeout = '30min';"
+sudo -u postgres psql -c "ALTER SYSTEM SET idle_in_transaction_session_timeout = '5min';"
+sudo -u postgres psql -c "SELECT pg_reload_conf();"
+```
+
+Your connection URL will be: `postgresql://qarote:your-secure-password@localhost:5432/qarote`
+
+### 2. Download the binary
+
+```bash
+# Auto-detects your OS and architecture
+PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/')"
+curl -L "https://github.com/getqarote/Qarote/releases/latest/download/qarote-${PLATFORM}.tar.gz" | tar xz --strip-components=1
+```
+
+Or download a specific build from [GitHub Releases](https://github.com/getqarote/Qarote/releases):
+
+| Platform | File |
+|---|---|
+| Linux x64 | `qarote-linux-x64.tar.gz` |
+| Linux ARM64 | `qarote-linux-arm64.tar.gz` |
+| macOS Apple Silicon | `qarote-darwin-arm64.tar.gz` |
+| macOS Intel | `qarote-darwin-x64.tar.gz` |
+
+<Callout type="tip" title="Windows">
+  Run the binary inside WSL2. Native Windows is not supported.
+</Callout>
+
+### 3. Run the setup wizard
+
+```bash
+./qarote setup
+```
+
+The wizard will:
+
+- Ask for your PostgreSQL URL and verify the connection
+- Create an admin account (written directly to the database — no sign-up flow needed)
+- Let you disable public registration (recommended for private deployments)
+- Generate `JWT_SECRET` and `ENCRYPTION_KEY`
+- Write a `.env` file in the current directory
+
+<Callout type="tip">
+  Say **Yes** to creating an admin account and **No** to public registration. You can invite team members later from inside the app.
+</Callout>
+
+### 4. Start Qarote
+
+```bash
+./qarote
+```
+
+The server starts on `http://localhost:3000`. Database migrations run automatically on first boot. The `migrations/` directory must stay alongside the binary.
+
+To run the alert worker (required for the alerting feature), start it in a separate terminal or as a systemd service:
+
+```bash
+./qarote worker
+```
+
+### Manual setup (without the wizard)
+
+If you prefer flags over the interactive wizard:
+
+```bash
+./qarote \
+  --database-url postgresql://qarote:password@localhost/qarote \
+  --jwt-secret $(openssl rand -hex 64) \
+  --encryption-key $(openssl rand -hex 64)
+```
+
+### CLI reference
+
+| Flag | Description |
+|---|---|
+| `./qarote setup` | Interactive setup wizard (generates `.env`) |
+| `./qarote worker` | Start the alert worker process |
+| `--database-url <url>` | PostgreSQL connection URL |
+| `--jwt-secret <secret>` | JWT signing secret (min 32 chars) |
+| `--encryption-key <key>` | Encryption key (min 32 chars) |
+| `-p`, `--port <port>` | Server port (default: `3000`) |
+| `-h`, `--host <host>` | Server host (default: `localhost`) |
+| `--enable-email <bool>` | Enable email features (default: `false`) |
+| `--smtp-host <host>` | SMTP server hostname |
+| `--smtp-port <port>` | SMTP server port (default: `587`) |
+| `--smtp-user <user>` | SMTP username |
+| `--smtp-pass <pass>` | SMTP password |
+| `--smtp-service <name>` | SMTP service for OAuth2 (e.g. `gmail`) |
+| `--smtp-oauth-client-id <id>` | OAuth2 client ID |
+| `--smtp-oauth-client-secret <s>` | OAuth2 client secret |
+| `--smtp-oauth-refresh-token <t>` | OAuth2 refresh token |
+
+### Updating (binary)
+
+```bash
+# Stop the running instance
+kill $(pgrep -f './qarote') 2>/dev/null || true
+
+# Download latest release
+PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/')"
+curl -L "https://github.com/getqarote/Qarote/releases/latest/download/qarote-${PLATFORM}.tar.gz" | tar xz --strip-components=1
+
+# Restart — migrations run automatically
+./qarote
+```
+
+Your `.env` file is preserved. To roll back, restore the backup: `mv qarote.backup qarote && ./qarote`
+
+---
+
+## Docker Compose
+
+The Docker Compose setup bundles PostgreSQL, the backend, the alert worker, and the frontend. One command starts everything.
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/getqarote/Qarote.git qarote
+cd qarote
+```
+
+### 2. Generate configuration
+
+```bash
+./setup.sh
+```
+
+This creates a `.env` file with secure random secrets. Alternatively, copy `.env.selfhosted.example` and fill in the values manually.
+
+Key variables:
+
+```bash
+# Security — generate with: openssl rand -hex 64
+JWT_SECRET=...
+ENCRYPTION_KEY=...
+
+# Ports
+POSTGRES_PORT=5432
+BACKEND_PORT=3000
+FRONTEND_PORT=8080
+
+# Frontend API URL (baked at build time — must match BACKEND_PORT)
+VITE_API_URL=http://localhost:3000
+```
+
+### 3. Start services
+
+```bash
+docker compose -f docker-compose.selfhosted.yml up -d
+```
+
+This starts four containers:
+
+| Container | Purpose |
+|---|---|
+| `qarote_postgres` | PostgreSQL 15 database |
+| `qarote_backend` | API server on port 3000 |
+| `qarote_alert_worker` | Alert evaluation worker |
+| `qarote_frontend` | React frontend on port 8080 |
+
+### 4. Run database migrations
+
+```bash
+docker exec qarote_backend pnpm run db:migrate
+```
+
+### 5. Open the dashboard
+
+Navigate to [http://localhost:8080](http://localhost:8080) and create your first account.
+
+<Callout type="info" title="Ports">
+  Frontend is served on `FRONTEND_PORT` (default 8080). The backend API is on `BACKEND_PORT` (default 3000). Both are configurable in `.env`.
+</Callout>
+
+### Updating (Docker Compose)
+
+```bash
+git pull origin main
+docker compose -f docker-compose.selfhosted.yml up -d --build
+docker exec qarote_backend pnpm run db:migrate
+```
+
+### Viewing logs
+
+```bash
+docker compose -f docker-compose.selfhosted.yml logs -f
+```
+
+---
+
+## Dokku
+
+Dokku gives you git-push deploys, automatic HTTPS via Let's Encrypt, and managed PostgreSQL — on a server you control.
+
+<Callout type="info" title="Why Dokku?">
+  Dokku is a lightweight self-hosted PaaS. Push your code with `git push dokku main` and it rebuilds and redeploys automatically. The Postgres plugin handles backups and linking. Caddy handles SSL.
+</Callout>
+
+### 1. Install Dokku
+
+Follow the [Dokku installation guide](https://dokku.com/docs/getting-started/installation/) to set up Dokku on your server.
+
+### 2. Create the app and database
+
+```bash
+# On your server (or via SSH)
+ssh dokku@your-server apps:create qarote
+
+sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
+dokku postgres:create qarote-db
+dokku postgres:link qarote-db qarote
+```
+
+`DATABASE_URL` is set automatically when you link the database.
+
+### 3. Set environment variables
+
+```bash
+dokku config:set qarote \
+  JWT_SECRET=$(openssl rand -hex 64) \
+  ENCRYPTION_KEY=$(openssl rand -hex 64) \
+  TZ=UTC \
+  ENABLE_EMAIL=false
+```
+
+### 4. Deploy
+
+From your local machine:
+
+```bash
+git remote add dokku dokku@your-server:qarote
+git push dokku main
+```
+
+Dokku builds the app from the `Procfile`, runs the `release` phase (migrations), and starts the `web` and `worker` processes.
+
+### 5. Run database migrations
+
+```bash
+dokku run qarote pnpm run db:migrate
+```
+
+### 6. Enable HTTPS (optional but recommended)
+
+```bash
+dokku domains:set qarote your-domain.com
+dokku letsencrypt:enable qarote
+```
+
+### Scale the alert worker
+
+```bash
+dokku ps:scale qarote worker=1
+```
+
+The `worker` process handles alert evaluation. It must be running for alerts to fire.
+
+### Updating (Dokku)
+
+```bash
+# Push latest — triggers rebuild and redeploy automatically
+git push dokku main
+
+# Apply any new migrations
+dokku run qarote pnpm run db:migrate
+```
+
+---
+
+## SMTP configuration
+
+Email features (password reset, invitations) are disabled by default. To enable them, set `ENABLE_EMAIL=true` and provide SMTP credentials.
+
+SMTP can be configured three ways, in priority order:
+
+1. **Admin UI** — Settings → Email Settings (takes effect immediately, no restart)
+2. **Setup wizard** — `./qarote setup` or `./setup.sh`
+3. **Environment variables** / `dokku config:set`
+
+### Common providers
+
+**Gmail (app password)**
+
+```bash
+ENABLE_EMAIL=true
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your-email@gmail.com
+SMTP_PASS=your-app-password  # Not your Google password — generate at myaccount.google.com/apppasswords
+```
+
+**SendGrid**
+
+```bash
+ENABLE_EMAIL=true
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USER=apikey
+SMTP_PASS=your-sendgrid-api-key
+```
+
+**Mailgun**
+
+```bash
+ENABLE_EMAIL=true
+SMTP_HOST=smtp.mailgun.org
+SMTP_PORT=587
+SMTP_USER=postmaster@your-domain.mailgun.org
+SMTP_PASS=your-mailgun-smtp-password
+```
+
+**Amazon SES**
+
+```bash
+ENABLE_EMAIL=true
+SMTP_HOST=email-smtp.us-east-1.amazonaws.com  # replace region as needed
+SMTP_PORT=587
+SMTP_USER=your-ses-smtp-username
+SMTP_PASS=your-ses-smtp-password
+```
+
+<Callout type="tip" title="Use OAuth2 for production">
+  Gmail and Office 365 support OAuth2 authentication, which is more secure than app passwords and doesn't require storing credentials directly. See the [Nodemailer OAuth2 guide](https://nodemailer.com/smtp/oauth2/) for setup instructions.
+</Callout>
+
+### Test your SMTP configuration
+
+```bash
+# Docker Compose
+docker exec qarote_backend pnpm run test:smtp
+docker exec qarote_backend pnpm run test:smtp -- --send admin@yourcompany.com
+
+# Dokku
+dokku run qarote pnpm run test:smtp -- --send admin@yourcompany.com
+```
+
+---
+
+## Troubleshooting
+
+### "Exec format error" (binary only)
+
+You downloaded the wrong architecture binary. Check your platform:
+
+```bash
+uname -m   # x86_64 → use -x64 | aarch64 → use -arm64
+```
+
+Re-download the correct variant — your `.env` is preserved.
+
+<Callout type="tip">
+  Multipass VMs on Apple Silicon are ARM64. Use `linux-arm64`, not `linux-x64`.
+</Callout>
+
+### Database connection refused
+
+- Verify PostgreSQL is running: `systemctl status postgresql` or `docker compose ps postgres`
+- Check the `DATABASE_URL` format: `postgres://user:password@host:port/database`
+- Make sure migrations have been run
+- For Docker Compose, wait for the health check to pass before the backend starts
+
+### Message rate charts are blank
+
+Your RabbitMQ `rates_mode` is set to `basic` (the default), which doesn't retain sample history.
+
+Fix it in `rabbitmq.conf`:
+
+```ini
+management.rates_mode = detailed
+```
+
+Or apply at runtime without restarting:
+
+```bash
+rabbitmqctl eval 'application:set_env(rabbitmq_management, rates_mode, detailed).'
+```
+
+### Services not starting (Docker Compose)
+
+```bash
+docker compose -f docker-compose.selfhosted.yml logs
+```
+
+Common causes: missing `.env` values, port conflicts on 3000/5432/8080, or insufficient disk space.
+
+### License or premium features not activating
+
+- Go to **Settings → License** and re-enter your key
+- Check that the key hasn't expired
+- Check backend logs for validation errors
+- Contact [support@qarote.io](mailto:support@qarote.io) if the issue persists
+
+---
+
+## License activation
+
+Premium features are activated through the UI — no env vars or restarts needed.
+
+1. Purchase a license at the [Customer Portal](https://portal.qarote.io)
+2. Copy your license key (a signed JWT string)
+3. In Qarote, go to **Settings → License**
+4. Paste the key and click **Activate**
+
+Features unlock immediately. Validation is cryptographic and offline — no network call to Qarote's servers.

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -168,14 +168,44 @@ const sectionFirstSlug = sectionData?.pages[0]?.slug ?? "getting-started";
 
     btn.addEventListener("click", () => {
       const text = pre.textContent ?? "";
-      navigator.clipboard.writeText(text).then(() => {
+
+      const onSuccess = () => {
         btn.textContent = "Copied!";
         btn.classList.add("copied");
         setTimeout(() => {
           btn.textContent = "Copy";
           btn.classList.remove("copied");
         }, 2000);
-      });
+      };
+
+      const onFailure = () => {
+        btn.textContent = "Failed";
+        btn.classList.add("failed");
+        setTimeout(() => {
+          btn.textContent = "Copy";
+          btn.classList.remove("failed");
+        }, 2000);
+      };
+
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        navigator.clipboard.writeText(text).then(onSuccess).catch(onFailure);
+      } else {
+        // DOM fallback for non-secure contexts (HTTP, old browsers)
+        try {
+          const ta = document.createElement("textarea");
+          ta.value = text;
+          ta.style.position = "fixed";
+          ta.style.opacity = "0";
+          document.body.appendChild(ta);
+          ta.focus();
+          ta.select();
+          const ok = document.execCommand("copy");
+          document.body.removeChild(ta);
+          ok ? onSuccess() : onFailure();
+        } catch {
+          onFailure();
+        }
+      }
     });
   });
 

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -233,6 +233,8 @@ const sectionFirstSlug = sectionData?.pages[0]?.slug ?? "getting-started";
   if (sidebarTrigger) {
     sidebarTrigger.addEventListener("click", () => {
       sidebarTrigger.setAttribute("aria-expanded", "true");
+      // Set dataset flag so the intent survives if React hasn't hydrated yet
+      document.documentElement.dataset.docsSidebarOpen = "true";
       document.dispatchEvent(new CustomEvent("open-docs-sidebar"));
     });
     document.addEventListener("close-docs-sidebar", () => {

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -21,6 +21,10 @@ const allPages = docsNav.flatMap((s) => s.pages);
 const currentIdx = allPages.findIndex((p) => p.slug === slug);
 const prevPage = currentIdx > 0 ? allPages[currentIdx - 1] : null;
 const nextPage = currentIdx < allPages.length - 1 ? allPages[currentIdx + 1] : null;
+
+// Breadcrumb: link to the first page of the current section
+const sectionData = docsNav.find((s) => s.section === section);
+const sectionFirstSlug = sectionData?.pages[0]?.slug ?? "getting-started";
 ---
 
 <BaseLayout
@@ -91,11 +95,11 @@ const nextPage = currentIdx < allPages.length - 1 ? allPages[currentIdx + 1] : n
 
     <!-- Main content -->
     <main class="flex-1 min-w-0 px-6 sm:px-10 lg:px-14 py-10">
-      <div class="max-w-2xl">
+      <div class="max-w-[65ch]">
         <!-- Breadcrumb -->
         {section && (
           <nav class="flex items-center gap-2 text-sm text-muted-foreground mb-6" aria-label="Breadcrumb">
-            <a href="/docs/getting-started/" class="hover:text-foreground transition-colors">{section}</a>
+            <a href={`/docs/${sectionFirstSlug}/`} class="hover:text-foreground transition-colors">{section}</a>
             <span aria-hidden="true">›</span>
             <span class="text-foreground">{title}</span>
           </nav>
@@ -140,7 +144,7 @@ const nextPage = currentIdx < allPages.length - 1 ? allPages[currentIdx + 1] : n
     </main>
 
     <!-- ToC -->
-    <aside class="hidden xl:block w-56 shrink-0 border-l border-border">
+    <aside class="hidden xl:block w-64 shrink-0 border-l border-border">
       <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-8 px-5">
         <DocsToC headings={headings} client:load />
       </div>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -20,7 +20,7 @@ const section = getSectionForSlug(slug);
 const allPages = docsNav.flatMap((s) => s.pages);
 const currentIdx = allPages.findIndex((p) => p.slug === slug);
 const prevPage = currentIdx > 0 ? allPages[currentIdx - 1] : null;
-const nextPage = currentIdx < allPages.length - 1 ? allPages[currentIdx + 1] : null;
+const nextPage = currentIdx !== -1 && currentIdx < allPages.length - 1 ? allPages[currentIdx + 1] : null;
 
 // Breadcrumb: link to the first page of the current section
 const sectionData = docsNav.find((s) => s.section === section);

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -154,6 +154,9 @@ const sectionFirstSlug = sectionData?.pages[0]?.slug ?? "getting-started";
 <script>
   // Copy-to-clipboard buttons on all code blocks
   document.querySelectorAll<HTMLElement>(".docs-prose pre").forEach((pre) => {
+    // Skip if already processed
+    if (pre.parentElement?.classList.contains("docs-pre-wrapper")) return;
+
     const wrapper = document.createElement("div");
     wrapper.className = "docs-pre-wrapper";
     pre.parentNode?.insertBefore(wrapper, pre);
@@ -214,6 +217,8 @@ const sectionFirstSlug = sectionData?.pages[0]?.slug ?? "getting-started";
     .querySelectorAll<HTMLElement>(".docs-prose h2, .docs-prose h3")
     .forEach((heading) => {
       if (!heading.id) return;
+      // Skip if already processed
+      if (heading.querySelector(".docs-anchor")) return;
       const anchor = document.createElement("a");
       anchor.href = `#${heading.id}`;
       anchor.className = "docs-anchor";

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -38,9 +38,10 @@ const sectionFirstSlug = sectionData?.pages[0]?.slug ?? "getting-started";
       <div class="flex items-center gap-3">
         <!-- Mobile sidebar trigger -->
         <button
+          id="docs-sidebar-trigger"
           class="lg:hidden p-2 -ml-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           aria-label="Open navigation"
-          onclick="document.dispatchEvent(new CustomEvent('open-docs-sidebar'))"
+          aria-expanded="false"
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <line x1="3" y1="6" x2="21" y2="6"/>
@@ -226,5 +227,17 @@ const sectionFirstSlug = sectionData?.pages[0]?.slug ?? "getting-started";
       anchor.textContent = "#";
       heading.appendChild(anchor);
     });
+
+  // Mobile sidebar trigger — replaces inline onclick, manages aria-expanded
+  const sidebarTrigger = document.getElementById("docs-sidebar-trigger");
+  if (sidebarTrigger) {
+    sidebarTrigger.addEventListener("click", () => {
+      sidebarTrigger.setAttribute("aria-expanded", "true");
+      document.dispatchEvent(new CustomEvent("open-docs-sidebar"));
+    });
+    document.addEventListener("close-docs-sidebar", () => {
+      sidebarTrigger.setAttribute("aria-expanded", "false");
+    });
+  }
 </script>
 </BaseLayout>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -1,7 +1,7 @@
 ---
 import type { MarkdownHeading } from "astro";
 
-import { getSectionForSlug } from "../lib/docs-nav";
+import { docsNav, getSectionForSlug } from "../lib/docs-nav";
 import BaseLayout from "./BaseLayout.astro";
 import DocsSidebar from "../components/docs/DocsSidebar";
 import DocsToC from "../components/docs/DocsToC";
@@ -15,6 +15,12 @@ interface Props {
 
 const { title, description, headings, slug } = Astro.props;
 const section = getSectionForSlug(slug);
+
+// Flatten all pages for prev/next navigation
+const allPages = docsNav.flatMap((s) => s.pages);
+const currentIdx = allPages.findIndex((p) => p.slug === slug);
+const prevPage = currentIdx > 0 ? allPages[currentIdx - 1] : null;
+const nextPage = currentIdx < allPages.length - 1 ? allPages[currentIdx + 1] : null;
 ---
 
 <BaseLayout
@@ -99,6 +105,37 @@ const section = getSectionForSlug(slug);
         <article class="docs-prose">
           <slot />
         </article>
+
+        <!-- Prev / Next navigation -->
+        {(prevPage || nextPage) && (
+          <nav
+            class="flex items-center justify-between mt-12 pt-6 border-t border-border gap-4"
+            aria-label="Page navigation"
+          >
+            <div class="flex-1">
+              {prevPage && (
+                <a
+                  href={`/docs/${prevPage.slug}/`}
+                  class="group flex flex-col gap-0.5 text-sm no-underline"
+                >
+                  <span class="text-xs text-muted-foreground uppercase tracking-wider font-medium">← Previous</span>
+                  <span class="text-foreground group-hover:text-primary transition-colors font-medium">{prevPage.title}</span>
+                </a>
+              )}
+            </div>
+            <div class="flex-1 flex justify-end text-right">
+              {nextPage && (
+                <a
+                  href={`/docs/${nextPage.slug}/`}
+                  class="group flex flex-col gap-0.5 text-sm no-underline"
+                >
+                  <span class="text-xs text-muted-foreground uppercase tracking-wider font-medium">Next →</span>
+                  <span class="text-foreground group-hover:text-primary transition-colors font-medium">{nextPage.title}</span>
+                </a>
+              )}
+            </div>
+          </nav>
+        )}
       </div>
     </main>
 
@@ -109,4 +146,46 @@ const section = getSectionForSlug(slug);
       </div>
     </aside>
   </div>
+
+<script>
+  // Copy-to-clipboard buttons on all code blocks
+  document.querySelectorAll<HTMLElement>(".docs-prose pre").forEach((pre) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "docs-pre-wrapper";
+    pre.parentNode?.insertBefore(wrapper, pre);
+    wrapper.appendChild(pre);
+
+    const btn = document.createElement("button");
+    btn.textContent = "Copy";
+    btn.className = "docs-copy-btn";
+    btn.setAttribute("aria-label", "Copy code to clipboard");
+    btn.setAttribute("type", "button");
+    wrapper.appendChild(btn);
+
+    btn.addEventListener("click", () => {
+      const text = pre.textContent ?? "";
+      navigator.clipboard.writeText(text).then(() => {
+        btn.textContent = "Copied!";
+        btn.classList.add("copied");
+        setTimeout(() => {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+        }, 2000);
+      });
+    });
+  });
+
+  // Anchor links on headings
+  document
+    .querySelectorAll<HTMLElement>(".docs-prose h2, .docs-prose h3")
+    .forEach((heading) => {
+      if (!heading.id) return;
+      const anchor = document.createElement("a");
+      anchor.href = `#${heading.id}`;
+      anchor.className = "docs-anchor";
+      anchor.setAttribute("aria-label", `Link to section: ${heading.textContent}`);
+      anchor.textContent = "#";
+      heading.appendChild(anchor);
+    });
+</script>
 </BaseLayout>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -1,0 +1,112 @@
+---
+import type { MarkdownHeading } from "astro";
+
+import { getSectionForSlug } from "../lib/docs-nav";
+import BaseLayout from "./BaseLayout.astro";
+import DocsSidebar from "../components/docs/DocsSidebar";
+import DocsToC from "../components/docs/DocsToC";
+
+interface Props {
+  title: string;
+  description: string;
+  headings: MarkdownHeading[];
+  slug: string;
+}
+
+const { title, description, headings, slug } = Astro.props;
+const section = getSectionForSlug(slug);
+---
+
+<BaseLayout
+  title={`${title} — Qarote Docs`}
+  description={description}
+  canonicalPath={`/docs/${slug}/`}
+>
+  <!-- Docs Nav -->
+  <nav class="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur-sm">
+    <div class="flex items-center justify-between h-14 px-4 sm:px-6 max-w-[1400px] mx-auto">
+      <div class="flex items-center gap-3">
+        <!-- Mobile sidebar trigger -->
+        <button
+          class="lg:hidden p-2 -ml-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          aria-label="Open navigation"
+          onclick="document.dispatchEvent(new CustomEvent('open-docs-sidebar'))"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="3" y1="6" x2="21" y2="6"/>
+            <line x1="3" y1="12" x2="21" y2="12"/>
+            <line x1="3" y1="18" x2="21" y2="18"/>
+          </svg>
+        </button>
+
+        <a href="/" class="flex items-center gap-1.5 shrink-0">
+          <img src="/images/new_icon.svg" alt="" width={22} height={22} class="w-[22px] h-[22px]" aria-hidden="true" />
+          <span class="font-display font-normal text-[1.1rem] leading-none">Qarote</span>
+        </a>
+
+        <span class="text-border text-xl select-none hidden sm:block" aria-hidden="true">/</span>
+        <span class="text-sm font-medium text-muted-foreground hidden sm:block">Docs</span>
+      </div>
+
+      <div class="flex items-center gap-4">
+        <a
+          href="/"
+          class="text-sm text-muted-foreground hover:text-foreground transition-colors hidden sm:flex items-center gap-1.5"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="15 18 9 12 15 6"/>
+          </svg>
+          Back to site
+        </a>
+        <a
+          href="https://github.com/getqarote/Qarote"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="View on GitHub"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Docs Body -->
+  <div class="max-w-[1400px] mx-auto flex min-h-[calc(100vh-3.5rem)]">
+
+    <!-- Desktop Sidebar -->
+    <aside class="hidden lg:block w-60 shrink-0 border-r border-border">
+      <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-8 px-4">
+        <DocsSidebar currentSlug={slug} client:load />
+      </div>
+    </aside>
+
+    <!-- Main content -->
+    <main class="flex-1 min-w-0 px-6 sm:px-10 lg:px-14 py-10">
+      <div class="max-w-2xl">
+        <!-- Breadcrumb -->
+        {section && (
+          <nav class="flex items-center gap-2 text-sm text-muted-foreground mb-6" aria-label="Breadcrumb">
+            <a href="/docs/getting-started/" class="hover:text-foreground transition-colors">{section}</a>
+            <span aria-hidden="true">›</span>
+            <span class="text-foreground">{title}</span>
+          </nav>
+        )}
+
+        <!-- Content -->
+        <article class="docs-prose">
+          <slot />
+        </article>
+      </div>
+    </main>
+
+    <!-- ToC -->
+    <aside class="hidden xl:block w-56 shrink-0 border-l border-border">
+      <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-8 px-5">
+        <DocsToC headings={headings} client:load />
+      </div>
+    </aside>
+  </div>
+</BaseLayout>

--- a/apps/web/src/lib/docs-nav.ts
+++ b/apps/web/src/lib/docs-nav.ts
@@ -14,6 +14,10 @@ export const docsNav: DocsSection[] = [
     pages: [{ title: "Introduction", slug: "getting-started" }],
   },
   {
+    section: "Self-Hosted",
+    pages: [{ title: "Deploying Qarote", slug: "self-hosted/deployment" }],
+  },
+  {
     section: "Queues",
     pages: [{ title: "Spy on live queues", slug: "queues/spy-on-live-queues" }],
   },

--- a/apps/web/src/lib/docs-nav.ts
+++ b/apps/web/src/lib/docs-nav.ts
@@ -1,0 +1,37 @@
+export interface DocsPage {
+  title: string;
+  slug: string;
+}
+
+export interface DocsSection {
+  section: string;
+  pages: DocsPage[];
+}
+
+export const docsNav: DocsSection[] = [
+  {
+    section: "Getting started",
+    pages: [{ title: "Introduction", slug: "getting-started" }],
+  },
+  {
+    section: "Queues",
+    pages: [{ title: "Spy on live queues", slug: "queues/spy-on-live-queues" }],
+  },
+  {
+    section: "Security & Privacy",
+    pages: [{ title: "Security and privacy", slug: "security-and-privacy" }],
+  },
+];
+
+export function getFirstDocSlug(): string {
+  return docsNav[0].pages[0].slug;
+}
+
+export function getSectionForSlug(slug: string): string | undefined {
+  for (const section of docsNav) {
+    if (section.pages.some((p) => p.slug === slug)) {
+      return section.section;
+    }
+  }
+  return undefined;
+}

--- a/apps/web/src/lib/docs-nav.ts
+++ b/apps/web/src/lib/docs-nav.ts
@@ -1,9 +1,9 @@
-interface DocsPage {
+export interface DocsPage {
   title: string;
   slug: string;
 }
 
-interface DocsSection {
+export interface DocsSection {
   section: string;
   pages: DocsPage[];
 }
@@ -28,7 +28,13 @@ export const docsNav: DocsSection[] = [
 ];
 
 export function getFirstDocSlug(): string {
-  return docsNav[0].pages[0].slug;
+  const firstPage = docsNav[0]?.pages[0];
+  if (!firstPage) {
+    throw new Error(
+      "docs-nav: docsNav must contain at least one section with one page"
+    );
+  }
+  return firstPage.slug;
 }
 
 export function getSectionForSlug(slug: string): string | undefined {

--- a/apps/web/src/lib/docs-nav.ts
+++ b/apps/web/src/lib/docs-nav.ts
@@ -1,9 +1,9 @@
-export interface DocsPage {
+interface DocsPage {
   title: string;
   slug: string;
 }
 
-export interface DocsSection {
+interface DocsSection {
   section: string;
   pages: DocsPage[];
 }

--- a/apps/web/src/pages/docs/[...slug].astro
+++ b/apps/web/src/pages/docs/[...slug].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection, render } from "astro:content";
+import { type CollectionEntry, getCollection, render } from "astro:content";
 
 import { Callout } from "../../components/docs/DocsCallout";
 import DocsLayout from "../../layouts/DocsLayout.astro";
@@ -12,7 +12,11 @@ export async function getStaticPaths() {
   }));
 }
 
-const { entry } = Astro.props;
+interface Props {
+  entry: CollectionEntry<"docs">;
+}
+
+const { entry } = Astro.props as Props;
 const { Content, headings } = await render(entry);
 
 const slug = entry.id;

--- a/apps/web/src/pages/docs/[...slug].astro
+++ b/apps/web/src/pages/docs/[...slug].astro
@@ -1,0 +1,28 @@
+---
+import { getCollection, render } from "astro:content";
+
+import { Callout } from "../../components/docs/DocsCallout";
+import DocsLayout from "../../layouts/DocsLayout.astro";
+
+export async function getStaticPaths() {
+  const docs = await getCollection("docs");
+  return docs.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content, headings } = await render(entry);
+
+const slug = entry.id;
+---
+
+<DocsLayout
+  title={entry.data.title}
+  description={entry.data.description}
+  headings={headings}
+  slug={slug}
+>
+  <Content components={{ Callout }} />
+</DocsLayout>

--- a/apps/web/src/pages/docs/index.astro
+++ b/apps/web/src/pages/docs/index.astro
@@ -1,5 +1,5 @@
 ---
 import { getFirstDocSlug } from "../../lib/docs-nav";
 
-return Astro.redirect(`/docs/${getFirstDocSlug()}/`, 301);
+return Astro.redirect(`/docs/${getFirstDocSlug()}/`, 302);
 ---

--- a/apps/web/src/pages/docs/index.astro
+++ b/apps/web/src/pages/docs/index.astro
@@ -1,0 +1,5 @@
+---
+import { getFirstDocSlug } from "../../lib/docs-nav";
+
+return Astro.redirect(`/docs/${getFirstDocSlug()}/`, 301);
+---

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -371,11 +371,11 @@
 
 .docs-prose h3 {
   font-family: var(--font-display);
-  font-size: 0.9375rem;
+  font-size: 1.0625rem;
   font-weight: 500;
   line-height: 1.4;
   margin-top: 1.75rem;
-  margin-bottom: 0.375rem;
+  margin-bottom: 0.5rem;
   color: hsl(var(--foreground));
   scroll-margin-top: 5rem;
   position: relative;
@@ -465,18 +465,13 @@
   color: hsl(var(--foreground)) !important;
 }
 
-/* Override shiki theme colors so text is always readable on our background */
+/* Preserve Shiki token colors — only reset layout properties */
 .docs-prose pre code {
   background: none !important;
   border: none !important;
   padding: 0 !important;
   font-family: var(--font-mono);
   font-size: inherit;
-  color: inherit !important;
-}
-
-.docs-prose pre code span {
-  color: inherit !important;
 }
 
 /* Tables — square borders, matches feature comparison table style */
@@ -516,7 +511,6 @@
 .docs-prose td:first-child {
   font-weight: 500;
   color: hsl(var(--foreground));
-  font-family: var(--font-mono);
   font-size: 0.9375rem;
 }
 

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -425,7 +425,7 @@
   top: 0.6em;
   width: 0.375rem;
   height: 0.375rem;
-  background-color: hsl(var(--primary) / 0.6);
+  background-color: hsl(var(--primary) / 60%);
   flex-shrink: 0;
 }
 
@@ -447,7 +447,7 @@
 .docs-prose :not(pre) > code {
   font-family: var(--font-mono);
   font-size: 0.84em;
-  background-color: hsl(var(--muted) / 0.5);
+  background-color: hsl(var(--muted) / 50%);
   color: hsl(var(--foreground));
   border: 1px solid hsl(var(--border));
   padding: 0.1em 0.35em;
@@ -455,7 +455,7 @@
 
 /* Code blocks — square border, bg-muted/30 matching feature card style */
 .docs-prose pre {
-  background-color: hsl(var(--muted) / 0.5) !important;
+  background-color: hsl(var(--muted) / 50%) !important;
   border: 1px solid hsl(var(--border));
   padding: 1rem 1.25rem;
   overflow-x: auto;
@@ -484,7 +484,7 @@
 }
 
 .docs-prose thead {
-  background-color: hsl(var(--muted) / 0.3);
+  background-color: hsl(var(--muted) / 30%);
   border-bottom: 1px solid hsl(var(--border));
 }
 
@@ -554,7 +554,7 @@
   font-family: var(--font-sans);
   font-weight: 500;
   color: hsl(var(--muted-foreground));
-  background-color: hsl(var(--muted) / 0.5);
+  background-color: hsl(var(--muted) / 50%);
   border: 1px solid hsl(var(--border));
   cursor: pointer;
   opacity: 0;

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -455,21 +455,28 @@
 
 /* Code blocks — square border, bg-muted/30 matching feature card style */
 .docs-prose pre {
-  background-color: hsl(var(--muted) / 0.3) !important;
+  background-color: hsl(var(--muted) / 0.5) !important;
   border: 1px solid hsl(var(--border));
   padding: 1rem 1.25rem;
   overflow-x: auto;
   margin-bottom: 1.5rem;
   font-size: 0.875rem;
   line-height: 1.7;
+  color: hsl(var(--foreground)) !important;
 }
 
+/* Override shiki theme colors so text is always readable on our background */
 .docs-prose pre code {
   background: none !important;
   border: none !important;
   padding: 0 !important;
   font-family: var(--font-mono);
   font-size: inherit;
+  color: inherit !important;
+}
+
+.docs-prose pre code span {
+  color: inherit !important;
 }
 
 /* Tables — square borders, matches feature comparison table style */

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -360,23 +360,25 @@
 .docs-prose h2 {
   font-family: var(--font-display);
   font-size: 1.25rem;
-  font-weight: 400;
+  font-weight: 500;
   line-height: 1.3;
   margin-top: 2.5rem;
   margin-bottom: 0.75rem;
   color: hsl(var(--foreground));
   scroll-margin-top: 5rem;
+  position: relative;
 }
 
 .docs-prose h3 {
   font-family: var(--font-display);
-  font-size: 1rem;
-  font-weight: 400;
+  font-size: 0.9375rem;
+  font-weight: 500;
   line-height: 1.4;
-  margin-top: 2rem;
-  margin-bottom: 0.5rem;
+  margin-top: 1.75rem;
+  margin-bottom: 0.375rem;
   color: hsl(var(--foreground));
   scroll-margin-top: 5rem;
+  position: relative;
 }
 
 .docs-prose p {
@@ -475,7 +477,7 @@
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1.5rem;
-  font-size: 0.9rem;
+  font-size: 0.9375rem;
   border: 1px solid hsl(var(--border));
 }
 
@@ -508,7 +510,65 @@
   font-weight: 500;
   color: hsl(var(--foreground));
   font-family: var(--font-mono);
-  font-size: 0.84em;
+  font-size: 0.9375rem;
+}
+
+/* Anchor links on headings — appear on hover */
+.docs-prose h2 .docs-anchor,
+.docs-prose h3 .docs-anchor {
+  display: inline-block;
+  margin-left: 0.4em;
+  opacity: 0;
+  color: hsl(var(--muted-foreground));
+  text-decoration: none;
+  font-weight: 400;
+  font-size: 0.875em;
+  transition: opacity 0.15s;
+  user-select: none;
+}
+.docs-prose h2:hover .docs-anchor,
+.docs-prose h3:hover .docs-anchor {
+  opacity: 1;
+}
+.docs-prose h2 .docs-anchor:hover,
+.docs-prose h3 .docs-anchor:hover {
+  color: hsl(var(--primary));
+  opacity: 1;
+}
+
+/* Copy button on code blocks */
+.docs-pre-wrapper {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+.docs-pre-wrapper pre {
+  margin-bottom: 0;
+}
+.docs-copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  background-color: hsl(var(--muted) / 0.5);
+  border: 1px solid hsl(var(--border));
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+  line-height: 1.5;
+}
+.docs-pre-wrapper:hover .docs-copy-btn {
+  opacity: 1;
+}
+.docs-copy-btn:hover {
+  color: hsl(var(--foreground));
+}
+.docs-copy-btn.copied {
+  color: hsl(var(--primary));
+  opacity: 1;
 }
 
 /* Blockquote */

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -335,8 +335,15 @@
 }
 
 /* ─── Docs prose ──────────────────────────────────────────────────────────── */
+/* Strictly follows the landing/features page design system:
+   - font-normal headings (display font, no heavy weight)
+   - text-muted-foreground body text
+   - square borders (no border-radius)
+   - bg-muted/30 for subtle fills
+   - primary accent for bullets and highlights
+*/
 .docs-prose {
-  color: hsl(var(--foreground));
+  color: hsl(var(--muted-foreground));
   font-size: 0.9375rem;
   line-height: 1.75;
 }
@@ -344,7 +351,7 @@
 .docs-prose h1 {
   font-family: var(--font-display);
   font-size: 2rem;
-  font-weight: 700;
+  font-weight: 400;
   line-height: 1.2;
   margin-bottom: 1.5rem;
   color: hsl(var(--foreground));
@@ -353,7 +360,7 @@
 .docs-prose h2 {
   font-family: var(--font-display);
   font-size: 1.25rem;
-  font-weight: 600;
+  font-weight: 400;
   line-height: 1.3;
   margin-top: 2.5rem;
   margin-bottom: 0.75rem;
@@ -363,8 +370,8 @@
 
 .docs-prose h3 {
   font-family: var(--font-display);
-  font-size: 1.05rem;
-  font-weight: 600;
+  font-size: 1rem;
+  font-weight: 400;
   line-height: 1.4;
   margin-top: 2rem;
   margin-bottom: 0.5rem;
@@ -389,7 +396,7 @@
 }
 
 .docs-prose strong {
-  font-weight: 600;
+  font-weight: 500;
   color: hsl(var(--foreground));
 }
 
@@ -397,10 +404,27 @@
   font-style: italic;
 }
 
+/* Lists — square primary bullet, matches changelog list style */
 .docs-prose ul {
-  list-style-type: disc;
-  padding-left: 1.5rem;
+  list-style: none;
+  padding-left: 1.25rem;
   margin-bottom: 1.25rem;
+}
+
+.docs-prose ul > li {
+  position: relative;
+  margin-bottom: 0.4rem;
+}
+
+.docs-prose ul > li::before {
+  content: "";
+  position: absolute;
+  left: -1.25rem;
+  top: 0.6em;
+  width: 0.375rem;
+  height: 0.375rem;
+  background-color: hsl(var(--primary) / 0.6);
+  flex-shrink: 0;
 }
 
 .docs-prose ol {
@@ -417,22 +441,20 @@
   margin-bottom: 0.5rem;
 }
 
-/* Inline code */
+/* Inline code — matches font-mono pattern used in changelog/metrics */
 .docs-prose :not(pre) > code {
   font-family: var(--font-mono);
   font-size: 0.84em;
-  background-color: hsl(var(--muted));
+  background-color: hsl(var(--muted) / 0.5);
   color: hsl(var(--foreground));
   border: 1px solid hsl(var(--border));
-  border-radius: 4px;
   padding: 0.1em 0.35em;
 }
 
-/* Code blocks (Shiki) */
+/* Code blocks — square border, bg-muted/30 matching feature card style */
 .docs-prose pre {
-  background-color: hsl(var(--muted)) !important;
+  background-color: hsl(var(--muted) / 0.3) !important;
   border: 1px solid hsl(var(--border));
-  border-radius: 8px;
   padding: 1rem 1.25rem;
   overflow-x: auto;
   margin-bottom: 1.5rem;
@@ -448,23 +470,28 @@
   font-size: inherit;
 }
 
-/* Tables */
+/* Tables — square borders, matches feature comparison table style */
 .docs-prose table {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1.5rem;
   font-size: 0.9rem;
+  border: 1px solid hsl(var(--border));
 }
 
 .docs-prose thead {
-  border-bottom: 2px solid hsl(var(--border));
+  background-color: hsl(var(--muted) / 0.3);
+  border-bottom: 1px solid hsl(var(--border));
 }
 
 .docs-prose th {
   text-align: left;
+  font-size: 0.7rem;
   font-weight: 600;
-  padding: 0.5rem 0.75rem;
-  color: hsl(var(--foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.6rem 0.75rem;
+  color: hsl(var(--muted-foreground));
 }
 
 .docs-prose td {
@@ -480,15 +507,16 @@
 .docs-prose td:first-child {
   font-weight: 500;
   color: hsl(var(--foreground));
+  font-family: var(--font-mono);
+  font-size: 0.84em;
 }
 
 /* Blockquote */
 .docs-prose blockquote {
-  border-left: 3px solid hsl(var(--primary));
+  border-left: 2px solid hsl(var(--primary));
   padding-left: 1rem;
   margin: 1.5rem 0;
   color: hsl(var(--muted-foreground));
-  font-style: italic;
 }
 
 /* HR */

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -333,3 +333,167 @@
     cursor: not-allowed;
   }
 }
+
+/* ─── Docs prose ──────────────────────────────────────────────────────────── */
+.docs-prose {
+  color: hsl(var(--foreground));
+  font-size: 0.9375rem;
+  line-height: 1.75;
+}
+
+.docs-prose h1 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 1.5rem;
+  color: hsl(var(--foreground));
+}
+
+.docs-prose h2 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.3;
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  color: hsl(var(--foreground));
+  scroll-margin-top: 5rem;
+}
+
+.docs-prose h3 {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+  color: hsl(var(--foreground));
+  scroll-margin-top: 5rem;
+}
+
+.docs-prose p {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+}
+
+.docs-prose a {
+  color: hsl(var(--primary));
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  transition: opacity 0.15s;
+}
+.docs-prose a:hover {
+  opacity: 0.75;
+}
+
+.docs-prose strong {
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.docs-prose em {
+  font-style: italic;
+}
+
+.docs-prose ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.docs-prose ol {
+  list-style-type: decimal;
+  padding-left: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.docs-prose li {
+  margin-bottom: 0.375rem;
+}
+
+.docs-prose li > p {
+  margin-bottom: 0.5rem;
+}
+
+/* Inline code */
+.docs-prose :not(pre) > code {
+  font-family: var(--font-mono);
+  font-size: 0.84em;
+  background-color: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+}
+
+/* Code blocks (Shiki) */
+.docs-prose pre {
+  background-color: hsl(var(--muted)) !important;
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+  line-height: 1.7;
+}
+
+.docs-prose pre code {
+  background: none !important;
+  border: none !important;
+  padding: 0 !important;
+  font-family: var(--font-mono);
+  font-size: inherit;
+}
+
+/* Tables */
+.docs-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+}
+
+.docs-prose thead {
+  border-bottom: 2px solid hsl(var(--border));
+}
+
+.docs-prose th {
+  text-align: left;
+  font-weight: 600;
+  padding: 0.5rem 0.75rem;
+  color: hsl(var(--foreground));
+}
+
+.docs-prose td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+}
+
+.docs-prose tr:last-child td {
+  border-bottom: none;
+}
+
+.docs-prose td:first-child {
+  font-weight: 500;
+  color: hsl(var(--foreground));
+}
+
+/* Blockquote */
+.docs-prose blockquote {
+  border-left: 3px solid hsl(var(--primary));
+  padding-left: 1rem;
+  margin: 1.5rem 0;
+  color: hsl(var(--muted-foreground));
+  font-style: italic;
+}
+
+/* HR */
+.docs-prose hr {
+  border: none;
+  border-top: 1px solid hsl(var(--border));
+  margin: 2rem 0;
+}

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -572,6 +572,11 @@
   opacity: 1;
 }
 
+.docs-copy-btn.failed {
+  color: hsl(var(--destructive));
+  opacity: 1;
+}
+
 /* Blockquote */
 .docs-prose blockquote {
   border-left: 2px solid hsl(var(--primary));

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -426,7 +426,6 @@
   width: 0.375rem;
   height: 0.375rem;
   background-color: hsl(var(--primary) / 60%);
-  flex-shrink: 0;
 }
 
 .docs-prose ol {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -41,6 +41,9 @@ const config: KnipConfig = {
     "apps/api/src/services/plan/features.service.ts",
     // Ignore hooks used in UI components
     "apps/web/src/hooks/use-mobile.tsx",
+    // Ignore docs components/lib used by .astro layouts (Knip doesn't scan .astro files)
+    "apps/web/src/components/docs/DocsToC.tsx",
+    "apps/web/src/lib/docs-nav.ts",
     // Workspace invites hook — function temporarily unused after removing invite from creation forms
     "apps/app/src/hooks/ui/useWorkspaceInvites.ts",
     // Threshold tone helpers — small library API of related helpers; some

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -43,6 +43,7 @@ const config: KnipConfig = {
     "apps/web/src/hooks/use-mobile.tsx",
     // Ignore docs components/lib used by .astro layouts (Knip doesn't scan .astro files)
     "apps/web/src/components/docs/DocsToC.tsx",
+    "apps/web/src/components/docs/DocsSidebar.tsx",
     "apps/web/src/lib/docs-nav.ts",
     // Workspace invites hook — function temporarily unused after removing invite from creation forms
     "apps/app/src/hooks/ui/useWorkspaceInvites.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@astrojs/mdx':
+        specifier: ^4.3.14
+        version: 4.3.14(astro@6.1.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@astrojs/react':
         specifier: ^5.0.2
         version: 5.0.2(@types/node@24.11.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.2)
@@ -758,6 +761,9 @@ packages:
   '@astrojs/compiler@3.0.1':
     resolution: {integrity: sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==}
 
+  '@astrojs/internal-helpers@0.7.6':
+    resolution: {integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==}
+
   '@astrojs/internal-helpers@0.8.0':
     resolution: {integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==}
 
@@ -773,8 +779,21 @@ packages:
       prettier-plugin-astro:
         optional: true
 
+  '@astrojs/markdown-remark@6.3.11':
+    resolution: {integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==}
+
   '@astrojs/markdown-remark@7.1.0':
     resolution: {integrity: sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==}
+
+  '@astrojs/mdx@4.3.14':
+    resolution: {integrity: sha512-FBrqJQORVm+rkRa2TS5CjU9PBA6hkhrwLVBSS9A77gN2+iehvjq1w6yya/d0YKC7osiVorKkr3Qd9wNbl0ZkGA==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+    peerDependencies:
+      astro: ^5.0.0
+
+  '@astrojs/prism@3.3.0':
+    resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@astrojs/prism@4.0.1':
     resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
@@ -2360,6 +2379,9 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
   '@mongodb-js/saslprep@1.4.6':
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
@@ -4037,17 +4059,29 @@ packages:
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
 
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
   '@shikijs/engine-javascript@4.0.2':
     resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
     engines: {node: '>=20'}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
   '@shikijs/engine-oniguruma@4.0.2':
     resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
     engines: {node: '>=20'}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
   '@shikijs/langs@4.0.2':
     resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
@@ -4057,9 +4091,15 @@ packages:
     resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
     engines: {node: '>=20'}
 
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
   '@shikijs/themes@4.0.2':
     resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
     engines: {node: '>=20'}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.0.2':
     resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
@@ -4472,6 +4512,9 @@ packages:
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -4483,6 +4526,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -4842,6 +4888,10 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   astro@6.1.2:
     resolution: {integrity: sha512-r3iIvmB6JvQxsdJLvapybKKq7Bojd1iQK6CCx5P55eRnXJIyUpHx/1UB/GdMm+em/lwaCUasxHCmIO0lCLV2uA==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -5168,6 +5218,9 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -5763,6 +5816,12 @@ packages:
   es-toolkit@1.44.0:
     resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
 
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -5861,6 +5920,24 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -6218,8 +6295,14 @@ packages:
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
 
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
@@ -6406,6 +6489,9 @@ packages:
   ini@5.0.0:
     resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   inquirer@12.11.1:
     resolution: {integrity: sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==}
@@ -6906,6 +6992,10 @@ packages:
     resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
     engines: {node: '>= 10'}
 
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -6943,6 +7033,18 @@ packages:
 
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -7008,11 +7110,29 @@ packages:
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
 
   micromark-factory-label@2.0.1:
     resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
 
   micromark-factory-space@2.0.1:
     resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
@@ -7043,6 +7163,9 @@ packages:
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
 
   micromark-util-html-tag-name@2.0.1:
     resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
@@ -7897,6 +8020,20 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -7926,6 +8063,9 @@ packages:
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
 
@@ -7939,6 +8079,9 @@ packages:
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -8132,6 +8275,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
@@ -8223,6 +8369,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -8347,6 +8497,12 @@ packages:
 
   stubborn-utils@1.0.2:
     resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   stylelint-config-recommended@18.0.0:
     resolution: {integrity: sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==}
@@ -8648,6 +8804,9 @@ packages:
 
   unist-util-modify-children@4.0.0:
     resolution: {integrity: sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
@@ -9277,6 +9436,8 @@ snapshots:
 
   '@astrojs/compiler@3.0.1': {}
 
+  '@astrojs/internal-helpers@0.7.6': {}
+
   '@astrojs/internal-helpers@0.8.0':
     dependencies:
       picomatch: 4.0.4
@@ -9306,6 +9467,32 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@astrojs/markdown-remark@6.3.11':
+    dependencies:
+      '@astrojs/internal-helpers': 0.7.6
+      '@astrojs/prism': 3.3.0
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-to-text: 4.0.2
+      import-meta-resolve: 4.2.0
+      js-yaml: 4.1.1
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.2
+      shiki: 3.23.0
+      smol-toml: 1.6.0
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@astrojs/markdown-remark@7.1.0':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
@@ -9331,6 +9518,29 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@astrojs/mdx@4.3.14(astro@6.1.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))':
+    dependencies:
+      '@astrojs/markdown-remark': 6.3.11
+      '@mdx-js/mdx': 3.1.1
+      acorn: 8.16.0
+      astro: 6.1.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      es-module-lexer: 1.7.0
+      estree-util-visit: 2.0.0
+      hast-util-to-html: 9.0.5
+      piccolore: 0.1.3
+      rehype-raw: 7.0.0
+      remark-gfm: 4.0.1
+      remark-smartypants: 3.0.2
+      source-map: 0.7.6
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@astrojs/prism@3.3.0':
+    dependencies:
+      prismjs: 1.30.0
 
   '@astrojs/prism@4.0.1':
     dependencies:
@@ -10998,6 +11208,36 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
+  '@mdx-js/mdx@3.1.1':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdx': 2.0.13
+      acorn: 8.16.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.0
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.16.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@mongodb-js/saslprep@1.4.6':
     dependencies:
       sparse-bitfield: 3.0.3
@@ -12629,6 +12869,13 @@ snapshots:
       '@sentry/core': 10.42.0
       react: 19.2.4
 
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/core@4.0.2':
     dependencies:
       '@shikijs/primitive': 4.0.2
@@ -12637,16 +12884,31 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.5
+
   '@shikijs/engine-javascript@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.5
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/engine-oniguruma@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
   '@shikijs/langs@4.0.2':
     dependencies:
@@ -12658,9 +12920,18 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
   '@shikijs/themes@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   '@shikijs/types@4.0.2':
     dependencies:
@@ -13194,6 +13465,10 @@ snapshots:
 
   '@types/esrecurse@4.3.1': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
@@ -13205,6 +13480,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdx@2.0.13': {}
 
   '@types/ms@2.1.0': {}
 
@@ -13642,6 +13919,8 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
+  astring@1.9.0: {}
+
   astro@6.1.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 3.0.1
@@ -14076,6 +14355,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -14553,6 +14834,20 @@ snapshots:
 
   es-toolkit@1.44.0: {}
 
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.16.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -14770,6 +15065,35 @@ snapshots:
       estraverse: 5.3.0
 
   estraverse@5.3.0: {}
+
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
 
   estree-walker@2.0.2: {}
 
@@ -15205,6 +15529,27 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-to-estree@3.1.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -15218,6 +15563,26 @@ snapshots:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   hast-util-to-parse5@8.0.1:
     dependencies:
@@ -15422,6 +15787,8 @@ snapshots:
   ini@4.1.1: {}
 
   ini@5.0.0: {}
+
+  inline-style-parser@0.2.7: {}
 
   inquirer@12.11.1(@types/node@25.3.3):
     dependencies:
@@ -15843,6 +16210,8 @@ snapshots:
       - supports-color
     optional: true
 
+  markdown-extensions@2.0.0: {}
+
   markdown-table@3.0.4: {}
 
   marked@15.0.12: {}
@@ -15932,6 +16301,55 @@ snapshots:
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -16062,6 +16480,57 @@ snapshots:
       micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-factory-destination@2.0.1:
     dependencies:
       micromark-util-character: 2.1.1
@@ -16074,6 +16543,18 @@ snapshots:
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
 
   micromark-factory-space@2.0.1:
     dependencies:
@@ -16126,6 +16607,16 @@ snapshots:
       micromark-util-symbol: 2.0.1
 
   micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
 
   micromark-util-html-tag-name@2.0.1: {}
 
@@ -17080,6 +17571,35 @@ snapshots:
       - '@types/react'
       - redux
 
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -17116,6 +17636,14 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-raw: 9.1.0
       vfile: 6.0.3
+
+  rehype-recma@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      hast-util-to-estree: 3.1.3
+    transitivePeerDependencies:
+      - supports-color
 
   rehype-stringify@10.0.1:
     dependencies:
@@ -17168,6 +17696,13 @@ snapshots:
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17453,6 +17988,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   shiki@4.0.2:
     dependencies:
       '@shikijs/core': 4.0.2
@@ -17572,6 +18118,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
 
@@ -17695,6 +18243,14 @@ snapshots:
       stubborn-utils: 1.0.2
 
   stubborn-utils@1.0.2: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   stylelint-config-recommended@18.0.0(stylelint@17.4.0(typescript@5.9.3)):
     dependencies:
@@ -18045,6 +18601,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       array-iterate: 2.0.1
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
 
   unist-util-position@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a full documentation system to the landing site (`apps/web`) using Astro Content Collections + `@astrojs/mdx`
- 3-column docs layout: collapsible sidebar / MDX prose / scroll-aware Table of Contents
- Mobile-responsive: sidebar in Sheet drawer, ToC hidden on small screens
- Design system strictly follows the existing landing/features page patterns (font-normal headings, square borders, `bg-muted/30`, primary bullet squares, `text-muted-foreground` body)
- `<Callout>` component with info / tip / warning / danger variants

**Routes added:**
- `/docs/` → redirects to first page
- `/docs/getting-started/` — Introduction
- `/docs/security-and-privacy/` — Security & privacy
- `/docs/queues/spy-on-live-queues/` — Spy on live queues

**New files:**
- `src/content.config.ts` — Astro 6 Content Layer collection definition
- `src/lib/docs-nav.ts` — Sidebar nav config (add a page in one line)
- `src/layouts/DocsLayout.astro` — 3-column layout with breadcrumb
- `src/components/docs/DocsSidebar.tsx` — Sidebar + mobile Sheet
- `src/components/docs/DocsToC.tsx` — ToC with IntersectionObserver active tracking
- `src/components/docs/DocsCallout.tsx` — Callout block component
- `src/pages/docs/index.astro` + `[...slug].astro` — Static routes
- `src/content/docs/**/*.mdx` — 3 content pages

## Test plan

- [ ] Visit `/docs/` — should redirect to `/docs/getting-started/`
- [ ] Sidebar shows active page highlight
- [ ] ToC tracks scroll position on long pages
- [ ] Callout blocks render with correct styles
- [ ] Code blocks display in `font-mono` with square border
- [ ] Tables match the landing page table style
- [ ] Mobile: hamburger opens Sheet sidebar
- [ ] "Docs" link appears in StickyNav (desktop + mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full docs section with sidebar navigation, per-page table of contents, prev/next navigation, and a docs-specific layout with anchor links and copyable code-block buttons.
  * In-content callouts and new docs pages: Getting Started, Spy on live queues, Security & privacy.
  * “Docs” added to site navigation; docs index redirects to the first doc.

* **Chores**
  * Enabled MDX rendering and added styling scope for documentation content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->