### PR TITLE
docs: update PostgreSQL requirement from 15 to 17

### DIFF
--- a/apps/web/src/content/docs/self-hosted/deployment.mdx
+++ b/apps/web/src/content/docs/self-hosted/deployment.mdx
@@ -18,7 +18,7 @@ All deployments start with the **free tier** (core monitoring). Premium features
 
 ## Prerequisites
 
-- **Binary:** PostgreSQL 15+ already running (no Docker or Node.js needed)
+- **Binary:** PostgreSQL 17+ already running (no Docker or Node.js needed)
 - **Docker Compose:** Docker and Docker Compose installed (PostgreSQL is bundled)
 - **Dokku:** Dokku installed on your server
 - Minimum 2 GB RAM, 10 GB disk space
@@ -33,7 +33,7 @@ If PostgreSQL isn't already running:
 
 ```bash
 # macOS
-brew install postgresql@15
+brew install postgresql@17
 
 # Ubuntu / Debian / WSL2
 sudo apt install postgresql
@@ -202,7 +202,7 @@ This starts four containers:
 
 | Container             | Purpose                     |
 | --------------------- | --------------------------- |
-| `qarote_postgres`     | PostgreSQL 15 database      |
+| `qarote_postgres`     | PostgreSQL 17 database      |
 | `qarote_backend`      | API server on port 3000     |
 | `qarote_alert_worker` | Alert evaluation worker     |
 | `qarote_frontend`     | React frontend on port 8080 |

--- a/docs/COMMUNITY_EDITION.md
+++ b/docs/COMMUNITY_EDITION.md
@@ -136,7 +136,7 @@ If you prefer Docker Compose or need more control over the deployment, you can u
 #### Prerequisites
 
 - Docker and Docker Compose
-- PostgreSQL 15+ (or use the included PostgreSQL container)
+- PostgreSQL 17+ (or use the included PostgreSQL container)
 
 #### Quick Start
 

--- a/docs/SELF_HOSTED_DEPLOYMENT.md
+++ b/docs/SELF_HOSTED_DEPLOYMENT.md
@@ -45,7 +45,7 @@ Qarote self-hosted provides core RabbitMQ monitoring out of the box. Premium fea
 
 Requirements depend on your deployment method:
 
-- **Binary:** PostgreSQL 15+ (no Docker, Node.js, or web server needed)
+- **Binary:** PostgreSQL 17+ (no Docker, Node.js, or web server needed)
 - **Docker Compose:** Docker and Docker Compose (PostgreSQL is included)
 - **Dokku:** Dokku installed on your server
 - Minimum 2GB RAM, 10GB disk space
@@ -62,7 +62,7 @@ Qarote is available as a single binary that embeds both the API and frontend. No
 > ```
 >
 > **Install PostgreSQL** if you don't have it:
-> - **macOS:** `brew install postgresql@15`
+> - **macOS:** `brew install postgresql@17`
 > - **Ubuntu/Debian:** `sudo apt install postgresql`
 > - **Windows (WSL2):** `sudo apt install postgresql`
 


### PR DESCRIPTION
## Summary

- Updates all documentation references from PostgreSQL 15 to 17 (current stable)
- Affects 3 files: `apps/web/src/content/docs/self-hosted/deployment.mdx`, `docs/SELF_HOSTED_DEPLOYMENT.md`, `docs/COMMUNITY_EDITION.md`
- 5 occurrences total: min-version requirements, `brew install` commands, and the Docker Compose container description table

PostgreSQL 18 is still in beta (released April 2025), so 17 is the correct stable target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)