### PR TITLE
feat(app): inline cluster name editing on Nodes page

### DIFF
--- a/apps/api/locales/en/errors.json
+++ b/apps/api/locales/en/errors.json
@@ -145,6 +145,7 @@
     "failedToDeleteServer": "Failed to delete server",
     "connectionFailed": "Connection failed",
     "failedToFetchOverview": "Failed to fetch server overview",
+    "failedToSetClusterName": "Failed to update cluster name",
     "serverWorkspaceNotFound": "Server workspace not found",
     "failedToFetchQueues": "Failed to fetch queues",
     "failedToFetchQueue": "Failed to fetch queue",

--- a/apps/api/locales/es/errors.json
+++ b/apps/api/locales/es/errors.json
@@ -146,6 +146,7 @@
     "failedToDeleteServer": "Error al eliminar el servidor",
     "connectionFailed": "Error de conexión",
     "failedToFetchOverview": "Error al obtener la descripción general del servidor",
+    "failedToSetClusterName": "Error al actualizar el nombre del clúster",
     "serverWorkspaceNotFound": "Espacio de trabajo del servidor no encontrado",
     "failedToFetchQueues": "Error al obtener las colas",
     "failedToFetchQueue": "Error al obtener la cola",

--- a/apps/api/locales/fr/errors.json
+++ b/apps/api/locales/fr/errors.json
@@ -146,6 +146,7 @@
     "failedToDeleteServer": "Échec de la suppression du serveur",
     "connectionFailed": "Échec de la connexion",
     "failedToFetchOverview": "Échec de la récupération de l'aperçu du serveur",
+    "failedToSetClusterName": "Échec de la mise à jour du nom du cluster",
     "serverWorkspaceNotFound": "Espace de travail du serveur introuvable",
     "failedToFetchQueues": "Échec de la récupération des files d'attente",
     "failedToFetchQueue": "Échec de la récupération de la file d'attente",

--- a/apps/api/locales/zh/errors.json
+++ b/apps/api/locales/zh/errors.json
@@ -146,6 +146,7 @@
     "failedToDeleteServer": "删除服务器失败",
     "connectionFailed": "连接失败",
     "failedToFetchOverview": "获取服务器概览失败",
+    "failedToSetClusterName": "更新集群名称失败",
     "serverWorkspaceNotFound": "未找到服务器工作区",
     "failedToFetchQueues": "获取队列列表失败",
     "failedToFetchQueue": "获取队列信息失败",

--- a/apps/api/src/core/rabbitmq/ApiClient.ts
+++ b/apps/api/src/core/rabbitmq/ApiClient.ts
@@ -1168,6 +1168,26 @@ export class RabbitMQApiClient extends RabbitMQBaseClient {
     }
   }
 
+  async setClusterName(name: string): Promise<void> {
+    try {
+      logger.debug({ name }, "Setting RabbitMQ cluster name");
+      await this.request("/cluster-name", {
+        method: "PUT",
+        body: JSON.stringify({ name }),
+      });
+      logger.debug({ name }, "RabbitMQ cluster name set successfully");
+    } catch (error) {
+      logger.error({ error, name }, "Failed to set RabbitMQ cluster name");
+      if (error instanceof Error) {
+        captureRabbitMQError(error, {
+          operation: "setClusterName",
+          serverId: this.baseUrl,
+        });
+      }
+      throw error;
+    }
+  }
+
   // User Management Methods
   async getUsers(): Promise<RabbitMQUser[]> {
     try {

--- a/apps/api/src/schemas/rabbitmq.ts
+++ b/apps/api/src/schemas/rabbitmq.ts
@@ -108,6 +108,10 @@ export const ServerWorkspaceInputSchema = z.object({
   workspaceId: z.string(),
 });
 
+export const SetClusterNameSchema = ServerWorkspaceInputSchema.extend({
+  name: z.string().min(1, "Cluster name is required").max(255),
+});
+
 // Schema for creating an exchange
 export const CreateExchangeSchema = z.object({
   name: z.string().min(1, "Exchange name is required"),

--- a/apps/api/src/trpc/routers/rabbitmq/overview.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/overview.ts
@@ -6,15 +6,18 @@ import {
   getUpgradeRecommendationForOverLimit,
 } from "@/services/plan/plan.service";
 
-import { ServerWorkspaceInputSchema } from "@/schemas/rabbitmq";
+import {
+  ServerWorkspaceInputSchema,
+  SetClusterNameSchema,
+} from "@/schemas/rabbitmq";
 
 import { OverviewMapper } from "@/mappers/rabbitmq";
 
-import { router, workspaceProcedure } from "@/trpc/trpc";
+import { authorize, router, workspaceProcedure } from "@/trpc/trpc";
 
 import { createRabbitMQClient, verifyServerAccess } from "./shared";
 
-import { UserPlan } from "@/generated/prisma/client";
+import { UserPlan, UserRole } from "@/generated/prisma/client";
 import { te } from "@/i18n";
 
 /**
@@ -103,6 +106,43 @@ export const overviewRouter = router({
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: te(ctx.locale, "rabbitmq.failedToFetchOverview"),
+        });
+      }
+    }),
+
+  setClusterName: authorize([UserRole.ADMIN])
+    .input(SetClusterNameSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { serverId, workspaceId, name } = input;
+
+      try {
+        const server = await verifyServerAccess(serverId, workspaceId);
+        if (!server) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: te(ctx.locale, "rabbitmq.serverNotFoundOrAccessDenied"),
+          });
+        }
+
+        const client = await createRabbitMQClient(serverId, workspaceId);
+        await client.setClusterName(name);
+
+        ctx.logger.info(
+          { serverId, name },
+          `Cluster name updated to "${name}" by user ${ctx.user.id}`
+        );
+
+        return { success: true };
+      } catch (error) {
+        ctx.logger.error({ error, serverId }, "Error setting cluster name");
+
+        if (error instanceof TRPCError) {
+          throw error;
+        }
+
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: te(ctx.locale, "rabbitmq.failedToSetClusterName"),
         });
       }
     }),

--- a/apps/app/public/locales/en/nodes.json
+++ b/apps/app/public/locales/en/nodes.json
@@ -11,5 +11,11 @@
   "uptime": "Uptime",
   "connections": "Connections",
   "noNodesFound": "No nodes found",
-  "permissionErrorTitle": "Node Information Unavailable"
+  "permissionErrorTitle": "Node Information Unavailable",
+  "clusterName": "Cluster name",
+  "editClusterName": "Edit cluster name",
+  "saveClusterName": "Save",
+  "cancelEdit": "Cancel",
+  "clusterNameUpdated": "Cluster name updated",
+  "clusterNameError": "Failed to update cluster name"
 }

--- a/apps/app/public/locales/es/nodes.json
+++ b/apps/app/public/locales/es/nodes.json
@@ -11,5 +11,11 @@
   "uptime": "Tiempo activo",
   "connections": "Conexiones",
   "noNodesFound": "No se encontraron nodos",
-  "permissionErrorTitle": "Información de nodos no disponible"
+  "permissionErrorTitle": "Información de nodos no disponible",
+  "clusterName": "Nombre del clúster",
+  "editClusterName": "Editar nombre del clúster",
+  "saveClusterName": "Guardar",
+  "cancelEdit": "Cancelar",
+  "clusterNameUpdated": "Nombre del clúster actualizado",
+  "clusterNameError": "Error al actualizar el nombre del clúster"
 }

--- a/apps/app/public/locales/fr/nodes.json
+++ b/apps/app/public/locales/fr/nodes.json
@@ -11,5 +11,11 @@
   "uptime": "Disponibilité",
   "connections": "Connexions",
   "noNodesFound": "Aucun nœud trouvé",
-  "permissionErrorTitle": "Informations sur les nœuds indisponibles"
+  "permissionErrorTitle": "Informations sur les nœuds indisponibles",
+  "clusterName": "Nom du cluster",
+  "editClusterName": "Modifier le nom du cluster",
+  "saveClusterName": "Enregistrer",
+  "cancelEdit": "Annuler",
+  "clusterNameUpdated": "Nom du cluster mis à jour",
+  "clusterNameError": "Échec de la mise à jour du nom du cluster"
 }

--- a/apps/app/public/locales/zh/nodes.json
+++ b/apps/app/public/locales/zh/nodes.json
@@ -11,5 +11,11 @@
   "uptime": "运行时间",
   "connections": "连接数",
   "noNodesFound": "未找到节点",
-  "permissionErrorTitle": "节点信息不可用"
+  "permissionErrorTitle": "节点信息不可用",
+  "clusterName": "集群名称",
+  "editClusterName": "编辑集群名称",
+  "saveClusterName": "保存",
+  "cancelEdit": "取消",
+  "clusterNameUpdated": "集群名称已更新",
+  "clusterNameError": "更新集群名称失败"
 }

--- a/apps/app/src/hooks/queries/useRabbitMQ.ts
+++ b/apps/app/src/hooks/queries/useRabbitMQ.ts
@@ -482,6 +482,18 @@ export const useDeletePolicy = () => {
   return mutation;
 };
 
+export const useSetClusterName = () => {
+  const utils = trpc.useUtils();
+
+  const mutation = trpc.rabbitmq.overview.setClusterName.useMutation({
+    onSuccess: () => {
+      utils.rabbitmq.overview.getOverview.invalidate();
+    },
+  });
+
+  return mutation;
+};
+
 export const useTopology = (
   serverId: string | null,
   vhost?: string | null,

--- a/apps/app/src/pages/Nodes.tsx
+++ b/apps/app/src/pages/Nodes.tsx
@@ -1,27 +1,80 @@
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+
+import { Check, Pencil, X } from "lucide-react";
 
 import { EnhancedNodesOverview } from "@/components/nodes/EnhancedNodesOverview";
 import { EnhancedNodesTable } from "@/components/nodes/EnhancedNodesTable";
 import { NoServerConfigured } from "@/components/NoServerConfigured";
 import { PageError } from "@/components/PageError";
 import { NoServerSelectedCard, PageShell } from "@/components/PageShell";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { TitleWithCount } from "@/components/ui/TitleWithCount";
 
 import { useServerContext } from "@/contexts/ServerContext";
 
-import { useNodes } from "@/hooks/queries/useRabbitMQ";
+import { useCurrentOrganization } from "@/hooks/queries/useOrganization";
+import {
+  useNodes,
+  useOverview,
+  useSetClusterName,
+} from "@/hooks/queries/useRabbitMQ";
+import { useToast } from "@/hooks/ui/useToast";
+import { useWorkspace } from "@/hooks/ui/useWorkspace";
 
 import { RabbitMQAuthorizationError } from "@/types/apiErrors";
 
 const Nodes = () => {
   const { t } = useTranslation("nodes");
   const { selectedServerId, hasServers } = useServerContext();
+  const { workspace } = useWorkspace();
+  const { toast } = useToast();
+  const { data: orgData } = useCurrentOrganization();
+  const isOrgAdmin = orgData?.role === "OWNER" || orgData?.role === "ADMIN";
+
   const {
     data: nodesData,
     isLoading: nodesLoading,
     error: nodesQueryError,
   } = useNodes(selectedServerId);
+
+  const { data: overviewData } = useOverview(selectedServerId);
+
+  const setClusterNameMutation = useSetClusterName();
+  const [editingClusterName, setEditingClusterName] = useState(false);
+  const [clusterNameValue, setClusterNameValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const currentClusterName = overviewData?.overview?.cluster_name ?? "";
+
+  useEffect(() => {
+    if (editingClusterName) {
+      setClusterNameValue(currentClusterName);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [editingClusterName, currentClusterName]);
+
+  const handleSaveClusterName = async () => {
+    if (!selectedServerId || !workspace?.id) return;
+    try {
+      await setClusterNameMutation.mutateAsync({
+        serverId: selectedServerId,
+        workspaceId: workspace.id,
+        name: clusterNameValue.trim(),
+      });
+      setEditingClusterName(false);
+      toast({ title: t("clusterNameUpdated") });
+    } catch {
+      toast({ title: t("clusterNameError"), variant: "destructive" });
+    }
+  };
+
+  const handleCancelEdit = () => {
+    setEditingClusterName(false);
+  };
+
   const nodes = nodesData?.nodes || [];
 
   const nodesPermissionStatus = nodesData?.permissionStatus;
@@ -90,6 +143,67 @@ const Nodes = () => {
           </div>
         </div>
       </div>
+
+      {/* Cluster Name */}
+      {currentClusterName && (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">{t("clusterName")}:</span>
+          {editingClusterName ? (
+            <>
+              <Input
+                ref={inputRef}
+                value={clusterNameValue}
+                onChange={(e) => setClusterNameValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSaveClusterName();
+                  if (e.key === "Escape") handleCancelEdit();
+                }}
+                className="h-7 w-64 text-sm font-mono"
+                disabled={setClusterNameMutation.isPending}
+              />
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7"
+                onClick={handleSaveClusterName}
+                disabled={
+                  setClusterNameMutation.isPending || !clusterNameValue.trim()
+                }
+                aria-label={t("saveClusterName")}
+              >
+                <Check className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7"
+                onClick={handleCancelEdit}
+                disabled={setClusterNameMutation.isPending}
+                aria-label={t("cancelEdit")}
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            </>
+          ) : (
+            <>
+              <span className="font-mono font-semibold text-foreground">
+                {currentClusterName}
+              </span>
+              {isOrgAdmin && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7 opacity-50 hover:opacity-100"
+                  onClick={() => setEditingClusterName(true)}
+                  aria-label={t("editClusterName")}
+                >
+                  <Pencil className="h-3 w-3" />
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      )}
 
       {/* Cluster Overview */}
       <EnhancedNodesOverview


### PR DESCRIPTION
## Summary

- Adds inline cluster name editing to the Nodes page, matching the RabbitMQ management UI behaviour
- Edit button is shown only to org owners and admins (hidden for regular members)
- Backend mutation uses `PUT /api/cluster-name` and is protected by `authorize([UserRole.ADMIN])`

## Changes

- **`ApiClient.ts`** — new `setClusterName(name)` method calling `PUT /api/cluster-name`
- **`schemas/rabbitmq.ts`** — new `SetClusterNameSchema`
- **`routers/rabbitmq/overview.ts`** — new `setClusterName` mutation (admin-only)
- **`hooks/queries/useRabbitMQ.ts`** — new `useSetClusterName()` hook, invalidates overview on success
- **`pages/Nodes.tsx`** — inline edit UI: pencil icon → input with ✓/✗ buttons, Enter saves, Escape cancels, toast on success/error
- **i18n** — `failedToSetClusterName` in API error locales + 6 UI keys in app nodes locales (en/fr/es/zh)

## Test plan

- [ ] As org owner/admin: navigate to Nodes page, verify cluster name is displayed with pencil icon
- [ ] Click pencil, edit the name, press Enter or ✓ — verify name updates in RabbitMQ and toast appears
- [ ] Press Escape or ✗ — verify edit is cancelled without changes
- [ ] As a regular member: verify pencil icon is not shown (read-only)
- [ ] Verify backend rejects non-admin requests with a 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)