### PR TITLE
feat(app): broker definitions export and import

### DIFF
--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -197,7 +197,9 @@
     "failedToUpdateThresholds": "Failed to update thresholds",
     "failedToGetAlertSettings": "Failed to get alert settings",
     "onlyOwnerCanUpdateAlertSettings": "Only workspace owners can update alert settings",
-    "failedToUpdateAlertSettings": "Failed to update alert settings"
+    "failedToUpdateAlertSettings": "Failed to update alert settings",
+    "failedToFetchDefinitions": "Failed to fetch broker definitions",
+    "failedToImportDefinitions": "Failed to import broker definitions"
   },
   "alerts": {
     "failedToGetRules": "Failed to get alert rules",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -198,7 +198,9 @@
     "failedToUpdateThresholds": "Error al actualizar los umbrales",
     "failedToGetAlertSettings": "Error al obtener la configuración de alertas",
     "onlyOwnerCanUpdateAlertSettings": "Solo los propietarios del espacio de trabajo pueden actualizar la configuración de alertas",
-    "failedToUpdateAlertSettings": "Error al actualizar la configuración de alertas"
+    "failedToUpdateAlertSettings": "Error al actualizar la configuración de alertas",
+    "failedToFetchDefinitions": "Error al obtener las definiciones del broker",
+    "failedToImportDefinitions": "Error al importar las definiciones del broker"
   },
   "alerts": {
     "failedToGetRules": "Error al obtener las reglas de alerta",

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -198,7 +198,9 @@
     "failedToUpdateThresholds": "Échec de la mise à jour des seuils",
     "failedToGetAlertSettings": "Échec de la récupération des paramètres d'alerte",
     "onlyOwnerCanUpdateAlertSettings": "Seuls les propriétaires de l'espace de travail peuvent modifier les paramètres d'alerte",
-    "failedToUpdateAlertSettings": "Échec de la mise à jour des paramètres d'alerte"
+    "failedToUpdateAlertSettings": "Échec de la mise à jour des paramètres d'alerte",
+    "failedToFetchDefinitions": "Échec de la récupération des définitions du broker",
+    "failedToImportDefinitions": "Échec de l'importation des définitions du broker"
   },
   "alerts": {
     "failedToGetRules": "Échec de la récupération des règles d'alerte",

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -198,7 +198,9 @@
     "failedToUpdateThresholds": "更新阈值失败",
     "failedToGetAlertSettings": "获取告警设置失败",
     "onlyOwnerCanUpdateAlertSettings": "只有工作区所有者才能更新告警设置",
-    "failedToUpdateAlertSettings": "更新告警设置失败"
+    "failedToUpdateAlertSettings": "更新告警设置失败",
+    "failedToFetchDefinitions": "获取Broker定义失败",
+    "failedToImportDefinitions": "导入Broker定义失败"
   },
   "alerts": {
     "failedToGetRules": "获取告警规则失败",

--- a/apps/api/src/core/rabbitmq/ApiClient.ts
+++ b/apps/api/src/core/rabbitmq/ApiClient.ts
@@ -1375,6 +1375,54 @@ export class RabbitMQApiClient extends RabbitMQBaseClient {
     }
   }
 
+  async getDefinitions(vhost?: string): Promise<unknown> {
+    try {
+      const endpoint = vhost
+        ? `/definitions/${encodeURIComponent(vhost)}`
+        : "/definitions";
+      logger.debug({ vhost: vhost || "all" }, "Fetching RabbitMQ definitions");
+      const definitions = await this.request<unknown>(endpoint);
+      logger.debug("RabbitMQ definitions fetched successfully");
+      return definitions;
+    } catch (error) {
+      logger.error({ error }, "Failed to fetch RabbitMQ definitions");
+
+      if (error instanceof Error) {
+        captureRabbitMQError(error, {
+          operation: "getDefinitions",
+          serverId: this.baseUrl,
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  async uploadDefinitions(definitions: unknown, vhost?: string): Promise<void> {
+    try {
+      const endpoint = vhost
+        ? `/definitions/${encodeURIComponent(vhost)}`
+        : "/definitions";
+      logger.debug({ vhost: vhost || "all" }, "Uploading RabbitMQ definitions");
+      await this.request(endpoint, {
+        method: "POST",
+        body: JSON.stringify(definitions),
+      });
+      logger.debug("RabbitMQ definitions uploaded successfully");
+    } catch (error) {
+      logger.error({ error }, "Failed to upload RabbitMQ definitions");
+
+      if (error instanceof Error) {
+        captureRabbitMQError(error, {
+          operation: "uploadDefinitions",
+          serverId: this.baseUrl,
+        });
+      }
+
+      throw error;
+    }
+  }
+
   async deleteUser(username: string): Promise<void> {
     try {
       const encodedUsername = encodeURIComponent(username);

--- a/apps/api/src/trpc/routers/rabbitmq/definitions.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/definitions.ts
@@ -1,0 +1,86 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import {
+  ServerWorkspaceInputSchema,
+  VHostOptionalQuerySchema,
+} from "@/schemas/rabbitmq";
+
+import { authorize, router } from "@/trpc/trpc";
+
+import { createRabbitMQClientFromServer, verifyServerAccess } from "./shared";
+
+import { UserRole } from "@/generated/prisma/client";
+import { te } from "@/i18n";
+
+export const definitionsRouter = router({
+  getDefinitions: authorize([UserRole.ADMIN])
+    .input(ServerWorkspaceInputSchema.merge(VHostOptionalQuerySchema))
+    .query(async ({ input, ctx }) => {
+      const { serverId, workspaceId, vhost: vhostParam } = input;
+
+      try {
+        const server = await verifyServerAccess(serverId, workspaceId);
+        if (!server) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: te(ctx.locale, "rabbitmq.serverNotFoundOrAccessDenied"),
+          });
+        }
+
+        const client = createRabbitMQClientFromServer(server);
+        const vhost = vhostParam ? decodeURIComponent(vhostParam) : undefined;
+        const definitions = await client.getDefinitions(vhost);
+
+        return definitions;
+      } catch (error) {
+        ctx.logger.error(
+          { error, serverId, workspaceId, vhost: vhostParam },
+          "Error fetching RabbitMQ definitions"
+        );
+
+        if (error instanceof TRPCError) throw error;
+
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: te(ctx.locale, "rabbitmq.failedToFetchDefinitions"),
+        });
+      }
+    }),
+
+  importDefinitions: authorize([UserRole.ADMIN])
+    .input(
+      ServerWorkspaceInputSchema.merge(VHostOptionalQuerySchema).extend({
+        definitions: z.unknown(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { serverId, workspaceId, vhost: vhostParam, definitions } = input;
+
+      try {
+        const server = await verifyServerAccess(serverId, workspaceId);
+        if (!server) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: te(ctx.locale, "rabbitmq.serverNotFoundOrAccessDenied"),
+          });
+        }
+
+        const client = createRabbitMQClientFromServer(server);
+        const vhost = vhostParam ? decodeURIComponent(vhostParam) : undefined;
+        await client.uploadDefinitions(definitions, vhost);
+      } catch (error) {
+        ctx.logger.error(
+          { error, serverId, workspaceId, vhost: vhostParam },
+          "Error importing RabbitMQ definitions"
+        );
+
+        if (error instanceof TRPCError) throw error;
+
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: te(ctx.locale, "rabbitmq.failedToImportDefinitions"),
+        });
+      }
+    }),
+});

--- a/apps/api/src/trpc/routers/rabbitmq/index.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/index.ts
@@ -1,6 +1,7 @@
 import { router } from "@/trpc/trpc";
 
 import { alertsRouter } from "./alerts";
+import { definitionsRouter } from "./definitions";
 import { infrastructureRouter } from "./infrastructure";
 import { memoryRouter } from "./memory";
 import { messagesRouter } from "./messages";
@@ -30,4 +31,5 @@ export const rabbitmqRouter = router({
   users: usersRouter,
   topology: topologyRouter,
   policies: policiesRouter,
+  definitions: definitionsRouter,
 });

--- a/apps/app/public/locales/en/definitions.json
+++ b/apps/app/public/locales/en/definitions.json
@@ -1,0 +1,31 @@
+{
+  "pageTitle": "Definitions",
+  "pageSubtitle": "Export and import broker definitions for backup or migration",
+  "noServerTitle": "Definitions",
+  "noServerDescription": "Add a RabbitMQ server connection to export or import broker definitions.",
+  "selectServerPrompt": "Please select a RabbitMQ server to manage its broker definitions",
+  "allVhosts": "All virtual hosts",
+  "export": {
+    "title": "Export definitions",
+    "description": "Download the broker configuration as a JSON file. You can scope the export to a specific virtual host.",
+    "filenameLabel": "Filename",
+    "filenamePlaceholder": "rabbit_definitions_YYYY-MM-DD",
+    "vhostLabel": "Virtual host",
+    "downloadButton": "Download broker definitions",
+    "downloading": "Downloading..."
+  },
+  "import": {
+    "title": "Import definitions",
+    "description": "Upload a broker definitions JSON file to restore or migrate configuration. Existing definitions are preserved; new entries are added and conflicts are ignored.",
+    "fileLabel": "Definitions file",
+    "vhostLabel": "Virtual host",
+    "uploadButton": "Upload broker definitions",
+    "uploading": "Uploading...",
+    "confirmTitle": "Import broker definitions?",
+    "confirmDescription": "This will merge the uploaded definitions into your broker. Existing exchanges, queues, bindings, users, and policies are preserved; only new entries are added and conflicting ones are ignored.",
+    "confirmButton": "Yes, overwrite",
+    "successMessage": "Definitions imported successfully.",
+    "errorMessage": "Failed to import definitions. Please check the file and try again.",
+    "parseError": "Invalid JSON file. Please select a valid broker definitions file."
+  }
+}

--- a/apps/app/public/locales/en/sidebar.json
+++ b/apps/app/public/locales/en/sidebar.json
@@ -9,6 +9,7 @@
   "virtualHosts": "Virtual Hosts",
   "users": "Users",
   "alerts": "Alerts",
+  "definitions": "Definitions",
   "profile": "Profile",
   "settings": "Settings",
   "license": "License",

--- a/apps/app/public/locales/es/definitions.json
+++ b/apps/app/public/locales/es/definitions.json
@@ -1,0 +1,31 @@
+{
+  "pageTitle": "Definiciones",
+  "pageSubtitle": "Exporta e importa definiciones del broker para copia de seguridad o migración",
+  "noServerTitle": "Definiciones",
+  "noServerDescription": "Agrega una conexión de servidor RabbitMQ para exportar o importar definiciones del broker.",
+  "selectServerPrompt": "Por favor selecciona un servidor RabbitMQ para gestionar sus definiciones de broker",
+  "allVhosts": "Todos los hosts virtuales",
+  "export": {
+    "title": "Exportar definiciones",
+    "description": "Descarga la configuración del broker como archivo JSON. Puedes limitar la exportación a un host virtual específico.",
+    "filenameLabel": "Nombre de archivo",
+    "filenamePlaceholder": "rabbit_definitions_AAAA-MM-DD",
+    "vhostLabel": "Host virtual",
+    "downloadButton": "Descargar definiciones del broker",
+    "downloading": "Descargando..."
+  },
+  "import": {
+    "title": "Importar definiciones",
+    "description": "Sube un archivo JSON de definiciones del broker para restaurar o migrar la configuración. Las definiciones existentes se conservan; se añaden nuevas entradas y los conflictos se ignoran.",
+    "fileLabel": "Archivo de definiciones",
+    "vhostLabel": "Host virtual",
+    "uploadButton": "Subir definiciones del broker",
+    "uploading": "Subiendo...",
+    "confirmTitle": "¿Importar definiciones del broker?",
+    "confirmDescription": "Las definiciones importadas se fusionarán en tu broker. Los intercambios, colas, enlaces, usuarios y políticas existentes se conservan; solo se añaden nuevas entradas y los conflictos se ignoran.",
+    "confirmButton": "Sí, sobrescribir",
+    "successMessage": "Definiciones importadas correctamente.",
+    "errorMessage": "Error al importar las definiciones. Por favor verifica el archivo e inténtalo de nuevo.",
+    "parseError": "Archivo JSON inválido. Por favor selecciona un archivo de definiciones de broker válido."
+  }
+}

--- a/apps/app/public/locales/es/sidebar.json
+++ b/apps/app/public/locales/es/sidebar.json
@@ -9,6 +9,7 @@
   "virtualHosts": "Hosts virtuales",
   "users": "Usuarios",
   "alerts": "Alertas",
+  "definitions": "Definiciones",
   "profile": "Perfil",
   "license": "Licencia",
   "helpSupport": "Ayuda y soporte",

--- a/apps/app/public/locales/fr/definitions.json
+++ b/apps/app/public/locales/fr/definitions.json
@@ -1,0 +1,31 @@
+{
+  "pageTitle": "Définitions",
+  "pageSubtitle": "Exportez et importez les définitions du broker pour la sauvegarde ou la migration",
+  "noServerTitle": "Définitions",
+  "noServerDescription": "Ajoutez une connexion à un serveur RabbitMQ pour exporter ou importer les définitions du broker.",
+  "selectServerPrompt": "Veuillez sélectionner un serveur RabbitMQ pour gérer ses définitions de broker",
+  "allVhosts": "Tous les hôtes virtuels",
+  "export": {
+    "title": "Exporter les définitions",
+    "description": "Téléchargez la configuration du broker sous forme de fichier JSON. Vous pouvez limiter l'export à un hôte virtuel spécifique.",
+    "filenameLabel": "Nom du fichier",
+    "filenamePlaceholder": "rabbit_definitions_AAAA-MM-JJ",
+    "vhostLabel": "Hôte virtuel",
+    "downloadButton": "Télécharger les définitions du broker",
+    "downloading": "Téléchargement..."
+  },
+  "import": {
+    "title": "Importer les définitions",
+    "description": "Importez un fichier JSON de définitions pour restaurer ou migrer la configuration. Les définitions existantes sont conservées ; les nouvelles entrées sont ajoutées et les conflits sont ignorés.",
+    "fileLabel": "Fichier de définitions",
+    "vhostLabel": "Hôte virtuel",
+    "uploadButton": "Importer les définitions du broker",
+    "uploading": "Importation...",
+    "confirmTitle": "Importer les définitions du broker ?",
+    "confirmDescription": "Les définitions importées seront fusionnées dans votre broker. Les exchanges, files d'attente, liaisons, utilisateurs et politiques existants sont conservés ; seules les nouvelles entrées sont ajoutées et les conflits sont ignorés.",
+    "confirmButton": "Oui, écraser",
+    "successMessage": "Définitions importées avec succès.",
+    "errorMessage": "Échec de l'importation des définitions. Veuillez vérifier le fichier et réessayer.",
+    "parseError": "Fichier JSON invalide. Veuillez sélectionner un fichier de définitions de broker valide."
+  }
+}

--- a/apps/app/public/locales/fr/sidebar.json
+++ b/apps/app/public/locales/fr/sidebar.json
@@ -9,6 +9,7 @@
   "virtualHosts": "Hôtes virtuels",
   "users": "Utilisateurs",
   "alerts": "Alertes",
+  "definitions": "Définitions",
   "profile": "Profil",
   "settings": "Paramètres",
   "license": "Licence",

--- a/apps/app/public/locales/zh/definitions.json
+++ b/apps/app/public/locales/zh/definitions.json
@@ -1,0 +1,31 @@
+{
+  "pageTitle": "定义",
+  "pageSubtitle": "导出和导入 Broker 定义，用于备份或迁移",
+  "noServerTitle": "定义",
+  "noServerDescription": "添加 RabbitMQ 服务器连接以导出或导入 Broker 定义。",
+  "selectServerPrompt": "请选择一个 RabbitMQ 服务器以管理其 Broker 定义",
+  "allVhosts": "所有虚拟主机",
+  "export": {
+    "title": "导出定义",
+    "description": "将 Broker 配置下载为 JSON 文件。可以将导出范围限定为特定虚拟主机。",
+    "filenameLabel": "文件名",
+    "filenamePlaceholder": "rabbit_definitions_YYYY-MM-DD",
+    "vhostLabel": "虚拟主机",
+    "downloadButton": "下载 Broker 定义",
+    "downloading": "下载中..."
+  },
+  "import": {
+    "title": "导入定义",
+    "description": "上传 Broker 定义 JSON 文件以恢复或迁移配置。现有定义将被保留，新条目将被添加，冲突项将被忽略。",
+    "fileLabel": "定义文件",
+    "vhostLabel": "虚拟主机",
+    "uploadButton": "上传 Broker 定义",
+    "uploading": "上传中...",
+    "confirmTitle": "导入 Broker 定义？",
+    "confirmDescription": "上传的定义将与您的 Broker 合并。现有的交换机、队列、绑定、用户和策略将被保留，仅添加新条目，冲突项将被忽略。",
+    "confirmButton": "确认覆盖",
+    "successMessage": "定义导入成功。",
+    "errorMessage": "导入定义失败，请检查文件后重试。",
+    "parseError": "JSON 文件无效，请选择有效的 Broker 定义文件。"
+  }
+}

--- a/apps/app/public/locales/zh/sidebar.json
+++ b/apps/app/public/locales/zh/sidebar.json
@@ -9,6 +9,7 @@
   "virtualHosts": "虚拟主机",
   "users": "用户",
   "alerts": "告警",
+  "definitions": "定义",
   "profile": "个人资料",
   "license": "许可证",
   "helpSupport": "帮助与支持",

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -107,6 +107,7 @@ const AcceptInvitation = lazy(() => import("./pages/AcceptInvitation"));
 const AcceptOrgInvitation = lazy(() => import("./pages/AcceptOrgInvitation"));
 const SSOCallback = lazy(() => import("./pages/SSOCallback"));
 const Onboarding = lazy(() => import("./pages/Onboarding"));
+const Definitions = lazy(() => import("./pages/Definitions"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const AppCore = () => (
@@ -286,6 +287,16 @@ const AppCore = () => (
                               <ProtectedRoute>
                                 <Layout>
                                   <Topology />
+                                </Layout>
+                              </ProtectedRoute>
+                            }
+                          />
+                          <Route
+                            path="/definitions"
+                            element={
+                              <ProtectedRoute>
+                                <Layout>
+                                  <Definitions />
                                 </Layout>
                               </ProtectedRoute>
                             }

--- a/apps/app/src/components/AppSidebar.tsx
+++ b/apps/app/src/components/AppSidebar.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { PixelActivity } from "@/components/ui/pixel-activity";
 import { PixelChart } from "@/components/ui/pixel-chart";
 import { PixelClock } from "@/components/ui/pixel-clock";
+import { PixelDatabase } from "@/components/ui/pixel-database";
 import { PixelFlag } from "@/components/ui/pixel-flag";
 import { PixelHelp } from "@/components/ui/pixel-help";
 import { PixelKey } from "@/components/ui/pixel-key";
@@ -85,6 +86,12 @@ const menuItems = [
     adminOnly: true,
   },
   { titleKey: "sidebar:alerts", url: "/alerts", icon: PixelFlag },
+  {
+    titleKey: "sidebar:definitions",
+    url: "/definitions",
+    icon: PixelDatabase,
+    adminOnly: true,
+  },
 ];
 
 // Helper function to shorten hostnames

--- a/apps/app/src/hooks/queries/useDefinitions.ts
+++ b/apps/app/src/hooks/queries/useDefinitions.ts
@@ -1,0 +1,67 @@
+import { trpc } from "@/lib/trpc/client";
+
+import { useWorkspace } from "../ui/useWorkspace";
+
+/**
+ * Definitions hooks
+ * Handles broker definitions export and import
+ */
+
+export const useExportDefinitions = (
+  serverId: string | null,
+  vhost?: string | null,
+  serverExists: boolean = true
+) => {
+  const { workspace } = useWorkspace();
+
+  const query = trpc.rabbitmq.definitions.getDefinitions.useQuery(
+    {
+      serverId: serverId || "",
+      workspaceId: workspace?.id || "",
+      vhost: vhost ? encodeURIComponent(vhost) : undefined,
+    },
+    {
+      enabled: !!serverId && !!workspace?.id && serverExists,
+      staleTime: 0,
+      retry: false,
+    }
+  );
+
+  return query;
+};
+
+export const useImportDefinitions = () => {
+  const utils = trpc.useUtils();
+
+  const mutation = trpc.rabbitmq.definitions.importDefinitions.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.rabbitmq.users.getUsers.invalidate(),
+        utils.rabbitmq.vhost.getVHosts.invalidate(),
+        utils.rabbitmq.infrastructure.getExchanges.invalidate(),
+        utils.rabbitmq.queues.getQueues.invalidate(),
+        utils.rabbitmq.policies.getPolicies.invalidate(),
+      ]);
+    },
+  });
+
+  const mutate: typeof mutation.mutate = (input, options) =>
+    mutation.mutate(
+      {
+        ...input,
+        vhost: input.vhost ? encodeURIComponent(input.vhost) : undefined,
+      },
+      options
+    );
+
+  const mutateAsync: typeof mutation.mutateAsync = (input, options) =>
+    mutation.mutateAsync(
+      {
+        ...input,
+        vhost: input.vhost ? encodeURIComponent(input.vhost) : undefined,
+      },
+      options
+    );
+
+  return { ...mutation, mutate, mutateAsync };
+};

--- a/apps/app/src/i18n.ts
+++ b/apps/app/src/i18n.ts
@@ -24,6 +24,7 @@ const i18n = createI18nInstance({
     "smtp",
     "topology",
     "onboarding",
+    "definitions",
   ],
   defaultNamespace: "common",
   loadPath: "/locales/{{lng}}/{{ns}}.json",

--- a/apps/app/src/pages/Definitions.tsx
+++ b/apps/app/src/pages/Definitions.tsx
@@ -1,0 +1,343 @@
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Download, Upload } from "lucide-react";
+
+import { NoServerConfigured } from "@/components/NoServerConfigured";
+import { PageError } from "@/components/PageError";
+import { NoServerSelectedCard, PageShell } from "@/components/PageShell";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+import { useServerContext } from "@/contexts/ServerContext";
+import { useVHostContext } from "@/contexts/VHostContextDefinition";
+
+import {
+  useExportDefinitions,
+  useImportDefinitions,
+} from "@/hooks/queries/useDefinitions";
+import { useToast } from "@/hooks/ui/useToast";
+import { useWorkspace } from "@/hooks/ui/useWorkspace";
+
+const ALL_VHOSTS_VALUE = "__all__";
+
+const Definitions = () => {
+  const { t } = useTranslation("definitions");
+  const { toast } = useToast();
+  const { workspace } = useWorkspace();
+  const { selectedServerId, hasServers } = useServerContext();
+  const { availableVHosts } = useVHostContext();
+
+  // --- Export state ---
+  const today = (() => {
+    const d = new Date();
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return `${yyyy}-${mm}-${dd}`;
+  })();
+  const [exportFilename, setExportFilename] = useState(
+    `rabbit_definitions_${today}`
+  );
+  const [exportVhost, setExportVhost] = useState<string>(ALL_VHOSTS_VALUE);
+
+  const vhostForExport =
+    exportVhost === ALL_VHOSTS_VALUE ? undefined : exportVhost;
+
+  const {
+    refetch: fetchDefinitions,
+    isFetching: isExporting,
+    error: exportError,
+  } = useExportDefinitions(selectedServerId, vhostForExport);
+
+  const handleExport = async () => {
+    const result = await fetchDefinitions();
+    if (!result.data) return;
+
+    const blob = new Blob([JSON.stringify(result.data, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = exportFilename.endsWith(".json")
+      ? exportFilename
+      : `${exportFilename}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  // --- Import state ---
+  const [importVhost, setImportVhost] = useState<string>(ALL_VHOSTS_VALUE);
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const importMutation = useImportDefinitions();
+
+  const vhostForImport =
+    importVhost === ALL_VHOSTS_VALUE ? undefined : importVhost;
+
+  const handleImportConfirm = async () => {
+    if (!importFile || !selectedServerId) return;
+
+    importMutation.reset();
+    setShowConfirmDialog(false);
+
+    const text = await importFile.text();
+    let definitions: unknown;
+    try {
+      definitions = JSON.parse(text);
+    } catch {
+      toast({
+        title: t("common:error"),
+        description: t("import.parseError"),
+        variant: "destructive",
+      });
+      return;
+    }
+
+    importMutation.mutate({
+      serverId: selectedServerId,
+      workspaceId: workspace?.id ?? "",
+      vhost: vhostForImport,
+      definitions,
+    });
+  };
+
+  if (!hasServers) {
+    return (
+      <PageShell bare>
+        <div className="flex items-center gap-4">
+          <SidebarTrigger />
+        </div>
+        <NoServerConfigured
+          title={t("noServerTitle")}
+          subtitle={t("pageSubtitle")}
+          description={t("noServerDescription")}
+        />
+      </PageShell>
+    );
+  }
+
+  if (!selectedServerId) {
+    return (
+      <PageShell>
+        <NoServerSelectedCard
+          title={t("pageTitle")}
+          subtitle={t("pageSubtitle")}
+          heading={t("noServerTitle")}
+          description={t("selectServerPrompt")}
+        />
+      </PageShell>
+    );
+  }
+
+  if (exportError) {
+    return (
+      <PageShell>
+        <div className="flex items-center gap-4">
+          <SidebarTrigger />
+          <div>
+            <h1 className="title-page">{t("pageTitle")}</h1>
+          </div>
+        </div>
+        <PageError message={t("common:serverConnectionError")} />
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell>
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <SidebarTrigger />
+        <div>
+          <h1 className="title-page">{t("pageTitle")}</h1>
+          <p className="text-muted-foreground text-sm">{t("pageSubtitle")}</p>
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* Export Card */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Download
+                className="h-4 w-4 text-muted-foreground"
+                aria-hidden="true"
+              />
+              {t("export.title")}
+            </CardTitle>
+            <CardDescription>{t("export.description")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="export-filename">
+                {t("export.filenameLabel")}
+              </Label>
+              <Input
+                id="export-filename"
+                value={exportFilename}
+                onChange={(e) => setExportFilename(e.target.value)}
+                placeholder={t("export.filenamePlaceholder")}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="export-vhost">{t("export.vhostLabel")}</Label>
+              <Select value={exportVhost} onValueChange={setExportVhost}>
+                <SelectTrigger id="export-vhost">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL_VHOSTS_VALUE}>
+                    {t("allVhosts")}
+                  </SelectItem>
+                  {availableVHosts.map((vhost) => (
+                    <SelectItem key={vhost.name} value={vhost.name}>
+                      {vhost.name === "/" ? t("common:default") : vhost.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <Button
+              onClick={handleExport}
+              disabled={isExporting || !exportFilename.trim()}
+              className="w-full"
+            >
+              <Download className="h-4 w-4" aria-hidden="true" />
+              {isExporting
+                ? t("export.downloading")
+                : t("export.downloadButton")}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {/* Import Card */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Upload
+                className="h-4 w-4 text-muted-foreground"
+                aria-hidden="true"
+              />
+              {t("import.title")}
+            </CardTitle>
+            <CardDescription>{t("import.description")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="import-file">{t("import.fileLabel")}</Label>
+              <Input
+                id="import-file"
+                ref={fileInputRef}
+                type="file"
+                accept=".json"
+                onChange={(e) => {
+                  setImportFile(e.target.files?.[0] ?? null);
+                  importMutation.reset();
+                }}
+                className="cursor-pointer"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="import-vhost">{t("import.vhostLabel")}</Label>
+              <Select value={importVhost} onValueChange={setImportVhost}>
+                <SelectTrigger id="import-vhost">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL_VHOSTS_VALUE}>
+                    {t("allVhosts")}
+                  </SelectItem>
+                  {availableVHosts.map((vhost) => (
+                    <SelectItem key={vhost.name} value={vhost.name}>
+                      {vhost.name === "/" ? t("common:default") : vhost.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {importMutation.isSuccess && (
+              <p className="text-sm text-green-600 dark:text-green-400">
+                {t("import.successMessage")}
+              </p>
+            )}
+
+            {importMutation.isError && (
+              <p className="text-sm text-destructive">
+                {t("import.errorMessage")}
+              </p>
+            )}
+
+            <Button
+              variant="destructive-outline"
+              onClick={() => setShowConfirmDialog(true)}
+              disabled={!importFile || importMutation.isPending}
+              className="w-full"
+            >
+              <Upload className="h-4 w-4" aria-hidden="true" />
+              {importMutation.isPending
+                ? t("import.uploading")
+                : t("import.uploadButton")}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Import confirmation dialog */}
+      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("import.confirmTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("import.confirmDescription")}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowConfirmDialog(false)}
+            >
+              {t("common:cancel")}
+            </Button>
+            <Button variant="destructive" onClick={handleImportConfirm}>
+              {t("import.confirmButton")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageShell>
+  );
+};
+
+export default Definitions;

--- a/apps/e2e/tests/rabbitmq/definitions.spec.ts
+++ b/apps/e2e/tests/rabbitmq/definitions.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect } from "../../fixtures/test-base.js";
+import { mockTrpcQuery } from "../../helpers/trpc-mock.js";
+
+const MOCK_DEFINITIONS = {
+  rabbit_version: "3.13.0",
+  rabbitmq_version: "3.13.0",
+  users: [{ name: "guest", password_hash: "abc123", tags: "administrator" }],
+  vhosts: [{ name: "/" }],
+  queues: [],
+  exchanges: [],
+  bindings: [],
+  policies: [],
+};
+
+test.describe("Definitions Page @p0", () => {
+  test("should navigate to definitions page as admin", async ({
+    adminPage,
+  }) => {
+    await adminPage.goto("/definitions");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    await expect(adminPage).toHaveURL(/\/definitions/);
+  });
+
+  test("should show no-server state when not connected", async ({
+    adminPage,
+  }) => {
+    await adminPage.goto("/definitions");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    await expect(
+      adminPage.getByText(/no rabbitmq server configured/i)
+    ).toBeVisible({ timeout: 15_000 });
+  });
+});
+
+test.describe("Definitions Export @p1", () => {
+  test("should show export card with download button", async ({
+    adminPage,
+  }) => {
+    await mockTrpcQuery(
+      adminPage,
+      "rabbitmq.definitions.getDefinitions",
+      MOCK_DEFINITIONS
+    );
+
+    await adminPage.goto("/definitions");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    await expect(
+      adminPage.getByRole("button", { name: /download broker definitions/i })
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("should show filename input pre-filled with today's date", async ({
+    adminPage,
+  }) => {
+    await adminPage.goto("/definitions");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, "0");
+    const dd = String(today.getDate()).padStart(2, "0");
+    const expectedDate = `${yyyy}-${mm}-${dd}`;
+
+    await expect(
+      adminPage.getByRole("textbox", { name: /filename/i })
+    ).toHaveValue(new RegExp(expectedDate), { timeout: 15_000 });
+  });
+});
+
+test.describe("Definitions Import @p1", () => {
+  test("should show import card with file input and upload button", async ({
+    adminPage,
+  }) => {
+    await adminPage.goto("/definitions");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    await expect(adminPage.locator('input[type="file"]')).toBeAttached({
+      timeout: 15_000,
+    });
+    await expect(
+      adminPage.getByRole("button", { name: /upload broker definitions/i })
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("upload button should be disabled until a file is chosen", async ({
+    adminPage,
+  }) => {
+    await adminPage.goto("/definitions");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    await expect(
+      adminPage.getByRole("button", { name: /upload broker definitions/i })
+    ).toBeDisabled({ timeout: 15_000 });
+  });
+
+  test("should show confirmation dialog before importing", async ({
+    adminPage,
+  }) => {
+    await adminPage.goto("/definitions");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    const definitionsJson = JSON.stringify(MOCK_DEFINITIONS);
+    const fileInput = adminPage.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: "definitions.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(definitionsJson),
+    });
+
+    await adminPage
+      .getByRole("button", { name: /upload broker definitions/i })
+      .click();
+
+    await expect(
+      adminPage.getByRole("dialog")
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      adminPage.getByRole("button", { name: /yes|confirm|import|overwrite/i })
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("should dismiss confirmation dialog on cancel", async ({
+    adminPage,
+  }) => {
+    await adminPage.goto("/definitions");
+    await adminPage.waitForLoadState("domcontentloaded");
+
+    const fileInput = adminPage.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: "definitions.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(JSON.stringify(MOCK_DEFINITIONS)),
+    });
+
+    await adminPage
+      .getByRole("button", { name: /upload broker definitions/i })
+      .click();
+
+    await adminPage.getByRole("button", { name: /cancel/i }).click();
+
+    await expect(adminPage.getByRole("dialog")).not.toBeVisible({
+      timeout: 5_000,
+    });
+  });
+});
+
+test.describe("Definitions Access Control @p1", () => {
+  test("should not show definitions link in sidebar for non-admin", async ({
+    readonlyPage,
+  }) => {
+    await readonlyPage.goto("/");
+    await readonlyPage.waitForLoadState("domcontentloaded");
+
+    await expect(
+      readonlyPage.getByRole("link", { name: /definitions/i })
+    ).not.toBeVisible({ timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **Export definitions** — downloads full broker config as JSON, optionally scoped to a vhost
- Adds **Import definitions** — uploads a definitions JSON file with a destructive-action confirmation dialog
- Both features are free (no feature gate)

## Changes

**Backend**
- `ApiClient`: `getDefinitions()` + `uploadDefinitions()` via RabbitMQ `GET/POST /api/definitions`
- New `definitionsRouter` with `getDefinitions` query and `importDefinitions` mutation
- Error i18n keys added to all 4 locale files (en/fr/es/zh)

**Frontend**
- `/definitions` page with export card + import card
- `useDefinitions` hook (`useExportDefinitions` + `useImportDefinitions`)
- Route, sidebar nav entry, `definitions` i18n namespace (en/fr/es/zh)

## Test plan

- [ ] Export: select vhost or All, click Download, verify `.json` file downloads
- [ ] Import: pick a JSON file, click Upload, confirm dialog appears, confirm triggers import
- [ ] Sidebar nav item navigates to `/definitions`
- [ ] No server selected → shows empty state
- [ ] `pnpm type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Definitions page for exporting and importing RabbitMQ broker definitions as JSON files with virtual host selection capabilities.
  * Added "Definitions" navigation item to the sidebar menu.
  * Extended multi-language support with Spanish, French, and Chinese translations for the new Definitions feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->