### PR TITLE
test(api): add unit tests for all tRPC routers

### DIFF
--- a/apps/api/src/trpc/routers/__tests__/discord.test.ts
+++ b/apps/api/src/trpc/routers/__tests__/discord.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockUserUpdate = vi.fn();
+const mockUserFindUnique = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: {
+      update: (...a: unknown[]) => mockUserUpdate(...a),
+      findUnique: (...a: unknown[]) => mockUserFindUnique(...a),
+    },
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+const { discordRouter } = await import("../discord");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      user: { update: mockUserUpdate, findUnique: mockUserFindUnique },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: { id: "user-1", email: "test@example.com", isActive: true },
+    locale: "en",
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe("discordRouter.markJoined", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("sets discordJoined=true and records timestamp", async () => {
+    mockUserUpdate.mockResolvedValue({ id: "user-1", discordJoined: true });
+
+    const caller = discordRouter.createCaller(makeCtx() as never);
+    await caller.markJoined();
+
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: expect.objectContaining({ discordJoined: true }),
+      })
+    );
+  });
+});
+
+describe("discordRouter.getStatus", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns discordJoined=false when user has not joined", async () => {
+    mockUserFindUnique.mockResolvedValue({
+      discordJoined: false,
+      discordJoinedAt: null,
+    });
+
+    const caller = discordRouter.createCaller(makeCtx() as never);
+    const result = await caller.getStatus();
+
+    expect(result.discordJoined).toBe(false);
+    expect(result.discordJoinedAt).toBeNull();
+  });
+
+  it("returns discordJoined=true with timestamp", async () => {
+    const joinedAt = new Date("2024-06-01");
+    mockUserFindUnique.mockResolvedValue({
+      discordJoined: true,
+      discordJoinedAt: joinedAt,
+    });
+
+    const caller = discordRouter.createCaller(makeCtx() as never);
+    const result = await caller.getStatus();
+
+    expect(result.discordJoined).toBe(true);
+    expect(result.discordJoinedAt).toBe(joinedAt.toISOString());
+  });
+});

--- a/apps/api/src/trpc/routers/__tests__/feedback.test.ts
+++ b/apps/api/src/trpc/routers/__tests__/feedback.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockFeedbackCreate = vi.fn();
+const mockFeedbackFindMany = vi.fn();
+const mockFeedbackFindUnique = vi.fn();
+const mockFeedbackUpdate = vi.fn();
+const mockFeedbackDelete = vi.fn();
+const mockFeedbackCount = vi.fn();
+const mockFeedbackGroupBy = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    feedback: {
+      create: (...a: unknown[]) => mockFeedbackCreate(...a),
+      findMany: (...a: unknown[]) => mockFeedbackFindMany(...a),
+      findUnique: (...a: unknown[]) => mockFeedbackFindUnique(...a),
+      update: (...a: unknown[]) => mockFeedbackUpdate(...a),
+      delete: (...a: unknown[]) => mockFeedbackDelete(...a),
+      count: (...a: unknown[]) => mockFeedbackCount(...a),
+      groupBy: (...a: unknown[]) => mockFeedbackGroupBy(...a),
+    },
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+vi.mock("@/mappers/feedback", () => ({
+  FeedbackMapper: {
+    toApiResponse: vi.fn((f) => ({ id: f.id, title: f.title })),
+    toApiResponseArray: vi.fn((f) =>
+      f.map((item: { id: string; title: string }) => ({
+        id: item.id,
+        title: item.title,
+      }))
+    ),
+  },
+}));
+
+const { feedbackRouter } = await import("../feedback");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      feedback: {
+        create: mockFeedbackCreate,
+        findMany: mockFeedbackFindMany,
+        findUnique: mockFeedbackFindUnique,
+        update: mockFeedbackUpdate,
+        delete: mockFeedbackDelete,
+        count: mockFeedbackCount,
+        groupBy: mockFeedbackGroupBy,
+      },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "test@example.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockFeedback = {
+  id: "fb-1",
+  type: "BUG",
+  category: "UI_UX" as const,
+  title: "Button broken",
+  description: "The save button does not work",
+  priority: "HIGH",
+  email: "test@example.com",
+  status: "OPEN",
+  userId: "user-1",
+  workspaceId: "ws-1",
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  user: {
+    id: "user-1",
+    email: "test@example.com",
+    firstName: "John",
+    lastName: "Doe",
+  },
+};
+
+const validSubmitInput = {
+  type: "BUG" as const,
+  category: "UI_UX" as const,
+  title: "Button broken",
+  description: "The save button does not work",
+  priority: "HIGH" as const,
+};
+
+// --- Tests ---
+
+describe("feedbackRouter.submit", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates feedback record linked to current user", async () => {
+    mockFeedbackCreate.mockResolvedValue(mockFeedback);
+
+    const caller = feedbackRouter.createCaller(makeCtx() as never);
+    await caller.submit(validSubmitInput);
+
+    expect(mockFeedbackCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: "user-1" }),
+      })
+    );
+  });
+
+  it("uses provided email over user email when supplied", async () => {
+    mockFeedbackCreate.mockResolvedValue(mockFeedback);
+
+    const caller = feedbackRouter.createCaller(makeCtx() as never);
+    await caller.submit({ ...validSubmitInput, email: "override@example.com" });
+
+    expect(mockFeedbackCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ email: "override@example.com" }),
+      })
+    );
+  });
+});
+
+describe("feedbackRouter.getAll (ADMIN only)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns paginated feedback list", async () => {
+    mockFeedbackCount.mockResolvedValue(1);
+    mockFeedbackFindMany.mockResolvedValue([mockFeedback]);
+
+    const caller = feedbackRouter.createCaller(makeCtx() as never);
+    const result = await caller.getAll({ page: 1, limit: 10 });
+
+    expect(result.feedback).toBeDefined();
+    expect(mockFeedbackFindMany).toHaveBeenCalledOnce();
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = feedbackRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-1",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+
+    await expect(caller.getAll({ page: 1, limit: 10 })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+});
+
+describe("feedbackRouter.getById (ADMIN only)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when feedback does not exist", async () => {
+    mockFeedbackFindUnique.mockResolvedValue(null);
+
+    const caller = feedbackRouter.createCaller(makeCtx() as never);
+    await expect(caller.getById({ id: "fb-999" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("returns feedback when found", async () => {
+    mockFeedbackFindUnique.mockResolvedValue(mockFeedback);
+
+    const caller = feedbackRouter.createCaller(makeCtx() as never);
+    const result = await caller.getById({ id: "fb-1" });
+
+    expect(result.feedback).toBeDefined();
+  });
+});
+
+describe("feedbackRouter.delete (ADMIN only)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("deletes feedback by id", async () => {
+    mockFeedbackDelete.mockResolvedValue({});
+
+    const caller = feedbackRouter.createCaller(makeCtx() as never);
+    const result = await caller.delete({ id: "fb-1" });
+
+    expect(mockFeedbackDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "fb-1" } })
+    );
+    expect(result.message).toBeDefined();
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = feedbackRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-1",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+
+    await expect(caller.delete({ id: "fb-1" })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/__tests__/user.test.ts
+++ b/apps/api/src/trpc/routers/__tests__/user.test.ts
@@ -1,0 +1,503 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockUserFindUnique = vi.fn();
+const mockUserUpdate = vi.fn();
+const mockUserFindMany = vi.fn();
+const mockWorkspaceMemberFindMany = vi.fn();
+const mockWorkspaceMemberCount = vi.fn();
+const mockWorkspaceMemberDeleteMany = vi.fn();
+const mockWorkspaceUpdate = vi.fn();
+const mockWorkspaceFindUnique = vi.fn();
+const mockInvitationFindMany = vi.fn();
+const mockOrganizationMemberFindFirst = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: (...a: unknown[]) => mockUserFindUnique(...a),
+      update: (...a: unknown[]) => mockUserUpdate(...a),
+      findMany: (...a: unknown[]) => mockUserFindMany(...a),
+    },
+    workspaceMember: {
+      findMany: (...a: unknown[]) => mockWorkspaceMemberFindMany(...a),
+      count: (...a: unknown[]) => mockWorkspaceMemberCount(...a),
+      deleteMany: (...a: unknown[]) => mockWorkspaceMemberDeleteMany(...a),
+    },
+    workspace: {
+      update: (...a: unknown[]) => mockWorkspaceUpdate(...a),
+      findUnique: (...a: unknown[]) => mockWorkspaceFindUnique(...a),
+    },
+    invitation: {
+      findMany: (...a: unknown[]) => mockInvitationFindMany(...a),
+    },
+    organizationMember: {
+      findFirst: (...a: unknown[]) => mockOrganizationMemberFindFirst(...a),
+    },
+    $transaction: (...a: unknown[]) => mockTransaction(...a),
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/core/workspace-access", () => ({
+  getUserWorkspaceRole: vi.fn().mockResolvedValue("MEMBER"),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+vi.mock("@/services/email/email-verification.service", () => ({
+  EmailVerificationService: {
+    generateVerificationToken: vi.fn().mockResolvedValue("tok-verify"),
+    sendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+vi.mock("@/mappers/auth", () => ({
+  UserMapper: {
+    toApiResponse: vi.fn((u) => ({
+      id: u.id,
+      email: u.email,
+      firstName: u.firstName,
+      lastName: u.lastName,
+    })),
+  },
+}));
+
+const { userRouter } = await import("../user");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      user: {
+        findUnique: mockUserFindUnique,
+        update: mockUserUpdate,
+        findMany: mockUserFindMany,
+      },
+      workspaceMember: {
+        findMany: mockWorkspaceMemberFindMany,
+        count: mockWorkspaceMemberCount,
+        deleteMany: mockWorkspaceMemberDeleteMany,
+      },
+      workspace: {
+        update: mockWorkspaceUpdate,
+        findUnique: mockWorkspaceFindUnique,
+      },
+      invitation: { findMany: mockInvitationFindMany },
+      organizationMember: { findFirst: mockOrganizationMemberFindFirst },
+      $transaction: mockTransaction,
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockUser = {
+  id: "user-1",
+  email: "admin@test.com",
+  firstName: "Admin",
+  lastName: "User",
+  image: null,
+  role: "ADMIN",
+  workspaceId: "ws-1",
+  isActive: true,
+  emailVerified: true,
+  lastLogin: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  googleId: null,
+  pendingEmail: null,
+  workspace: null,
+};
+
+// --- Tests ---
+
+describe("userRouter.getOnboardingInfo", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns hasOrganization=false when user has no org membership", async () => {
+    mockOrganizationMemberFindFirst.mockResolvedValue(null);
+    mockUserFindUnique.mockResolvedValue({ onboardingCompletedAt: null });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.getOnboardingInfo();
+
+    expect(result.hasOrganization).toBe(false);
+    expect(result.organizationName).toBeNull();
+    expect(result.onboardingCompleted).toBe(false);
+  });
+
+  it("returns hasOrganization=true with org name", async () => {
+    mockOrganizationMemberFindFirst.mockResolvedValue({
+      organization: { id: "org-1", name: "Acme Corp" },
+    });
+    mockUserFindUnique.mockResolvedValue({ onboardingCompletedAt: new Date() });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.getOnboardingInfo();
+
+    expect(result.hasOrganization).toBe(true);
+    expect(result.organizationName).toBe("Acme Corp");
+    expect(result.onboardingCompleted).toBe(true);
+  });
+});
+
+describe("userRouter.getProfile", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when user does not exist", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    await expect(caller.getProfile()).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("returns user profile with workspace", async () => {
+    const workspace = {
+      id: "ws-1",
+      name: "Test WS",
+      contactEmail: "ws@test.com",
+      logoUrl: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      _count: { users: 2, servers: 1 },
+    };
+    mockUserFindUnique.mockResolvedValue({ ...mockUser, workspace });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.getProfile();
+
+    expect(result.profile).toBeDefined();
+    expect(result.profile.workspace?.id).toBe("ws-1");
+  });
+});
+
+describe("userRouter.updateProfile", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("updates profile fields without email change", async () => {
+    mockUserUpdate.mockResolvedValue({ ...mockUser, firstName: "Updated" });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.updateProfile({ firstName: "Updated" });
+
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: { firstName: "Updated" },
+      })
+    );
+    expect(result.user).toBeDefined();
+  });
+
+  it("throws BAD_REQUEST when new email is already in use", async () => {
+    mockUserFindUnique.mockResolvedValue({ id: "other-user" });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.updateProfile({ email: "taken@example.com" })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("initiates email change flow when new email is free", async () => {
+    mockUserFindUnique.mockResolvedValue(null); // email not taken
+    mockUserUpdate.mockResolvedValue({
+      ...mockUser,
+      pendingEmail: "new@example.com",
+    });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.updateProfile({ email: "new@example.com" });
+
+    expect(result.message).toBeDefined();
+  });
+});
+
+describe("userRouter.getWorkspaceUsers", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns paginated workspace members", async () => {
+    mockWorkspaceMemberCount.mockResolvedValue(1);
+    mockWorkspaceMemberFindMany.mockResolvedValue([
+      {
+        role: "MEMBER",
+        user: {
+          id: "user-2",
+          email: "member@test.com",
+          firstName: "Jane",
+          lastName: "Doe",
+          image: null,
+          isActive: true,
+          lastLogin: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+    ]);
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.getWorkspaceUsers({
+      workspaceId: "ws-1",
+      page: 1,
+      limit: 10,
+    });
+
+    expect(result.users).toHaveLength(1);
+    expect(result.users[0].email).toBe("member@test.com");
+    expect(result.pagination).toBeDefined();
+  });
+});
+
+describe("userRouter.getInvitations (ADMIN only)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns invitations for workspace", async () => {
+    mockInvitationFindMany.mockResolvedValue([
+      { id: "inv-1", email: "u@u.com", role: "MEMBER", status: "PENDING" },
+    ]);
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.getInvitations({ workspaceId: "ws-1" });
+
+    expect(result.invitations).toHaveLength(1);
+    expect(mockInvitationFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          workspaceId: "ws-1",
+          status: "PENDING",
+        }),
+      })
+    );
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = userRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-1",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.getInvitations({ workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("userRouter.getUser", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when user does not exist", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getUser({ id: "unknown", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns user data when found", async () => {
+    mockUserFindUnique.mockResolvedValue({
+      ...mockUser,
+      workspace: { id: "ws-1", name: "WS" },
+    });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.getUser({ id: "user-1", workspaceId: "ws-1" });
+
+    expect(result.user).toBeDefined();
+    expect(result.user.workspace?.id).toBe("ws-1");
+  });
+});
+
+describe("userRouter.updateUser (ADMIN only)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when user does not exist", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.updateUser({ id: "unknown", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("updates user and returns updated profile", async () => {
+    mockUserFindUnique.mockResolvedValue(mockUser);
+    mockUserUpdate.mockResolvedValue({ ...mockUser, firstName: "NewName" });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.updateUser({
+      id: "user-1",
+      workspaceId: "ws-1",
+      firstName: "NewName",
+    });
+
+    expect(result.user).toBeDefined();
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: { firstName: "NewName" },
+      })
+    );
+  });
+});
+
+describe("userRouter.updateWorkspace (ADMIN only)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws BAD_REQUEST when user has no workspaceId", async () => {
+    const caller = userRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-1",
+          email: "u@u.com",
+          isActive: true,
+          role: "ADMIN",
+          workspaceId: null,
+        },
+      }) as never
+    );
+    await expect(
+      caller.updateWorkspace({ name: "New Name" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("updates workspace and returns serialized data", async () => {
+    const ws = {
+      id: "ws-1",
+      name: "Updated WS",
+      contactEmail: "ws@test.com",
+      logoUrl: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      _count: { users: 1, servers: 0 },
+    };
+    mockWorkspaceUpdate.mockResolvedValue(ws);
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.updateWorkspace({ name: "Updated WS" });
+
+    expect(result.workspace.name).toBe("Updated WS");
+    expect(typeof result.workspace.createdAt).toBe("string");
+  });
+});
+
+describe("userRouter.removeFromWorkspace (ADMIN only)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when target user does not exist", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.removeFromWorkspace({ userId: "ghost", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws BAD_REQUEST when trying to remove self", async () => {
+    const { getUserWorkspaceRole } = await import("@/core/workspace-access");
+    vi.mocked(getUserWorkspaceRole).mockResolvedValue("MEMBER");
+    mockUserFindUnique.mockResolvedValue({
+      id: "user-1",
+      email: "admin@test.com",
+      firstName: "Admin",
+      lastName: "User",
+    });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.removeFromWorkspace({ userId: "user-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("removes a member from the workspace successfully", async () => {
+    const { getUserWorkspaceRole } = await import("@/core/workspace-access");
+    vi.mocked(getUserWorkspaceRole).mockResolvedValue("MEMBER");
+    mockUserFindUnique.mockResolvedValue({
+      id: "user-2",
+      email: "member@test.com",
+      firstName: "Jane",
+      lastName: "Doe",
+    });
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        workspaceMember: { deleteMany: vi.fn() },
+        user: { update: vi.fn() },
+      };
+      return fn(tx);
+    });
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.removeFromWorkspace({
+      userId: "user-2",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.message).toBeDefined();
+    expect(result.removedUser.id).toBe("user-2");
+  });
+});
+
+describe("userRouter.updateLocale", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws BAD_REQUEST for unsupported locale", async () => {
+    const caller = userRouter.createCaller(makeCtx() as never);
+    await expect(caller.updateLocale({ locale: "xx" })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("updates locale and returns it", async () => {
+    mockUserUpdate.mockResolvedValue({});
+
+    const caller = userRouter.createCaller(makeCtx() as never);
+    const result = await caller.updateLocale({ locale: "en" });
+
+    expect(result.locale).toBe("en");
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: { locale: "en" },
+      })
+    );
+  });
+});

--- a/apps/api/src/trpc/routers/auth/__tests__/email.test.ts
+++ b/apps/api/src/trpc/routers/auth/__tests__/email.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockUserFindUnique = vi.fn();
+const mockUserUpdate = vi.fn();
+const mockAccountFindFirst = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: (...a: unknown[]) => mockUserFindUnique(...a),
+      update: (...a: unknown[]) => mockUserUpdate(...a),
+    },
+    account: {
+      findFirst: (...a: unknown[]) => mockAccountFindFirst(...a),
+    },
+  },
+}));
+
+vi.mock("@/core/auth", () => ({
+  comparePassword: vi.fn(),
+}));
+
+vi.mock("@/services/audit.service", () => ({
+  auditService: {
+    logPasswordEvent: vi.fn(),
+  },
+}));
+
+const mockGenerateVerificationToken = vi.fn().mockResolvedValue("tok-xyz");
+const mockSendVerificationEmail = vi.fn().mockResolvedValue({ success: true });
+
+vi.mock("@/services/email/email-verification.service", () => ({
+  EmailVerificationService: {
+    generateVerificationToken: (...a: unknown[]) =>
+      mockGenerateVerificationToken(...a),
+    sendVerificationEmail: (...a: unknown[]) => mockSendVerificationEmail(...a),
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+const { emailRouter } = await import("../email");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      user: { findUnique: mockUserFindUnique, update: mockUserUpdate },
+      account: { findFirst: mockAccountFindFirst },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: { id: "user-1", email: "test@example.com", isActive: true },
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockUserRecord = {
+  id: "user-1",
+  email: "test@example.com",
+  passwordHash: "hashed-pw",
+  firstName: "John",
+  lastName: "Doe",
+};
+
+// --- Tests ---
+
+describe("emailRouter.requestEmailChange", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when user does not exist", async () => {
+    mockAccountFindFirst.mockResolvedValue(null);
+    mockUserFindUnique.mockResolvedValueOnce(null); // userWithPassword lookup
+
+    const caller = emailRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.requestEmailChange({ newEmail: "new@example.com", password: "pw" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws BAD_REQUEST when user has no password (Google account)", async () => {
+    mockAccountFindFirst.mockResolvedValue(null);
+    mockUserFindUnique.mockResolvedValue({
+      ...mockUserRecord,
+      passwordHash: null,
+    });
+
+    const caller = emailRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.requestEmailChange({ newEmail: "new@example.com", password: "pw" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("throws UNAUTHORIZED when password is incorrect", async () => {
+    mockAccountFindFirst.mockResolvedValue({ password: "hashed-pw" });
+    mockUserFindUnique.mockResolvedValue(mockUserRecord);
+
+    const { comparePassword } = await import("@/core/auth");
+    vi.mocked(comparePassword).mockResolvedValue(false);
+
+    const caller = emailRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.requestEmailChange({
+        newEmail: "new@example.com",
+        password: "wrong",
+      })
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+
+  it("throws BAD_REQUEST when new email is already in use", async () => {
+    mockAccountFindFirst.mockResolvedValue({ password: "hashed-pw" });
+    mockUserFindUnique
+      .mockResolvedValueOnce(mockUserRecord) // userWithPassword
+      .mockResolvedValueOnce({ id: "other-user" }); // existingUser check
+
+    const { comparePassword } = await import("@/core/auth");
+    vi.mocked(comparePassword).mockResolvedValue(true);
+
+    const caller = emailRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.requestEmailChange({
+        newEmail: "taken@example.com",
+        password: "correct",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("sets pending email and sends verification on success", async () => {
+    mockAccountFindFirst.mockResolvedValue({ password: "hashed-pw" });
+    mockUserFindUnique
+      .mockResolvedValueOnce(mockUserRecord) // userWithPassword
+      .mockResolvedValueOnce(null); // existingUser (email is free)
+    mockUserUpdate.mockResolvedValue({});
+
+    const { comparePassword } = await import("@/core/auth");
+    vi.mocked(comparePassword).mockResolvedValue(true);
+
+    const caller = emailRouter.createCaller(makeCtx() as never);
+    const result = await caller.requestEmailChange({
+      newEmail: "new@example.com",
+      password: "correct",
+    });
+
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: { pendingEmail: "new@example.com" },
+      })
+    );
+    expect(mockSendVerificationEmail).toHaveBeenCalledOnce();
+    expect(result.pendingEmail).toBe("new@example.com");
+  });
+});
+
+describe("emailRouter.cancelEmailChange", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clears pending email", async () => {
+    mockUserUpdate.mockResolvedValue({});
+
+    const caller = emailRouter.createCaller(makeCtx() as never);
+    const result = await caller.cancelEmailChange();
+
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: { pendingEmail: null },
+      })
+    );
+    expect(result.message).toBeDefined();
+  });
+});

--- a/apps/api/src/trpc/routers/auth/__tests__/org-invitation.test.ts
+++ b/apps/api/src/trpc/routers/auth/__tests__/org-invitation.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockOrgInvitationFindFirst = vi.fn();
+const mockOrgMemberFindUnique = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    organizationInvitation: {
+      findFirst: (...a: unknown[]) => mockOrgInvitationFindFirst(...a),
+    },
+    organizationMember: {
+      findUnique: (...a: unknown[]) => mockOrgMemberFindUnique(...a),
+    },
+    $transaction: (...a: unknown[]) => mockTransaction(...a),
+  },
+}));
+
+vi.mock("@/core/org-invitation-accept", () => ({
+  applyWorkspaceAssignments: vi.fn().mockResolvedValue("ws-1"),
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+const { orgInvitationRouter } = await import("../org-invitation");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      organizationInvitation: { findFirst: mockOrgInvitationFindFirst },
+      organizationMember: { findUnique: mockOrgMemberFindUnique },
+      $transaction: mockTransaction,
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "test@example.com",
+      isActive: true,
+      workspaceId: null,
+    },
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockInvitation = {
+  id: "inv-1",
+  token: "tok-abc",
+  email: "test@example.com",
+  organizationId: "org-1",
+  role: "MEMBER",
+  workspaceAssignments: [],
+  acceptedAt: null,
+  expiresAt: new Date(Date.now() + 86_400_000),
+  organization: { id: "org-1", name: "Acme Corp" },
+};
+
+// --- Tests ---
+
+describe("orgInvitationRouter.acceptOrgInvitation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND for invalid or expired token", async () => {
+    mockOrgInvitationFindFirst.mockResolvedValue(null);
+
+    const caller = orgInvitationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.acceptOrgInvitation({ token: "bad-tok" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws FORBIDDEN when invitation email does not match user email", async () => {
+    mockOrgInvitationFindFirst.mockResolvedValue({
+      ...mockInvitation,
+      email: "other@example.com",
+    });
+
+    const caller = orgInvitationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.acceptOrgInvitation({ token: "tok-abc" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("accepts invitation and creates membership for new member", async () => {
+    mockOrgInvitationFindFirst.mockResolvedValue(mockInvitation);
+    mockOrgMemberFindUnique.mockResolvedValue(null);
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        organizationInvitation: { update: vi.fn() },
+        organizationMember: { create: vi.fn() },
+        user: { update: vi.fn() },
+      };
+      const { applyWorkspaceAssignments } =
+        await import("@/core/org-invitation-accept");
+      vi.mocked(applyWorkspaceAssignments).mockResolvedValue("ws-1");
+      return fn(tx);
+    });
+
+    const caller = orgInvitationRouter.createCaller(makeCtx() as never);
+    const result = await caller.acceptOrgInvitation({ token: "tok-abc" });
+
+    expect(result.success).toBe(true);
+    expect(result.organization.id).toBe("org-1");
+  });
+
+  it("accepts invitation and updates role for existing member (re-invite)", async () => {
+    mockOrgInvitationFindFirst.mockResolvedValue({
+      ...mockInvitation,
+      role: "ADMIN",
+    });
+    mockOrgMemberFindUnique.mockResolvedValue({ id: "mem-1", role: "MEMBER" });
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        organizationInvitation: { update: vi.fn() },
+        organizationMember: { update: vi.fn() },
+        user: { update: vi.fn() },
+      };
+      const { applyWorkspaceAssignments } =
+        await import("@/core/org-invitation-accept");
+      vi.mocked(applyWorkspaceAssignments).mockResolvedValue(null);
+      return fn(tx);
+    });
+
+    const caller = orgInvitationRouter.createCaller(makeCtx() as never);
+    const result = await caller.acceptOrgInvitation({ token: "tok-abc" });
+
+    expect(result.success).toBe(true);
+    expect(result.firstWorkspaceId).toBeNull();
+  });
+});

--- a/apps/api/src/trpc/routers/auth/__tests__/password.test.ts
+++ b/apps/api/src/trpc/routers/auth/__tests__/password.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockUserFindUnique = vi.fn();
+const mockUserUpdate = vi.fn();
+const mockAccountFindFirst = vi.fn();
+const mockAccountUpsert = vi.fn();
+const mockPasswordResetFindUnique = vi.fn();
+const mockPasswordResetCreate = vi.fn();
+const mockPasswordResetDeleteMany = vi.fn();
+const mockPasswordResetDelete = vi.fn();
+const mockPasswordResetUpdate = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: (...a: unknown[]) => mockUserFindUnique(...a),
+      update: (...a: unknown[]) => mockUserUpdate(...a),
+    },
+    account: {
+      findFirst: (...a: unknown[]) => mockAccountFindFirst(...a),
+      upsert: (...a: unknown[]) => mockAccountUpsert(...a),
+    },
+    passwordReset: {
+      findUnique: (...a: unknown[]) => mockPasswordResetFindUnique(...a),
+      create: (...a: unknown[]) => mockPasswordResetCreate(...a),
+      deleteMany: (...a: unknown[]) => mockPasswordResetDeleteMany(...a),
+      delete: (...a: unknown[]) => mockPasswordResetDelete(...a),
+      update: (...a: unknown[]) => mockPasswordResetUpdate(...a),
+    },
+    $transaction: (...a: unknown[]) => mockTransaction(...a),
+  },
+}));
+
+vi.mock("@/core/auth", () => ({
+  hashPassword: vi.fn().mockResolvedValue("bcrypt-hash"),
+  comparePassword: vi.fn(),
+}));
+
+vi.mock("better-auth/crypto", () => ({
+  hashPassword: vi.fn().mockResolvedValue("scrypt-hash"),
+}));
+
+vi.mock("@/services/audit.service", () => ({
+  auditService: {
+    logPasswordResetRequest: vi.fn(),
+    logPasswordResetFailed: vi.fn(),
+    logPasswordResetCompleted: vi.fn(),
+    logPasswordChange: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/email/password-reset-email.service", () => ({
+  passwordResetEmailService: {
+    sendPasswordResetEmail: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/services/encryption.service", () => ({
+  EncryptionService: {
+    generateEncryptionKey: vi.fn().mockReturnValue("reset-tok-xyz"),
+  },
+}));
+
+vi.mock("@/config", () => ({
+  isDevelopment: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+const { passwordRouter } = await import("../password");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      user: { findUnique: mockUserFindUnique, update: mockUserUpdate },
+      account: { findFirst: mockAccountFindFirst, upsert: mockAccountUpsert },
+      passwordReset: {
+        findUnique: mockPasswordResetFindUnique,
+        create: mockPasswordResetCreate,
+        deleteMany: mockPasswordResetDeleteMany,
+        delete: mockPasswordResetDelete,
+        update: mockPasswordResetUpdate,
+      },
+      $transaction: mockTransaction,
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: { id: "user-1", email: "test@example.com", isActive: true },
+    locale: "en",
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe("passwordRouter.requestPasswordReset", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns success message even when email not found (security)", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    const result = await caller.requestPasswordReset({ email: "ghost@x.com" });
+
+    expect(result.message).toBeDefined();
+    expect(mockPasswordResetCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates reset token and sends email when user exists", async () => {
+    mockUserFindUnique.mockResolvedValue({
+      id: "user-1",
+      email: "test@example.com",
+      firstName: "John",
+      lastName: "Doe",
+    });
+    mockPasswordResetDeleteMany.mockResolvedValue({});
+    mockPasswordResetCreate.mockResolvedValue({});
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    const result = await caller.requestPasswordReset({
+      email: "test@example.com",
+    });
+
+    expect(mockPasswordResetCreate).toHaveBeenCalledOnce();
+    expect(result.message).toBeDefined();
+  });
+
+  it("does not expose token in production", async () => {
+    mockUserFindUnique.mockResolvedValue({
+      id: "user-1",
+      email: "test@example.com",
+      firstName: null,
+      lastName: null,
+    });
+    mockPasswordResetDeleteMany.mockResolvedValue({});
+    mockPasswordResetCreate.mockResolvedValue({});
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    const result = await caller.requestPasswordReset({
+      email: "test@example.com",
+    });
+
+    expect((result as Record<string, unknown>).token).toBeUndefined();
+  });
+});
+
+describe("passwordRouter.resetPassword", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const futureDate = new Date(Date.now() + 86_400_000);
+  const mockReset = {
+    id: "reset-1",
+    userId: "user-1",
+    token: "reset-tok-xyz",
+    expiresAt: futureDate,
+    used: false,
+    user: {
+      id: "user-1",
+      email: "test@example.com",
+      firstName: "John",
+      lastName: "Doe",
+    },
+  };
+
+  it("throws BAD_REQUEST for invalid token", async () => {
+    mockPasswordResetFindUnique.mockResolvedValue(null);
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.resetPassword({ token: "bad-tok", password: "NewPass123!" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("throws BAD_REQUEST for expired token", async () => {
+    mockPasswordResetFindUnique.mockResolvedValue({
+      ...mockReset,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    mockPasswordResetDelete.mockResolvedValue({});
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.resetPassword({ token: "tok", password: "NewPass123!" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("throws BAD_REQUEST for already-used token", async () => {
+    mockPasswordResetFindUnique.mockResolvedValue({ ...mockReset, used: true });
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.resetPassword({ token: "tok", password: "NewPass123!" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("resets password successfully for valid token", async () => {
+    mockPasswordResetFindUnique.mockResolvedValue(mockReset);
+    mockTransaction.mockResolvedValue([]);
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    const result = await caller.resetPassword({
+      token: "reset-tok-xyz",
+      password: "NewPass123!",
+    });
+
+    expect(mockTransaction).toHaveBeenCalledOnce();
+    expect(result.message).toBeDefined();
+  });
+});
+
+describe("passwordRouter.changePassword", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const mockUserRecord = {
+    id: "user-1",
+    email: "test@example.com",
+    passwordHash: "bcrypt-hash",
+  };
+
+  it("throws NOT_FOUND when user does not exist", async () => {
+    mockAccountFindFirst.mockResolvedValue(null);
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.changePassword({
+        currentPassword: "old",
+        newPassword: "NewPass123!",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws BAD_REQUEST when user has no password (Google sign-in)", async () => {
+    mockAccountFindFirst.mockResolvedValue(null);
+    mockUserFindUnique.mockResolvedValue({
+      ...mockUserRecord,
+      passwordHash: null,
+    });
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.changePassword({
+        currentPassword: "old",
+        newPassword: "NewPass123!",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("throws BAD_REQUEST when current password is wrong", async () => {
+    mockAccountFindFirst.mockResolvedValue({ password: "bcrypt-hash" });
+    mockUserFindUnique.mockResolvedValue(mockUserRecord);
+
+    const { comparePassword } = await import("@/core/auth");
+    vi.mocked(comparePassword).mockResolvedValue(false);
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.changePassword({
+        currentPassword: "wrong",
+        newPassword: "NewPass123!",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("changes password successfully", async () => {
+    mockAccountFindFirst.mockResolvedValue({ password: "bcrypt-hash" });
+    mockUserFindUnique.mockResolvedValue(mockUserRecord);
+    mockTransaction.mockResolvedValue([]);
+
+    const { comparePassword } = await import("@/core/auth");
+    vi.mocked(comparePassword).mockResolvedValue(true);
+
+    const caller = passwordRouter.createCaller(makeCtx() as never);
+    const result = await caller.changePassword({
+      currentPassword: "OldPass123!",
+      newPassword: "NewPass123!",
+    });
+
+    expect(mockTransaction).toHaveBeenCalledOnce();
+    expect(result.message).toBeDefined();
+  });
+});

--- a/apps/api/src/trpc/routers/auth/__tests__/registration.test.ts
+++ b/apps/api/src/trpc/routers/auth/__tests__/registration.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockUserFindUnique = vi.fn();
+const mockUserCreate = vi.fn();
+const mockAccountCreate = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: (...a: unknown[]) => mockUserFindUnique(...a),
+      create: (...a: unknown[]) => mockUserCreate(...a),
+    },
+    account: { create: (...a: unknown[]) => mockAccountCreate(...a) },
+    $transaction: (...a: unknown[]) => mockTransaction(...a),
+  },
+}));
+
+vi.mock("@/core/auth", () => ({
+  hashPassword: vi.fn().mockResolvedValue("hashed-pw"),
+}));
+
+vi.mock("@/services/email/email-verification.service", () => ({
+  EmailVerificationService: {
+    generateVerificationToken: vi.fn().mockResolvedValue("tok-123"),
+    sendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+vi.mock("@/services/integrations/notion.service", () => ({
+  notionService: { syncUser: vi.fn() },
+}));
+
+vi.mock("@/services/sentry", () => ({
+  trackSignUpError: vi.fn(),
+}));
+
+vi.mock("@/services/stripe/customer.service", () => ({
+  StripeCustomerService: {
+    provisionTrialForNewUser: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/config", () => ({
+  emailConfig: { enabled: true },
+  registrationConfig: { enabled: true },
+  isDevelopment: () => false,
+}));
+
+vi.mock("@/config/deployment", () => ({
+  isSelfHostedMode: () => false,
+  isCloudMode: () => false,
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+vi.mock("@/mappers/auth", () => ({
+  UserMapper: {
+    toApiResponse: vi.fn((u) => ({ id: u.id, email: u.email })),
+  },
+}));
+
+const { registrationRouter } = await import("../registration");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      user: { findUnique: mockUserFindUnique, create: mockUserCreate },
+      account: { create: mockAccountCreate },
+      $transaction: mockTransaction,
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: null,
+    locale: "en",
+    req: {},
+    ...overrides,
+  };
+}
+
+const validInput = {
+  email: "new@example.com",
+  password: "Password123!",
+  firstName: "John",
+  lastName: "Doe",
+  acceptTerms: true,
+  sourceApp: "app" as const,
+};
+
+const mockCreatedUser = {
+  id: "user-new",
+  email: "new@example.com",
+  firstName: "John",
+  lastName: "Doe",
+  role: "USER",
+  workspaceId: null,
+  isActive: true,
+  emailVerified: false,
+  lastLogin: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// --- Tests ---
+
+describe("registrationRouter.register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws FORBIDDEN when registration is disabled", async () => {
+    const config = await import("@/config");
+    const descriptor = Object.getOwnPropertyDescriptor(
+      config.registrationConfig,
+      "enabled"
+    )!;
+    Object.defineProperty(config.registrationConfig, "enabled", {
+      ...descriptor,
+      value: false,
+    });
+
+    try {
+      const caller = registrationRouter.createCaller(makeCtx() as never);
+      await expect(caller.register(validInput)).rejects.toMatchObject({
+        code: "FORBIDDEN",
+      });
+    } finally {
+      Object.defineProperty(config.registrationConfig, "enabled", descriptor);
+    }
+  });
+
+  it("throws BAD_REQUEST when terms not accepted", async () => {
+    const caller = registrationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.register({ ...validInput, acceptTerms: false })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("throws BAD_REQUEST when email already exists", async () => {
+    mockUserFindUnique.mockResolvedValue({ id: "existing-user" });
+
+    const caller = registrationRouter.createCaller(makeCtx() as never);
+    await expect(caller.register(validInput)).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("creates user and account in transaction when email is free", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        user: { create: vi.fn().mockResolvedValue(mockCreatedUser) },
+        account: { create: vi.fn().mockResolvedValue({}) },
+      };
+      return fn(tx);
+    });
+
+    const caller = registrationRouter.createCaller(makeCtx() as never);
+    const result = await caller.register(validInput);
+
+    expect(result.user).toBeDefined();
+    expect(result.autoVerified).toBe(false);
+    expect(mockTransaction).toHaveBeenCalledOnce();
+  });
+
+  it("auto-verifies user when email is disabled", async () => {
+    const { emailConfig } = await import("@/config");
+    vi.mocked(emailConfig).enabled = false;
+
+    mockUserFindUnique.mockResolvedValue(null);
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        user: {
+          create: vi.fn().mockResolvedValue({
+            ...mockCreatedUser,
+            emailVerified: true,
+          }),
+        },
+        account: { create: vi.fn().mockResolvedValue({}) },
+      };
+      return fn(tx);
+    });
+
+    const caller = registrationRouter.createCaller(makeCtx() as never);
+    const result = await caller.register(validInput);
+
+    expect(result.autoVerified).toBe(true);
+
+    vi.mocked(emailConfig).enabled = true;
+  });
+});

--- a/apps/api/src/trpc/routers/auth/__tests__/session.test.ts
+++ b/apps/api/src/trpc/routers/auth/__tests__/session.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockUserFindUnique = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: { findUnique: (...a: unknown[]) => mockUserFindUnique(...a) },
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+vi.mock("@/mappers/auth", () => ({
+  UserMapper: {
+    toApiResponse: vi.fn((u) => ({
+      id: u.id,
+      email: u.email,
+      authProvider: null,
+      hasPassword: false,
+    })),
+  },
+}));
+
+const { sessionRouter } = await import("../session");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      user: { findUnique: mockUserFindUnique },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: { id: "user-1", email: "test@example.com", isActive: true },
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockFullUser = {
+  id: "user-1",
+  email: "test@example.com",
+  image: null,
+  firstName: "John",
+  lastName: "Doe",
+  role: "USER",
+  workspaceId: "ws-1",
+  isActive: true,
+  emailVerified: true,
+  lastLogin: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  pendingEmail: null,
+  subscription: null,
+  workspace: { id: "ws-1" },
+  accounts: [{ providerId: "credential" }],
+};
+
+// --- Tests ---
+
+describe("sessionRouter.getSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws NOT_FOUND when user no longer exists in DB", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const caller = sessionRouter.createCaller(makeCtx() as never);
+    await expect(caller.getSession()).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("returns user with credential auth provider", async () => {
+    mockUserFindUnique.mockResolvedValue(mockFullUser);
+
+    const caller = sessionRouter.createCaller(makeCtx() as never);
+    const result = await caller.getSession();
+
+    expect(result.user).toBeDefined();
+    expect(result.user.id).toBe("user-1");
+  });
+
+  it("sets authProvider=google when account has google providerId", async () => {
+    const { UserMapper } = await import("@/mappers/auth");
+    const mapped = {
+      id: "user-1",
+      email: "test@example.com",
+      authProvider: null as string | null,
+      hasPassword: false,
+    };
+    vi.mocked(UserMapper.toApiResponse).mockReturnValue(mapped as never);
+
+    mockUserFindUnique.mockResolvedValue({
+      ...mockFullUser,
+      accounts: [{ providerId: "google" }],
+    });
+
+    const caller = sessionRouter.createCaller(makeCtx() as never);
+    const result = await caller.getSession();
+
+    expect(result.user.authProvider).toBe("google");
+    expect(result.user.hasPassword).toBe(false);
+  });
+
+  it("sets authProvider=password and hasPassword=true for credential account", async () => {
+    const { UserMapper } = await import("@/mappers/auth");
+    const mapped = {
+      id: "user-1",
+      email: "test@example.com",
+      authProvider: null as string | null,
+      hasPassword: false,
+    };
+    vi.mocked(UserMapper.toApiResponse).mockReturnValue(mapped as never);
+
+    mockUserFindUnique.mockResolvedValue({
+      ...mockFullUser,
+      accounts: [{ providerId: "credential" }],
+    });
+
+    const caller = sessionRouter.createCaller(makeCtx() as never);
+    const result = await caller.getSession();
+
+    expect(result.user.authProvider).toBe("password");
+    expect(result.user.hasPassword).toBe(true);
+  });
+
+  it("fetches user by ctx.user.id", async () => {
+    mockUserFindUnique.mockResolvedValue(mockFullUser);
+
+    const caller = sessionRouter.createCaller(makeCtx() as never);
+    await caller.getSession();
+
+    expect(mockUserFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "user-1" } })
+    );
+  });
+});

--- a/apps/api/src/trpc/routers/auth/__tests__/verification.test.ts
+++ b/apps/api/src/trpc/routers/auth/__tests__/verification.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockUserFindUnique = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: { findUnique: (...a: unknown[]) => mockUserFindUnique(...a) },
+  },
+}));
+
+const mockVerifyToken = vi.fn();
+const mockGenerateVerificationToken = vi.fn().mockResolvedValue("tok-abc");
+const mockSendVerificationEmail = vi.fn().mockResolvedValue({ success: true });
+
+vi.mock("@/services/email/email-verification.service", () => ({
+  EmailVerificationService: {
+    verifyToken: (...a: unknown[]) => mockVerifyToken(...a),
+    generateVerificationToken: (...a: unknown[]) =>
+      mockGenerateVerificationToken(...a),
+    sendVerificationEmail: (...a: unknown[]) => mockSendVerificationEmail(...a),
+  },
+}));
+
+vi.mock("@/services/integrations/notion.service", () => ({
+  notionService: { syncUser: vi.fn() },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+vi.mock("@/mappers/auth", () => ({
+  UserMapper: { toApiResponse: vi.fn((u) => ({ id: u.id, email: u.email })) },
+}));
+
+const { verificationRouter } = await import("../verification");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      user: { findUnique: mockUserFindUnique },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: null,
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockUser = {
+  id: "user-1",
+  email: "test@example.com",
+  firstName: "John",
+  lastName: "Doe",
+  role: "USER",
+  workspaceId: null,
+  isActive: true,
+  emailVerified: true,
+  emailVerifiedAt: new Date(),
+  lastLogin: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  pendingEmail: null,
+};
+
+// --- Tests ---
+
+describe("verificationRouter.verifyEmail", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws BAD_REQUEST when token is invalid", async () => {
+    mockVerifyToken.mockResolvedValue({
+      success: false,
+      error: "Invalid token",
+    });
+
+    const caller = verificationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.verifyEmail({ token: "bad-tok" })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("throws NOT_FOUND when user is missing after verification", async () => {
+    mockVerifyToken.mockResolvedValue({
+      success: true,
+      user: { id: "user-1" },
+    });
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const caller = verificationRouter.createCaller(makeCtx() as never);
+    await expect(caller.verifyEmail({ token: "tok-ok" })).rejects.toMatchObject(
+      {
+        code: "NOT_FOUND",
+      }
+    );
+  });
+
+  it("returns user on successful verification", async () => {
+    mockVerifyToken.mockResolvedValue({
+      success: true,
+      user: { id: "user-1" },
+    });
+    mockUserFindUnique.mockResolvedValue(mockUser);
+
+    const caller = verificationRouter.createCaller(makeCtx() as never);
+    const result = await caller.verifyEmail({ token: "tok-ok" });
+
+    expect(result.message).toBe("Email verified successfully");
+    expect(result.user).toBeDefined();
+  });
+});
+
+describe("verificationRouter.resendVerification", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws BAD_REQUEST when unauthenticated and no email provided", async () => {
+    const caller = verificationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.resendVerification({ type: "SIGNUP" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("throws UNAUTHORIZED when EMAIL_CHANGE requested unauthenticated", async () => {
+    const caller = verificationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.resendVerification({ type: "EMAIL_CHANGE", email: "x@x.com" })
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+
+  it("returns generic message for non-existent email (security)", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const caller = verificationRouter.createCaller(makeCtx() as never);
+    const result = await caller.resendVerification({
+      type: "SIGNUP",
+      email: "ghost@example.com",
+    });
+
+    expect(result.message).toContain("If an account exists");
+  });
+
+  it("throws BAD_REQUEST when email already verified (SIGNUP type)", async () => {
+    mockUserFindUnique.mockResolvedValue({
+      ...mockUser,
+      emailVerified: true,
+      isActive: true,
+    });
+
+    const caller = verificationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.resendVerification({ type: "SIGNUP", email: "test@example.com" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("sends verification email for authenticated user", async () => {
+    const authedCtx = makeCtx({
+      user: {
+        id: "user-1",
+        email: "test@example.com",
+        firstName: "John",
+        workspaceId: null,
+      },
+    });
+
+    const caller = verificationRouter.createCaller(authedCtx as never);
+    const result = await caller.resendVerification({ type: "SIGNUP" });
+
+    expect(mockGenerateVerificationToken).toHaveBeenCalledOnce();
+    expect(mockSendVerificationEmail).toHaveBeenCalledOnce();
+    expect(result.message).toBe("Verification email sent successfully");
+  });
+
+  it("throws BAD_REQUEST when authenticated user has no pending email for EMAIL_CHANGE", async () => {
+    mockUserFindUnique.mockResolvedValue({ ...mockUser, pendingEmail: null });
+
+    const authedCtx = makeCtx({
+      user: {
+        id: "user-1",
+        email: "test@example.com",
+        firstName: "John",
+        workspaceId: null,
+      },
+    });
+
+    const caller = verificationRouter.createCaller(authedCtx as never);
+    await expect(
+      caller.resendVerification({ type: "EMAIL_CHANGE" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+});
+
+describe("verificationRouter.getVerificationStatus", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when user does not exist", async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const ctx = makeCtx({ user: { id: "user-1", isActive: true } });
+    const caller = verificationRouter.createCaller(ctx as never);
+    await expect(caller.getVerificationStatus()).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("returns verification status", async () => {
+    mockUserFindUnique.mockResolvedValue({
+      emailVerified: true,
+      emailVerifiedAt: new Date("2024-01-01"),
+      pendingEmail: "pending@example.com",
+    });
+
+    const ctx = makeCtx({ user: { id: "user-1", isActive: true } });
+    const caller = verificationRouter.createCaller(ctx as never);
+    const result = await caller.getVerificationStatus();
+
+    expect(result.emailVerified).toBe(true);
+    expect(result.pendingEmail).toBe("pending@example.com");
+  });
+});

--- a/apps/api/src/trpc/routers/payment/__tests__/checkout.test.ts
+++ b/apps/api/src/trpc/routers/payment/__tests__/checkout.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockOrgFindUnique = vi.fn();
+const mockOrgUpdate = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    organization: {
+      findUnique: (...a: unknown[]) => mockOrgFindUnique(...a),
+      update: (...a: unknown[]) => mockOrgUpdate(...a),
+    },
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+vi.mock("@/services/stripe/stripe.service", () => ({
+  StripeService: {
+    createCustomer: vi.fn().mockResolvedValue({ id: "cus-123" }),
+    createCheckoutSession: vi
+      .fn()
+      .mockResolvedValue({ url: "https://checkout.stripe.com/test" }),
+  },
+}));
+
+vi.mock("@/core/utils", () => ({
+  getUserDisplayName: vi.fn((u) => u?.email ?? ""),
+}));
+
+const { checkoutRouter } = await import("../checkout");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      organization: { findUnique: mockOrgFindUnique, update: mockOrgUpdate },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    organizationId: "org-1",
+    orgRole: "ADMIN",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    locale: "en",
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe("checkoutRouter.createCheckoutSession", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws BAD_REQUEST when plan is FREE", async () => {
+    const caller = checkoutRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.createCheckoutSession({ plan: "FREE", billingInterval: "monthly" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("throws BAD_REQUEST when organization does not exist", async () => {
+    mockOrgFindUnique.mockResolvedValue(null);
+
+    const caller = checkoutRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.createCheckoutSession({
+        plan: "DEVELOPER",
+        billingInterval: "monthly",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("creates checkout session with existing Stripe customer", async () => {
+    mockOrgFindUnique.mockResolvedValue({
+      id: "org-1",
+      stripeCustomerId: "cus-existing",
+    });
+
+    const caller = checkoutRouter.createCaller(makeCtx() as never);
+    const result = await caller.createCheckoutSession({
+      plan: "DEVELOPER",
+      billingInterval: "monthly",
+    });
+
+    expect(result.url).toBe("https://checkout.stripe.com/test");
+  });
+
+  it("creates Stripe customer when none exists and updates org", async () => {
+    mockOrgFindUnique.mockResolvedValue({
+      id: "org-1",
+      stripeCustomerId: null,
+    });
+    mockOrgUpdate.mockResolvedValue({});
+
+    const caller = checkoutRouter.createCaller(makeCtx() as never);
+    const result = await caller.createCheckoutSession({
+      plan: "ENTERPRISE",
+      billingInterval: "yearly",
+    });
+
+    expect(mockOrgUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "org-1" },
+        data: { stripeCustomerId: "cus-123" },
+      })
+    );
+    expect(result.url).toBe("https://checkout.stripe.com/test");
+  });
+});

--- a/apps/api/src/trpc/routers/payment/__tests__/subscription.test.ts
+++ b/apps/api/src/trpc/routers/payment/__tests__/subscription.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockOrgFindUnique = vi.fn();
+const mockOrgUpdate = vi.fn();
+const mockSubscriptionUpdateMany = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    organization: {
+      findUnique: (...a: unknown[]) => mockOrgFindUnique(...a),
+      update: (...a: unknown[]) => mockOrgUpdate(...a),
+    },
+    subscription: {
+      updateMany: (...a: unknown[]) => mockSubscriptionUpdateMany(...a),
+    },
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+const mockCancelSubscription = vi.fn();
+const mockCreateCheckoutSession = vi.fn();
+const mockCreateCustomer = vi.fn().mockResolvedValue({ id: "cus-123" });
+
+vi.mock("@/services/stripe/stripe.service", () => ({
+  StripeService: {
+    cancelSubscription: (...a: unknown[]) => mockCancelSubscription(...a),
+    createCheckoutSession: (...a: unknown[]) => mockCreateCheckoutSession(...a),
+    createCustomer: (...a: unknown[]) => mockCreateCustomer(...a),
+  },
+}));
+
+vi.mock("@/services/stripe/core.service", () => ({
+  CoreStripeService: {
+    mapStripeStatusToSubscriptionStatus: vi.fn((s) => s),
+  },
+}));
+
+vi.mock("@/core/utils", () => ({
+  getUserDisplayName: vi.fn((u) => u?.email ?? ""),
+}));
+
+const { subscriptionRouter } = await import("../subscription");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      organization: { findUnique: mockOrgFindUnique, update: mockOrgUpdate },
+      subscription: { updateMany: mockSubscriptionUpdateMany },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    organizationId: "org-1",
+    orgRole: "ADMIN",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    locale: "en",
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe("subscriptionRouter.cancelSubscription", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws BAD_REQUEST when org has no active subscription", async () => {
+    mockOrgFindUnique.mockResolvedValue({ stripeSubscriptionId: null });
+
+    const caller = subscriptionRouter.createCaller(makeCtx() as never);
+    await expect(caller.cancelSubscription({})).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("cancels subscription and returns success", async () => {
+    mockOrgFindUnique.mockResolvedValue({ stripeSubscriptionId: "sub-123" });
+    mockCancelSubscription.mockResolvedValue({
+      id: "sub-123",
+      status: "canceled",
+      cancel_at_period_end: false,
+      canceled_at: null,
+      items: { data: [] },
+    });
+    mockSubscriptionUpdateMany.mockResolvedValue({ count: 1 });
+
+    const caller = subscriptionRouter.createCaller(makeCtx() as never);
+    const result = await caller.cancelSubscription({ cancelImmediately: true });
+
+    expect(result.success).toBe(true);
+    expect(result.subscription.id).toBe("sub-123");
+  });
+});
+
+describe("subscriptionRouter.renewSubscription", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws BAD_REQUEST when org does not exist", async () => {
+    mockOrgFindUnique.mockResolvedValue(null);
+
+    const caller = subscriptionRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.renewSubscription({ plan: "DEVELOPER" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("returns checkout URL for renewal", async () => {
+    mockOrgFindUnique.mockResolvedValue({
+      id: "org-1",
+      stripeCustomerId: "cus-existing",
+    });
+    mockCreateCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/renew",
+    });
+
+    const caller = subscriptionRouter.createCaller(makeCtx() as never);
+    const result = await caller.renewSubscription({
+      plan: "ENTERPRISE",
+      interval: "yearly",
+    });
+
+    expect(result.url).toBe("https://checkout.stripe.com/renew");
+  });
+});

--- a/apps/api/src/trpc/routers/portal/__tests__/license.test.ts
+++ b/apps/api/src/trpc/routers/portal/__tests__/license.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockOrgFindUnique = vi.fn();
+const mockOrgUpdate = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    organization: {
+      findUnique: (...a: unknown[]) => mockOrgFindUnique(...a),
+      update: (...a: unknown[]) => mockOrgUpdate(...a),
+    },
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+const mockValidateLicense = vi.fn();
+const mockGetLicensesForUser = vi.fn();
+
+vi.mock("@/services/license/license.service", () => ({
+  licenseService: {
+    validateLicense: (...a: unknown[]) => mockValidateLicense(...a),
+    getLicensesForUser: (...a: unknown[]) => mockGetLicensesForUser(...a),
+  },
+}));
+
+vi.mock("@/services/stripe/stripe.service", () => ({
+  StripeService: {
+    createCustomer: vi.fn().mockResolvedValue({ id: "cus-123" }),
+  },
+  stripe: {
+    checkout: {
+      sessions: {
+        create: vi
+          .fn()
+          .mockResolvedValue({ url: "https://checkout.stripe.com/license" }),
+      },
+    },
+  },
+}));
+
+vi.mock("@/mappers/license", () => ({
+  LicenseMapper: {
+    toApiResponseArray: vi.fn((l) => l),
+  },
+}));
+
+vi.mock("@/core/utils", () => ({
+  getUserDisplayName: vi.fn((u) => u?.email ?? ""),
+}));
+
+const { licenseRouter } = await import("../license");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      organization: { findUnique: mockOrgFindUnique, update: mockOrgUpdate },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    organizationId: "org-1",
+    orgRole: "ADMIN",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    locale: "en",
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe("licenseRouter.validate", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws FORBIDDEN when license is invalid", async () => {
+    mockValidateLicense.mockResolvedValue({
+      valid: false,
+      message: "License expired",
+    });
+
+    const caller = licenseRouter.createCaller(makeCtx({ user: null }) as never);
+    await expect(
+      caller.validate({ licenseKey: "bad-key" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("returns valid=true with license data when valid", async () => {
+    const expiresAt = new Date("2026-12-31");
+    mockValidateLicense.mockResolvedValue({
+      valid: true,
+      license: { id: "lic-1", tier: "DEVELOPER", expiresAt },
+    });
+
+    const caller = licenseRouter.createCaller(makeCtx({ user: null }) as never);
+    const result = await caller.validate({ licenseKey: "valid-key" });
+
+    expect(result.valid).toBe(true);
+    expect(result.license?.expiresAt).toBe(expiresAt.toISOString());
+  });
+});
+
+describe("licenseRouter.getLicenses", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns licenses for authenticated user", async () => {
+    const licenses = [{ id: "lic-1", tier: "DEVELOPER" }];
+    mockGetLicensesForUser.mockResolvedValue(licenses);
+
+    const caller = licenseRouter.createCaller(makeCtx() as never);
+    const result = await caller.getLicenses();
+
+    expect(result.licenses).toEqual(licenses);
+    expect(mockGetLicensesForUser).toHaveBeenCalledWith(
+      "admin@test.com",
+      "ws-1"
+    );
+  });
+});
+
+describe("licenseRouter.purchaseLicense", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws BAD_REQUEST when org does not exist", async () => {
+    mockOrgFindUnique.mockResolvedValue(null);
+
+    const caller = licenseRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.purchaseLicense({ tier: "DEVELOPER" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("returns checkout URL when org exists with customer", async () => {
+    mockOrgFindUnique.mockResolvedValue({
+      id: "org-1",
+      stripeCustomerId: "cus-existing",
+    });
+
+    const caller = licenseRouter.createCaller(makeCtx() as never);
+    const result = await caller.purchaseLicense({ tier: "DEVELOPER" });
+
+    expect(result.checkoutUrl).toBe("https://checkout.stripe.com/license");
+  });
+});

--- a/apps/api/src/trpc/routers/public/__tests__/invitation.test.ts
+++ b/apps/api/src/trpc/routers/public/__tests__/invitation.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockInvitationFindFirst = vi.fn();
+const mockUserFindUnique = vi.fn();
+const mockUserCreate = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    invitation: {
+      findFirst: (...a: unknown[]) => mockInvitationFindFirst(...a),
+    },
+    user: {
+      findUnique: (...a: unknown[]) => mockUserFindUnique(...a),
+      create: (...a: unknown[]) => mockUserCreate(...a),
+    },
+    $transaction: (...a: unknown[]) => mockTransaction(...a),
+  },
+}));
+
+vi.mock("@/core/auth", () => ({
+  hashPassword: vi.fn().mockResolvedValue("hashed-pw"),
+}));
+
+vi.mock("@/core/utils", () => ({
+  formatInvitedBy: vi.fn((u) => u),
+}));
+
+vi.mock("@/core/workspace-access", () => ({
+  ensureWorkspaceMember: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  getWorkspacePlan: vi.fn().mockResolvedValue("FREE"),
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+const { publicInvitationRouter } = await import("../invitation");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      invitation: { findFirst: mockInvitationFindFirst },
+      user: { findUnique: mockUserFindUnique, create: mockUserCreate },
+      $transaction: mockTransaction,
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: null,
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const futureDate = new Date(Date.now() + 86_400_000);
+
+const mockInvitation = {
+  id: "inv-1",
+  email: "user@example.com",
+  role: "MEMBER",
+  token: "tok-abc",
+  status: "PENDING",
+  expiresAt: futureDate,
+  workspaceId: "ws-1",
+  workspace: {
+    id: "ws-1",
+    name: "Test Workspace",
+    contactEmail: "ws@test.com",
+  },
+  invitedBy: {
+    id: "u-1",
+    email: "admin@test.com",
+    firstName: "Admin",
+    lastName: null,
+  },
+};
+
+// --- Tests ---
+
+describe("publicInvitationRouter.getDetails", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND for invalid/expired token", async () => {
+    mockInvitationFindFirst.mockResolvedValue(null);
+
+    const caller = publicInvitationRouter.createCaller(makeCtx() as never);
+    await expect(caller.getDetails({ token: "bad-tok" })).rejects.toMatchObject(
+      {
+        code: "NOT_FOUND",
+      }
+    );
+  });
+
+  it("returns invitation details with workspace plan", async () => {
+    mockInvitationFindFirst.mockResolvedValue(mockInvitation);
+
+    const caller = publicInvitationRouter.createCaller(makeCtx() as never);
+    const result = await caller.getDetails({ token: "tok-abc" });
+
+    expect(result.success).toBe(true);
+    expect(result.invitation.workspace.id).toBe("ws-1");
+    expect(result.invitation.workspace.plan).toBe("FREE");
+  });
+});
+
+describe("publicInvitationRouter.accept", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const acceptInput = {
+    token: "tok-abc",
+    password: "Password123!",
+    firstName: "Jane",
+    lastName: "Doe",
+  };
+
+  it("throws NOT_FOUND for invalid/expired invitation token", async () => {
+    mockInvitationFindFirst.mockResolvedValue(null);
+
+    const caller = publicInvitationRouter.createCaller(makeCtx() as never);
+    await expect(caller.accept(acceptInput)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("creates user and accepts invitation in transaction", async () => {
+    mockInvitationFindFirst.mockResolvedValue(mockInvitation);
+    mockUserFindUnique.mockResolvedValue(null); // email not already taken
+    const newUser = {
+      id: "new-user",
+      email: "user@example.com",
+      firstName: "Jane",
+      lastName: "Doe",
+      role: "MEMBER",
+      workspaceId: "ws-1",
+    };
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        user: { create: vi.fn().mockResolvedValue(newUser) },
+        account: { create: vi.fn() },
+        invitation: { update: vi.fn() },
+        workspaceMember: { create: vi.fn() },
+      };
+      return fn(tx);
+    });
+
+    const caller = publicInvitationRouter.createCaller(makeCtx() as never);
+    const result = await caller.accept(acceptInput);
+
+    expect(mockTransaction).toHaveBeenCalledOnce();
+    expect(result.message).toBeDefined();
+    expect(result.user.id).toBe("new-user");
+  });
+
+  it("throws CONFLICT when email is already registered", async () => {
+    mockInvitationFindFirst.mockResolvedValue(mockInvitation);
+    mockUserFindUnique.mockResolvedValue({ id: "existing-user" });
+
+    const caller = publicInvitationRouter.createCaller(makeCtx() as never);
+    await expect(caller.accept(acceptInput)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/definitions.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/definitions.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClientFromServer = vi.fn();
+
+vi.mock("@/core/prisma", () => ({ prisma: {} }));
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+}));
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClientFromServer: (...a: unknown[]) =>
+    mockCreateRabbitMQClientFromServer(...a),
+}));
+
+const { definitionsRouter } = await import("../definitions");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {},
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockServer = { id: "srv-1", workspaceId: "ws-1" };
+
+const mockDefinitions = {
+  rabbit_version: "3.12.0",
+  queues: [{ name: "my-queue", vhost: "/" }],
+  exchanges: [],
+  bindings: [],
+};
+
+// --- Tests ---
+
+describe("definitionsRouter.getDefinitions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = definitionsRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "user@test.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.getDefinitions({ serverId: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = definitionsRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getDefinitions({ serverId: "srv-999", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns definitions for all vhosts when no vhost provided", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      getDefinitions: vi.fn().mockResolvedValue(mockDefinitions),
+    };
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+
+    const caller = definitionsRouter.createCaller(makeCtx() as never);
+    const result = await caller.getDefinitions({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(result).toEqual(mockDefinitions);
+    expect(mockClient.getDefinitions).toHaveBeenCalledWith(undefined);
+  });
+
+  it("passes decoded vhost to client.getDefinitions", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      getDefinitions: vi.fn().mockResolvedValue(mockDefinitions),
+    };
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+
+    const caller = definitionsRouter.createCaller(makeCtx() as never);
+    await caller.getDefinitions({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      vhost: "%2F",
+    });
+
+    expect(mockClient.getDefinitions).toHaveBeenCalledWith("/");
+  });
+});
+
+describe("definitionsRouter.importDefinitions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = definitionsRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "user@test.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.importDefinitions({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        definitions: mockDefinitions,
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = definitionsRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.importDefinitions({
+        serverId: "srv-999",
+        workspaceId: "ws-1",
+        definitions: mockDefinitions,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("calls uploadDefinitions and returns undefined on success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      uploadDefinitions: vi.fn().mockResolvedValue(undefined),
+    };
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+
+    const caller = definitionsRouter.createCaller(makeCtx() as never);
+    const result = await caller.importDefinitions({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      definitions: mockDefinitions,
+    });
+
+    expect(mockClient.uploadDefinitions).toHaveBeenCalledWith(
+      mockDefinitions,
+      undefined
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("passes decoded vhost to uploadDefinitions", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      uploadDefinitions: vi.fn().mockResolvedValue(undefined),
+    };
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+
+    const caller = definitionsRouter.createCaller(makeCtx() as never);
+    await caller.importDefinitions({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      definitions: mockDefinitions,
+      vhost: "%2F",
+    });
+
+    expect(mockClient.uploadDefinitions).toHaveBeenCalledWith(
+      mockDefinitions,
+      "/"
+    );
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/infrastructure.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/infrastructure.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClient = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: { rabbitMQServer: { update: vi.fn() } },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+}));
+
+vi.mock("@/mappers/rabbitmq", () => ({
+  NodeMapper: { toApiResponseArray: vi.fn((ns) => ns) },
+  ExchangeMapper: { toApiResponseArray: vi.fn((es) => es) },
+  BindingMapper: { toApiResponseArray: vi.fn((bs) => bs) },
+}));
+
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClient: (...a: unknown[]) => mockCreateRabbitMQClient(...a),
+  createRabbitMQClientFromServer: vi.fn(),
+}));
+
+const { infrastructureRouter } = await import("../infrastructure");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: { rabbitMQServer: { update: vi.fn() } },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    locale: "en",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    ...overrides,
+  };
+}
+
+const mockServer = {
+  id: "srv-1",
+  name: "Test Server",
+  host: "rabbitmq.example.com",
+  port: 15672,
+  useHttps: false,
+  workspaceId: "ws-1",
+};
+
+const mockClient = {
+  getNodes: vi.fn().mockResolvedValue([]),
+  getConnections: vi.fn().mockResolvedValue([]),
+  getChannels: vi.fn().mockResolvedValue([]),
+  getExchanges: vi.fn().mockResolvedValue([]),
+  getBindings: vi.fn().mockResolvedValue([]),
+  createExchange: vi.fn().mockResolvedValue(undefined),
+  deleteExchange: vi.fn().mockResolvedValue(undefined),
+};
+
+// --- Tests ---
+
+describe("infrastructureRouter.getNodes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = infrastructureRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getNodes({ serverId: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns nodes list on success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    mockClient.getNodes.mockResolvedValue([
+      { name: "rabbit@node1", running: true },
+    ]);
+
+    const caller = infrastructureRouter.createCaller(makeCtx() as never);
+    const result = await caller.getNodes({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.nodes).toBeDefined();
+    expect(mockClient.getNodes).toHaveBeenCalled();
+  });
+});
+
+describe("infrastructureRouter.getConnections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = infrastructureRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getConnections({ serverId: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns connections and channel counts on success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    mockClient.getConnections.mockResolvedValue([
+      { name: "conn-1" },
+      { name: "conn-2" },
+    ]);
+    mockClient.getChannels.mockResolvedValue([{ name: "chan-1" }]);
+
+    const caller = infrastructureRouter.createCaller(makeCtx() as never);
+    const result = await caller.getConnections({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.totalConnections).toBe(2);
+    expect(result.totalChannels).toBe(1);
+  });
+});
+
+describe("infrastructureRouter.createExchange (ADMIN only)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = infrastructureRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.createExchange({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        name: "my-exchange",
+        type: "direct",
+        vhost: "/",
+        durable: true,
+        auto_delete: false,
+        internal: false,
+        arguments: {},
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("creates exchange and returns success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+
+    const caller = infrastructureRouter.createCaller(makeCtx() as never);
+    const result = await caller.createExchange({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      name: "my-exchange",
+      type: "direct",
+      vhost: "/",
+      durable: true,
+      auto_delete: false,
+      internal: false,
+      arguments: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockClient.createExchange).toHaveBeenCalledWith(
+      "my-exchange",
+      "direct",
+      "/",
+      expect.any(Object)
+    );
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = infrastructureRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.createExchange({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        name: "my-exchange",
+        type: "direct",
+        vhost: "/",
+        durable: true,
+        auto_delete: false,
+        internal: false,
+        arguments: {},
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("infrastructureRouter.deleteExchange (ADMIN only)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = infrastructureRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.deleteExchange({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        exchangeName: "old-exchange",
+        vhost: "/",
+        ifUnused: false,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("deletes exchange and returns success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+
+    const caller = infrastructureRouter.createCaller(makeCtx() as never);
+    const result = await caller.deleteExchange({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      exchangeName: "old-exchange",
+      vhost: "/",
+      ifUnused: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockClient.deleteExchange).toHaveBeenCalledWith(
+      "old-exchange",
+      "/",
+      expect.any(Object)
+    );
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = infrastructureRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.deleteExchange({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        exchangeName: "old-exchange",
+        vhost: "/",
+        ifUnused: false,
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/memory.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/memory.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClient = vi.fn();
+
+vi.mock("@/core/prisma", () => ({ prisma: {} }));
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+}));
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClient: (...a: unknown[]) => mockCreateRabbitMQClient(...a),
+}));
+
+const { memoryRouter } = await import("../memory");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {},
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockServer = {
+  id: "srv-1",
+  workspaceId: "ws-1",
+  workspace: { id: "ws-1", name: "Test WS" },
+};
+
+const mockNode = {
+  name: "rabbit@node1",
+  running: true,
+  uptime: 1000000,
+  mem_limit: 8589934592,
+  mem_used: 2147483648,
+  mem_alarm: false,
+  mem_calculation_strategy: "rss",
+  fd_used: 100,
+  fd_total: 1024,
+  sockets_used: 10,
+  sockets_total: 100,
+  proc_used: 200,
+  proc_total: 1048576,
+  gc_num: 5000,
+  gc_bytes_reclaimed: 100000,
+  gc_num_details: { rate: 10 },
+  io_read_count: 1000,
+  io_read_bytes: 500000,
+  io_read_avg_time: 0.5,
+  io_write_count: 2000,
+  io_write_bytes: 1000000,
+  io_write_avg_time: 0.3,
+  io_sync_count: 500,
+  io_sync_avg_time: 0.1,
+  mnesia_ram_tx_count: 100,
+  mnesia_disk_tx_count: 50,
+  msg_store_read_count: 300,
+  msg_store_write_count: 400,
+  queue_index_read_count: 200,
+  queue_index_write_count: 300,
+  run_queue: 0,
+  processors: 4,
+  context_switches: 10000,
+  disk_free_alarm: false,
+  mem_used_details: { rate: 1024 },
+  disk_free_details: { rate: -512 },
+  fd_used_details: { rate: 0 },
+  sockets_used_details: { rate: 0 },
+  proc_used_details: { rate: 0 },
+};
+
+// --- Tests ---
+
+describe("memoryRouter.getNodeMemory", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = memoryRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getNodeMemory({
+        serverId: "srv-999",
+        workspaceId: "ws-1",
+        nodeName: "rabbit@node1",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws NOT_FOUND when server has no workspace", async () => {
+    mockVerifyServerAccess.mockResolvedValue({
+      ...mockServer,
+      workspace: null,
+    });
+    const mockClient = { getNodes: vi.fn().mockResolvedValue([mockNode]) };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = memoryRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getNodeMemory({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        nodeName: "rabbit@node1",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws NOT_FOUND when the requested node is not in the list", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = { getNodes: vi.fn().mockResolvedValue([mockNode]) };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = memoryRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getNodeMemory({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        nodeName: "rabbit@nonexistent",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns node memory data on success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = { getNodes: vi.fn().mockResolvedValue([mockNode]) };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = memoryRouter.createCaller(makeCtx() as never);
+    const result = await caller.getNodeMemory({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      nodeName: "rabbit@node1",
+    });
+
+    expect(result.node.name).toBe("rabbit@node1");
+    expect(result.node.running).toBe(true);
+    expect(result.node.immediate).toBeDefined();
+    expect(result.node.immediate.totalMemory).toBe(mockNode.mem_limit);
+    expect(result.node.immediate.usedMemory).toBe(mockNode.mem_used);
+    expect(result.planAccess.hasBasic).toBe(true);
+    expect(mockClient.getNodes).toHaveBeenCalledOnce();
+  });
+
+  it("returns correct memory usage percentage", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = { getNodes: vi.fn().mockResolvedValue([mockNode]) };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = memoryRouter.createCaller(makeCtx() as never);
+    const result = await caller.getNodeMemory({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      nodeName: "rabbit@node1",
+    });
+
+    const expectedPct = (mockNode.mem_used / mockNode.mem_limit) * 100;
+    expect(result.node.immediate.memoryUsagePercentage).toBeCloseTo(
+      expectedPct
+    );
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/messages.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/messages.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClient = vi.fn();
+
+vi.mock("@/core/prisma", () => ({ prisma: {} }));
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+}));
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClient: (...a: unknown[]) => mockCreateRabbitMQClient(...a),
+}));
+
+const { messagesRouter } = await import("../messages");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {},
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockServer = {
+  id: "srv-1",
+  workspaceId: "ws-1",
+};
+
+const baseInput = {
+  serverId: "srv-1",
+  workspaceId: "ws-1",
+  queueName: "my-queue",
+  message: "Hello, RabbitMQ!",
+  vhost: "%2F",
+};
+
+// --- Tests ---
+
+describe("messagesRouter.publishMessage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = messagesRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "user@test.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(caller.publishMessage(baseInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = messagesRouter.createCaller(makeCtx() as never);
+    await expect(caller.publishMessage(baseInput)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("throws BAD_REQUEST when server has no workspaceId", async () => {
+    mockVerifyServerAccess.mockResolvedValue({
+      ...mockServer,
+      workspaceId: null,
+    });
+
+    const caller = messagesRouter.createCaller(makeCtx() as never);
+    await expect(caller.publishMessage(baseInput)).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("returns success when message is routed", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      publishMessage: vi.fn().mockResolvedValue({ routed: true }),
+    };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = messagesRouter.createCaller(makeCtx() as never);
+    const result = await caller.publishMessage(baseInput);
+
+    expect(result.success).toBe(true);
+    expect(result.routed).toBe(true);
+    expect(result.queueName).toBe("my-queue");
+    expect(result.messageLength).toBe("Hello, RabbitMQ!".length);
+  });
+
+  it("uses queue name as routing key when no routingKey provided", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      publishMessage: vi.fn().mockResolvedValue({ routed: true }),
+    };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = messagesRouter.createCaller(makeCtx() as never);
+    await caller.publishMessage(baseInput);
+
+    // Default exchange = "", routing key = queue name
+    expect(mockClient.publishMessage).toHaveBeenCalledWith(
+      "",
+      "my-queue",
+      "/",
+      "Hello, RabbitMQ!",
+      undefined
+    );
+  });
+
+  it("uses provided exchange and routingKey when specified", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      publishMessage: vi.fn().mockResolvedValue({ routed: true }),
+    };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = messagesRouter.createCaller(makeCtx() as never);
+    await caller.publishMessage({
+      ...baseInput,
+      exchange: "my-exchange",
+      routingKey: "my-key",
+    });
+
+    expect(mockClient.publishMessage).toHaveBeenCalledWith(
+      "my-exchange",
+      "my-key",
+      "/",
+      "Hello, RabbitMQ!",
+      undefined
+    );
+  });
+
+  it("throws UNPROCESSABLE_CONTENT when message is not routed", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      publishMessage: vi.fn().mockResolvedValue({ routed: false }),
+    };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = messagesRouter.createCaller(makeCtx() as never);
+    await expect(caller.publishMessage(baseInput)).rejects.toMatchObject({
+      code: "UNPROCESSABLE_CONTENT",
+    });
+  });
+
+  it("converts camelCase properties to snake_case for publishMessage", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      publishMessage: vi.fn().mockResolvedValue({ routed: true }),
+    };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = messagesRouter.createCaller(makeCtx() as never);
+    await caller.publishMessage({
+      ...baseInput,
+      properties: {
+        deliveryMode: 2,
+        priority: 5,
+        contentType: "application/json",
+      },
+    });
+
+    expect(mockClient.publishMessage).toHaveBeenCalledWith(
+      "",
+      "my-queue",
+      "/",
+      "Hello, RabbitMQ!",
+      expect.objectContaining({
+        delivery_mode: 2,
+        priority: 5,
+        content_type: "application/json",
+      })
+    );
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/overview.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/overview.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClient = vi.fn();
+
+vi.mock("@/core/prisma", () => ({ prisma: {} }));
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+  getOverLimitWarningMessage: vi.fn().mockReturnValue("Over limit warning"),
+  getUpgradeRecommendationForOverLimit: vi
+    .fn()
+    .mockReturnValue({ message: "Upgrade now", recommendedPlan: "PRO" }),
+}));
+vi.mock("@/mappers/rabbitmq", () => ({
+  OverviewMapper: { toApiResponse: vi.fn((d) => d) },
+}));
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClient: (...a: unknown[]) => mockCreateRabbitMQClient(...a),
+}));
+
+const { overviewRouter } = await import("../overview");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {},
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockServer = {
+  id: "srv-1",
+  workspaceId: "ws-1",
+  isOverQueueLimit: false,
+  queueCountAtConnect: null,
+  overLimitWarningShown: false,
+  workspace: null,
+};
+
+const mockOverviewData = {
+  cluster_name: "rabbit@node1",
+  rabbitmq_version: "3.12.0",
+  queue_totals: { messages: 10 },
+};
+
+// --- Tests ---
+
+describe("overviewRouter.getOverview", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = overviewRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getOverview({ serverId: "srv-999", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns overview on success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      getOverview: vi.fn().mockResolvedValue(mockOverviewData),
+    };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = overviewRouter.createCaller(makeCtx() as never);
+    const result = await caller.getOverview({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.overview).toEqual(mockOverviewData);
+    expect(mockClient.getOverview).toHaveBeenCalledOnce();
+  });
+
+  it("includes warning block when server isOverQueueLimit", async () => {
+    const serverWithLimit = {
+      ...mockServer,
+      isOverQueueLimit: true,
+      queueCountAtConnect: 5,
+      overLimitWarningShown: false,
+      workspace: { id: "ws-1", name: "Test WS" },
+    };
+    mockVerifyServerAccess.mockResolvedValue(serverWithLimit);
+    const mockClient = {
+      getOverview: vi.fn().mockResolvedValue(mockOverviewData),
+    };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = overviewRouter.createCaller(makeCtx() as never);
+    const result = await caller.getOverview({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.warning).toBeDefined();
+    expect(result.warning?.isOverLimit).toBe(true);
+  });
+});
+
+describe("overviewRouter.setClusterName", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = overviewRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "user@test.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.setClusterName({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        name: "new-name",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = overviewRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.setClusterName({
+        serverId: "srv-999",
+        workspaceId: "ws-1",
+        name: "new-name",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns success when cluster name is set", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = { setClusterName: vi.fn().mockResolvedValue(undefined) };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = overviewRouter.createCaller(makeCtx() as never);
+    const result = await caller.setClusterName({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      name: "my-cluster",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockClient.setClusterName).toHaveBeenCalledWith("my-cluster");
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/policies.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/policies.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClient = vi.fn();
+
+vi.mock("@/core/prisma", () => ({ prisma: {} }));
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+}));
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClient: (...a: unknown[]) => mockCreateRabbitMQClient(...a),
+}));
+
+const { policiesRouter } = await import("../policies");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {},
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockServer = { id: "srv-1", workspaceId: "ws-1" };
+
+const mockPolicies = [
+  {
+    name: "ha-all",
+    vhost: "/",
+    pattern: ".*",
+    "apply-to": "all",
+    definition: { "ha-mode": "all" },
+    priority: 0,
+  },
+];
+
+const baseInput = { serverId: "srv-1", workspaceId: "ws-1" };
+
+// --- Tests ---
+
+describe("policiesRouter.getPolicies", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = policiesRouter.createCaller(makeCtx() as never);
+    await expect(caller.getPolicies(baseInput)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("returns policies list on success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = { getPolicies: vi.fn().mockResolvedValue(mockPolicies) };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = policiesRouter.createCaller(makeCtx() as never);
+    const result = await caller.getPolicies(baseInput);
+
+    expect(result.success).toBe(true);
+    expect(result.policies).toEqual(mockPolicies);
+    expect(result.totalPolicies).toBe(1);
+    expect(mockClient.getPolicies).toHaveBeenCalledWith(undefined);
+  });
+
+  it("passes decoded vhost to client.getPolicies", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = { getPolicies: vi.fn().mockResolvedValue([]) };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = policiesRouter.createCaller(makeCtx() as never);
+    await caller.getPolicies({ ...baseInput, vhost: "%2F" });
+
+    expect(mockClient.getPolicies).toHaveBeenCalledWith("/");
+  });
+});
+
+describe("policiesRouter.createOrUpdatePolicy", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = policiesRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "user@test.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.createOrUpdatePolicy({
+        ...baseInput,
+        vhost: "/",
+        name: "ha-all",
+        pattern: ".*",
+        applyTo: "all",
+        definition: { "ha-mode": "all" },
+        priority: 0,
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = policiesRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.createOrUpdatePolicy({
+        ...baseInput,
+        vhost: "/",
+        name: "ha-all",
+        pattern: ".*",
+        applyTo: "all",
+        definition: { "ha-mode": "all" },
+        priority: 0,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("calls createOrUpdatePolicy and returns success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = {
+      createOrUpdatePolicy: vi.fn().mockResolvedValue(undefined),
+    };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = policiesRouter.createCaller(makeCtx() as never);
+    const result = await caller.createOrUpdatePolicy({
+      ...baseInput,
+      vhost: "%2F",
+      name: "ha-all",
+      pattern: ".*",
+      applyTo: "all",
+      definition: { "ha-mode": "all" },
+      priority: 0,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockClient.createOrUpdatePolicy).toHaveBeenCalledWith(
+      "/",
+      "ha-all",
+      {
+        pattern: ".*",
+        "apply-to": "all",
+        definition: { "ha-mode": "all" },
+        priority: 0,
+      }
+    );
+  });
+});
+
+describe("policiesRouter.deletePolicy", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = policiesRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "user@test.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.deletePolicy({ ...baseInput, vhost: "/", policyName: "ha-all" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = policiesRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.deletePolicy({ ...baseInput, vhost: "/", policyName: "ha-all" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("calls deletePolicy and returns success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    const mockClient = { deletePolicy: vi.fn().mockResolvedValue(undefined) };
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+
+    const caller = policiesRouter.createCaller(makeCtx() as never);
+    const result = await caller.deletePolicy({
+      ...baseInput,
+      vhost: "%2F",
+      policyName: "ha-all",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockClient.deletePolicy).toHaveBeenCalledWith("/", "ha-all");
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/queues.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/queues.test.ts
@@ -1,0 +1,318 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClientFromServer = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    rabbitMQServer: { update: vi.fn() },
+    queue: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: "q-1" }),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    queueMetric: {
+      create: vi.fn().mockResolvedValue({}),
+      deleteMany: vi.fn().mockResolvedValue({}),
+    },
+    $transaction: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+  getOrgResourceCounts: vi
+    .fn()
+    .mockResolvedValue({ servers: 0, users: 0, workspaces: 0 }),
+  validateQueueCreationOnServer: vi.fn(),
+  getOverLimitWarningMessage: vi.fn().mockReturnValue("over limit"),
+  getUpgradeRecommendationForOverLimit: vi
+    .fn()
+    .mockReturnValue({ message: "upgrade", recommendedPlan: null }),
+  getPlanDisplayName: vi.fn().mockReturnValue("Free"),
+}));
+
+vi.mock("@/mappers/rabbitmq", () => ({
+  QueueMapper: {
+    toApiResponseArray: vi.fn((qs) => qs),
+    toApiResponse: vi.fn((q) => q),
+  },
+  ConsumerMapper: { toApiResponseArray: vi.fn((cs) => cs) },
+  BindingMapper: { toApiResponseArray: vi.fn((bs) => bs) },
+}));
+
+vi.mock("@/core/rabbitmq/AmqpClient", () => ({ RabbitMQAmqpClient: class {} }));
+vi.mock("@/core/rabbitmq/BoundedBuffer", () => ({ BoundedBuffer: class {} }));
+vi.mock("@/core/utils", () => ({ abortableSleep: vi.fn() }));
+
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClient: vi.fn(),
+  createRabbitMQClientFromServer: (...a: unknown[]) =>
+    mockCreateRabbitMQClientFromServer(...a),
+  createAmqpClient: vi.fn(),
+  createStandaloneAmqpConnection: vi.fn(),
+}));
+
+const { queuesRouter } = await import("../queues");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: { rabbitMQServer: { update: vi.fn() } },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    locale: "en",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    ...overrides,
+  };
+}
+
+const mockServer = {
+  id: "srv-1",
+  name: "Test Server",
+  host: "rabbitmq.example.com",
+  port: 15672,
+  amqpPort: 5672,
+  username: "enc:guest",
+  password: "enc:password",
+  vhost: "/",
+  useHttps: false,
+  isOverQueueLimit: false,
+  queueCountAtConnect: null,
+  overLimitWarningShown: false,
+  workspaceId: "ws-1",
+  workspace: { id: "ws-1", name: "Test WS" },
+};
+
+const mockClient = {
+  getQueues: vi.fn().mockResolvedValue([]),
+  getQueue: vi.fn().mockResolvedValue({ name: "test-queue", vhost: "/" }),
+  createQueue: vi.fn().mockResolvedValue({ name: "new-queue" }),
+  deleteQueue: vi.fn().mockResolvedValue(undefined),
+  purgeQueue: vi.fn().mockResolvedValue(undefined),
+  getQueueConsumers: vi.fn().mockResolvedValue([]),
+  getQueueBindings: vi.fn().mockResolvedValue([]),
+};
+
+// --- Tests ---
+
+describe("queuesRouter.getQueues", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = queuesRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getQueues({ serverId: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws NOT_FOUND when server has no workspace", async () => {
+    mockVerifyServerAccess.mockResolvedValue({
+      ...mockServer,
+      workspace: null,
+    });
+
+    const caller = queuesRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getQueues({ serverId: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns queue list on success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    mockClient.getQueues.mockResolvedValue([
+      { name: "q1", vhost: "/", messages: 0 },
+    ]);
+
+    const caller = queuesRouter.createCaller(makeCtx() as never);
+    const result = await caller.getQueues({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.queues).toBeDefined();
+    expect(mockClient.getQueues).toHaveBeenCalled();
+  });
+});
+
+describe("queuesRouter.createQueue (ADMIN only)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = queuesRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.createQueue({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        vhost: "/",
+        name: "my-queue",
+        durable: true,
+        autoDelete: false,
+        exclusive: false,
+        arguments: {},
+        routingKey: "",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("creates queue and returns success on valid input", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    mockClient.createQueue.mockResolvedValue({ name: "my-queue" });
+
+    const caller = queuesRouter.createCaller(makeCtx() as never);
+    const result = await caller.createQueue({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      vhost: "/",
+      name: "my-queue",
+      durable: true,
+      autoDelete: false,
+      exclusive: false,
+      arguments: {},
+      routingKey: "",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockClient.createQueue).toHaveBeenCalledWith(
+      "my-queue",
+      "/",
+      expect.objectContaining({ durable: true })
+    );
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = queuesRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.createQueue({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        vhost: "/",
+        name: "my-queue",
+        durable: true,
+        autoDelete: false,
+        exclusive: false,
+        arguments: {},
+        routingKey: "",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("queuesRouter.deleteQueue (ADMIN only)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = queuesRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.deleteQueue({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        queueName: "old-queue",
+        vhost: "/",
+        ifUnused: false,
+        ifEmpty: false,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("deletes queue and returns success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    mockClient.deleteQueue.mockResolvedValue(undefined);
+
+    const caller = queuesRouter.createCaller(makeCtx() as never);
+    const result = await caller.deleteQueue({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      queueName: "old-queue",
+      vhost: "/",
+      ifUnused: false,
+      ifEmpty: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockClient.deleteQueue).toHaveBeenCalledWith(
+      "old-queue",
+      "/",
+      expect.any(Object)
+    );
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = queuesRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.deleteQueue({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        queueName: "old-queue",
+        vhost: "/",
+        ifUnused: false,
+        ifEmpty: false,
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/server.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/server.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockServerFindMany = vi.fn();
+const mockServerFindUnique = vi.fn();
+const mockServerUpdate = vi.fn();
+const mockServerDelete = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    rabbitMQServer: {
+      findMany: (...a: unknown[]) => mockServerFindMany(...a),
+      findUnique: (...a: unknown[]) => mockServerFindUnique(...a),
+      update: (...a: unknown[]) => mockServerUpdate(...a),
+      delete: (...a: unknown[]) => mockServerDelete(...a),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+  getOrgResourceCounts: vi
+    .fn()
+    .mockResolvedValue({ servers: 0, users: 0, workspaces: 0 }),
+  validateServerCreation: vi.fn(),
+  validateRabbitMqVersion: vi.fn(),
+  extractMajorMinorVersion: vi.fn().mockReturnValue("3.12"),
+}));
+
+vi.mock("@/services/encryption.service", () => ({
+  EncryptionService: {
+    encrypt: vi.fn((v) => `enc:${v}`),
+    decrypt: vi.fn((v) => v?.replace?.("enc:", "") ?? v),
+    generateEncryptionKey: vi.fn().mockReturnValue("key-xyz"),
+  },
+}));
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClient = vi.fn();
+
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClient: (...a: unknown[]) => mockCreateRabbitMQClient(...a),
+  createRabbitMQClientFromServer: vi.fn(),
+}));
+
+vi.mock("@/services/alerts/alert.default-rules", () => ({
+  seedDefaultAlertRules: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetOverview = vi.fn();
+vi.mock("@/core/rabbitmq", () => {
+  return {
+    RabbitMQClient: class {
+      getOverview = mockGetOverview;
+    },
+    RabbitMQAmqpClientFactory: { createClient: vi.fn() },
+    QueuePauseState: {},
+  };
+});
+
+const { serverRouter } = await import("../server");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      rabbitMQServer: {
+        findMany: mockServerFindMany,
+        findUnique: mockServerFindUnique,
+        update: mockServerUpdate,
+        delete: mockServerDelete,
+      },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    locale: "en",
+    ...overrides,
+  };
+}
+
+const mockServer = {
+  id: "srv-1",
+  name: "My RabbitMQ",
+  host: "rabbitmq.example.com",
+  port: 15672,
+  amqpPort: 5672,
+  username: "enc:guest",
+  password: "enc:password",
+  vhost: "/",
+  useHttps: false,
+  isOverQueueLimit: false,
+  queueCountAtConnect: null,
+  overLimitWarningShown: false,
+  workspaceId: "ws-1",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  workspace: { id: "ws-1", name: "Test WS" },
+};
+
+// --- Tests ---
+
+describe("serverRouter.getServers", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns servers for workspace with decrypted username", async () => {
+    mockServerFindMany.mockResolvedValue([mockServer]);
+
+    const caller = serverRouter.createCaller(makeCtx() as never);
+    const result = await caller.getServers({ workspaceId: "ws-1" });
+
+    expect(result.servers).toHaveLength(1);
+    expect(result.servers[0].username).toBe("guest"); // decrypted
+    expect(mockServerFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { workspaceId: "ws-1" } })
+    );
+  });
+
+  it("returns empty array when no servers", async () => {
+    mockServerFindMany.mockResolvedValue([]);
+
+    const caller = serverRouter.createCaller(makeCtx() as never);
+    const result = await caller.getServers({ workspaceId: "ws-1" });
+
+    expect(result.servers).toHaveLength(0);
+  });
+});
+
+describe("serverRouter.getServer", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when server does not exist", async () => {
+    mockServerFindUnique.mockResolvedValue(null);
+
+    const caller = serverRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getServer({ id: "srv-999", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("returns server with decrypted username", async () => {
+    mockServerFindUnique.mockResolvedValue(mockServer);
+
+    const caller = serverRouter.createCaller(makeCtx() as never);
+    const result = await caller.getServer({ id: "srv-1", workspaceId: "ws-1" });
+
+    expect(result.server.id).toBe("srv-1");
+    expect(result.server.username).toBe("guest"); // decrypted
+  });
+});
+
+describe("serverRouter.deleteServer (ADMIN only)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when server does not exist in workspace", async () => {
+    mockServerFindUnique.mockResolvedValue(null);
+
+    const caller = serverRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.deleteServer({ id: "srv-999", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("deletes server and returns success message", async () => {
+    mockServerFindUnique.mockResolvedValue(mockServer);
+    mockServerDelete.mockResolvedValue({});
+
+    const caller = serverRouter.createCaller(makeCtx() as never);
+    const result = await caller.deleteServer({
+      id: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(mockServerDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "srv-1" } })
+    );
+    expect(result.message).toBeDefined();
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = serverRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-1",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.deleteServer({ id: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("serverRouter.testConnection (ADMIN only)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns success with version info when connection works", async () => {
+    mockGetOverview.mockResolvedValue({
+      rabbitmq_version: "3.12.0",
+      cluster_name: "test-cluster",
+    });
+
+    const caller = serverRouter.createCaller(makeCtx() as never);
+    const result = await caller.testConnection({
+      workspaceId: "ws-1",
+      host: "rabbitmq.example.com",
+      port: 15672,
+      amqpPort: 5672,
+      username: "guest",
+      password: "guest",
+      vhost: "/",
+      useHttps: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.version).toBe("3.12.0");
+    expect(result.cluster_name).toBe("test-cluster");
+  });
+
+  it("throws BAD_REQUEST when connection fails", async () => {
+    mockGetOverview.mockRejectedValue(new Error("Connection refused"));
+
+    const caller = serverRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.testConnection({
+        workspaceId: "ws-1",
+        host: "bad.host",
+        port: 15672,
+        amqpPort: 5672,
+        username: "guest",
+        password: "wrong",
+        vhost: "/",
+        useHttps: false,
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/users.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/users.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClientFromServer = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: { rabbitMQServer: { update: vi.fn() } },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+}));
+
+vi.mock("@/services/encryption.service", () => ({
+  EncryptionService: {
+    encrypt: vi.fn((v) => `enc:${v}`),
+    decrypt: vi.fn((v) => v?.replace?.("enc:", "") ?? v),
+  },
+}));
+
+vi.mock("@/mappers/rabbitmq", () => ({
+  UserMapper: {
+    toApiResponseArray: vi.fn((us) => us),
+    toApiResponse: vi.fn((u) => u),
+  },
+}));
+
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClient: vi.fn(),
+  createRabbitMQClientFromServer: (...a: unknown[]) =>
+    mockCreateRabbitMQClientFromServer(...a),
+}));
+
+const { usersRouter } = await import("../users");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: { rabbitMQServer: { update: vi.fn() } },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    locale: "en",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    ...overrides,
+  };
+}
+
+const mockServer = {
+  id: "srv-1",
+  host: "rabbitmq.example.com",
+  port: 15672,
+  username: "enc:guest",
+  password: "enc:password",
+  vhost: "/",
+  useHttps: false,
+  workspaceId: "ws-1",
+};
+
+const mockClient = {
+  getUsers: vi.fn().mockResolvedValue([]),
+  getUser: vi
+    .fn()
+    .mockResolvedValue({
+      name: "alice",
+      tags: "administrator",
+      password_hash: "hash123",
+    }),
+  getUserPermissions: vi.fn().mockResolvedValue([]),
+  createUser: vi.fn().mockResolvedValue(undefined),
+  updateUser: vi.fn().mockResolvedValue(undefined),
+  deleteUser: vi.fn().mockResolvedValue(undefined),
+  setUserPermissions: vi.fn().mockResolvedValue(undefined),
+  deleteUserPermissions: vi.fn().mockResolvedValue(undefined),
+};
+
+// --- Tests ---
+
+describe("usersRouter.getUsers (ADMIN only)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = usersRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getUsers({ serverId: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns users list on success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    mockClient.getUsers.mockResolvedValue([
+      { name: "alice", tags: "administrator" },
+      { name: "bob", tags: "" },
+    ]);
+    mockClient.getUserPermissions.mockResolvedValue([{ vhost: "/" }]);
+
+    const caller = usersRouter.createCaller(makeCtx() as never);
+    const result = await caller.getUsers({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.users).toBeDefined();
+    expect(mockClient.getUsers).toHaveBeenCalled();
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = usersRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.getUsers({ serverId: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("usersRouter.createUser (ADMIN only)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = usersRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.createUser({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        username: "newuser",
+        password: "pass123",
+        tags: "",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("creates user and returns success message", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+
+    const caller = usersRouter.createCaller(makeCtx() as never);
+    const result = await caller.createUser({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      username: "newuser",
+      password: "pass123",
+      tags: "",
+    });
+
+    expect(result.message).toBeDefined();
+    expect(mockClient.createUser).toHaveBeenCalledWith(
+      "newuser",
+      expect.objectContaining({ password: "pass123" })
+    );
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = usersRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.createUser({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        username: "newuser",
+        password: "pass123",
+        tags: "",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("usersRouter.deleteUser (ADMIN only)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClientFromServer.mockReturnValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = usersRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.deleteUser({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        username: "olduser",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws FORBIDDEN when trying to delete the connection user", async () => {
+    // EncryptionService.decrypt is mocked to strip "enc:" prefix, so "enc:guest" → "guest"
+    mockVerifyServerAccess.mockResolvedValue({
+      ...mockServer,
+      username: "enc:guest",
+    });
+
+    const caller = usersRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.deleteUser({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        username: "guest",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("deletes user and returns success message", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+
+    const caller = usersRouter.createCaller(makeCtx() as never);
+    const result = await caller.deleteUser({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      username: "olduser",
+    });
+
+    expect(result.message).toBeDefined();
+    expect(mockClient.deleteUser).toHaveBeenCalledWith("olduser");
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = usersRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.deleteUser({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        username: "olduser",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/apps/api/src/trpc/routers/rabbitmq/__tests__/vhost.test.ts
+++ b/apps/api/src/trpc/routers/rabbitmq/__tests__/vhost.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockVerifyServerAccess = vi.fn();
+const mockCreateRabbitMQClient = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: { rabbitMQServer: { update: vi.fn() } },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+  getOrgPlan: vi.fn().mockResolvedValue("FREE"),
+}));
+
+vi.mock("@/mappers/rabbitmq", () => ({
+  VHostMapper: {
+    toApiResponseArray: vi.fn((vs) => vs),
+    toApiResponse: vi.fn((v) => v),
+  },
+}));
+
+vi.mock("../shared", () => ({
+  verifyServerAccess: (...a: unknown[]) => mockVerifyServerAccess(...a),
+  createRabbitMQClient: (...a: unknown[]) => mockCreateRabbitMQClient(...a),
+  createRabbitMQClientFromServer: vi.fn(),
+}));
+
+const { vhostRouter } = await import("../vhost");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: { rabbitMQServer: { update: vi.fn() } },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      isActive: true,
+      role: "ADMIN",
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    locale: "en",
+    resolveOrg: vi
+      .fn()
+      .mockResolvedValue({ organizationId: "org-1", role: "ADMIN" }),
+    ...overrides,
+  };
+}
+
+const mockServer = {
+  id: "srv-1",
+  host: "rabbitmq.example.com",
+  port: 15672,
+  useHttps: false,
+  workspaceId: "ws-1",
+};
+
+const mockClient = {
+  getVHosts: vi.fn().mockResolvedValue([]),
+  getVHost: vi.fn().mockResolvedValue({ name: "my-vhost", tracing: false }),
+  getVHostPermissions: vi.fn().mockResolvedValue([]),
+  getVHostLimits: vi.fn().mockResolvedValue({}),
+  getQueues: vi.fn().mockResolvedValue([]),
+  getExchanges: vi.fn().mockResolvedValue([]),
+  getConnections: vi.fn().mockResolvedValue([]),
+  createVHost: vi.fn().mockResolvedValue(undefined),
+  deleteVHost: vi.fn().mockResolvedValue(undefined),
+  updateVHost: vi.fn().mockResolvedValue(undefined),
+  setUserPermissions: vi.fn().mockResolvedValue(undefined),
+  deleteUserPermissions: vi.fn().mockResolvedValue(undefined),
+  setVHostLimit: vi.fn().mockResolvedValue(undefined),
+  deleteVHostLimit: vi.fn().mockResolvedValue(undefined),
+};
+
+// --- Tests ---
+
+describe("vhostRouter.getVHosts (ADMIN or MEMBER)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = vhostRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getVHosts({ serverId: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("returns vhosts list on success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    mockClient.getVHosts.mockResolvedValue([{ name: "/", tracing: false }]);
+
+    const caller = vhostRouter.createCaller(makeCtx() as never);
+    const result = await caller.getVHosts({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.vhosts).toBeDefined();
+    expect(mockClient.getVHosts).toHaveBeenCalled();
+  });
+
+  it("throws FORBIDDEN when user is USER role", async () => {
+    const caller = vhostRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.getVHosts({ serverId: "srv-1", workspaceId: "ws-1" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("succeeds when user is MEMBER role", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+    mockClient.getVHosts.mockResolvedValue([]);
+
+    const caller = vhostRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-3",
+          email: "m@m.com",
+          isActive: true,
+          role: "MEMBER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    const result = await caller.getVHosts({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("vhostRouter.createVHost (ADMIN only)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = vhostRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.createVHost({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        name: "new-vhost",
+        tracing: false,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("creates vhost and returns success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+
+    const caller = vhostRouter.createCaller(makeCtx() as never);
+    const result = await caller.createVHost({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      name: "new-vhost",
+      tracing: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockClient.createVHost).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "new-vhost" })
+    );
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = vhostRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.createVHost({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        name: "new-vhost",
+        tracing: false,
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("vhostRouter.deleteVHost (ADMIN only)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRabbitMQClient.mockResolvedValue(mockClient);
+  });
+
+  it("throws NOT_FOUND when verifyServerAccess returns null", async () => {
+    mockVerifyServerAccess.mockResolvedValue(null);
+
+    const caller = vhostRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.deleteVHost({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        vhostName: "old-vhost",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws BAD_REQUEST when trying to delete the default vhost", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+
+    const caller = vhostRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.deleteVHost({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        vhostName: "/",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("deletes vhost and returns success", async () => {
+    mockVerifyServerAccess.mockResolvedValue(mockServer);
+
+    const caller = vhostRouter.createCaller(makeCtx() as never);
+    const result = await caller.deleteVHost({
+      serverId: "srv-1",
+      workspaceId: "ws-1",
+      vhostName: "old-vhost",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockClient.deleteVHost).toHaveBeenCalledWith("old-vhost");
+  });
+
+  it("throws FORBIDDEN when user is not ADMIN", async () => {
+    const caller = vhostRouter.createCaller(
+      makeCtx({
+        user: {
+          id: "user-2",
+          email: "u@u.com",
+          isActive: true,
+          role: "USER",
+          workspaceId: "ws-1",
+        },
+      }) as never
+    );
+    await expect(
+      caller.deleteVHost({
+        serverId: "srv-1",
+        workspaceId: "ws-1",
+        vhostName: "old-vhost",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/apps/api/src/trpc/routers/workspace/__tests__/invitation.test.ts
+++ b/apps/api/src/trpc/routers/workspace/__tests__/invitation.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockUserFindUnique = vi.fn();
+const mockInvitationFindMany = vi.fn();
+const mockInvitationFindFirst = vi.fn();
+const mockInvitationDelete = vi.fn();
+const mockInvitationCreate = vi.fn();
+const mockInvitationCount = vi.fn();
+
+vi.mock("@/core/prisma", () => ({
+  prisma: {
+    user: { findUnique: (...a: unknown[]) => mockUserFindUnique(...a) },
+    invitation: {
+      findMany: (...a: unknown[]) => mockInvitationFindMany(...a),
+      findFirst: (...a: unknown[]) => mockInvitationFindFirst(...a),
+      delete: (...a: unknown[]) => mockInvitationDelete(...a),
+      create: (...a: unknown[]) => mockInvitationCreate(...a),
+      count: (...a: unknown[]) => mockInvitationCount(...a),
+    },
+  },
+}));
+
+vi.mock("@/core/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/trpc/middlewares/rateLimiter", () => ({
+  standardRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  strictRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+  billingRateLimiter: (opts: { next: () => unknown }) => opts.next(),
+}));
+
+vi.mock("@/middlewares/workspace", () => ({
+  hasWorkspaceAccess: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/services/plan/plan.service", () => ({
+  getWorkspacePlan: vi.fn().mockResolvedValue("FREE"),
+  validateUserInvitation: vi.fn().mockResolvedValue(undefined),
+  PlanErrorCode: { PLAN_RESTRICTION: "PLAN_RESTRICTION" },
+  PlanLimitExceededError: class extends Error {},
+  PlanValidationError: class extends Error {},
+}));
+
+vi.mock("@/services/email/email.service", () => ({
+  EmailService: {
+    sendInvitationEmail: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+vi.mock("@/services/email/core-email.service", () => ({
+  CoreEmailService: {
+    sendInvitationEmail: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+vi.mock("@/services/encryption.service", () => ({
+  EncryptionService: {
+    generateEncryptionKey: vi.fn().mockReturnValue("token-xyz"),
+  },
+}));
+
+vi.mock("@/core/utils", () => ({
+  formatInvitedBy: vi.fn((u) => u),
+  getUserDisplayName: vi.fn((u) => u?.email ?? ""),
+}));
+
+vi.mock("@/config", () => ({
+  emailConfig: { enabled: true },
+}));
+
+vi.mock("@/config/features", () => ({
+  FEATURES: {},
+  getAllPremiumFeatures: () => [],
+  FEATURE_DESCRIPTIONS: {},
+}));
+
+vi.mock("@/core/feature-flags", () => ({
+  isFeatureEnabled: vi.fn().mockResolvedValue(true),
+  getLicensePayload: vi.fn(),
+  invalidateLicenseCache: vi.fn(),
+}));
+
+const { invitationRouter } = await import("../invitation");
+
+// --- Helpers ---
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    prisma: {
+      user: { findUnique: mockUserFindUnique },
+      invitation: {
+        findMany: mockInvitationFindMany,
+        findFirst: mockInvitationFindFirst,
+        delete: mockInvitationDelete,
+        create: mockInvitationCreate,
+        count: mockInvitationCount,
+      },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: {
+      id: "user-1",
+      email: "admin@test.com",
+      role: "ADMIN",
+      isActive: true,
+      workspaceId: "ws-1",
+    },
+    workspaceId: "ws-1",
+    locale: "en",
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe("invitationRouter.getInvitations", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws FORBIDDEN when user has no workspace in DB", async () => {
+    mockUserFindUnique.mockResolvedValue({ workspaceId: null });
+
+    const caller = invitationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.getInvitations({ page: 1, limit: 10 })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("returns paginated invitations for workspace", async () => {
+    mockUserFindUnique.mockResolvedValue({ workspaceId: "ws-1" });
+    mockInvitationCount.mockResolvedValue(2);
+    mockInvitationFindMany.mockResolvedValue([
+      {
+        id: "inv-1",
+        email: "user@example.com",
+        role: "MEMBER",
+        status: "PENDING",
+        expiresAt: new Date(Date.now() + 86_400_000),
+        createdAt: new Date(),
+        invitedBy: {
+          id: "user-1",
+          email: "admin@test.com",
+          firstName: "Admin",
+          lastName: "User",
+        },
+      },
+    ]);
+
+    const caller = invitationRouter.createCaller(makeCtx() as never);
+    const result = await caller.getInvitations({ page: 1, limit: 10 });
+
+    expect(result.invitations).toHaveLength(1);
+    expect(mockInvitationFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ workspaceId: "ws-1" }),
+      })
+    );
+  });
+});
+
+describe("invitationRouter.revokeInvitation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws FORBIDDEN when user has no workspace", async () => {
+    mockUserFindUnique.mockResolvedValue({ workspaceId: null });
+
+    const caller = invitationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.revokeInvitation({ invitationId: "inv-1" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("throws NOT_FOUND when invitation does not exist in workspace", async () => {
+    mockUserFindUnique.mockResolvedValue({ workspaceId: "ws-1" });
+    mockInvitationFindFirst.mockResolvedValue(null);
+
+    const caller = invitationRouter.createCaller(makeCtx() as never);
+    await expect(
+      caller.revokeInvitation({ invitationId: "inv-999" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("deletes invitation when found", async () => {
+    mockUserFindUnique.mockResolvedValue({ workspaceId: "ws-1" });
+    mockInvitationFindFirst.mockResolvedValue({
+      id: "inv-1",
+      workspaceId: "ws-1",
+    });
+    mockInvitationDelete.mockResolvedValue({});
+
+    const caller = invitationRouter.createCaller(makeCtx() as never);
+    const result = await caller.revokeInvitation({ invitationId: "inv-1" });
+
+    expect(mockInvitationDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "inv-1" } })
+    );
+    expect(result.message).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds unit tests covering 23 previously untested tRPC routers across all groups
- 896 tests passing; only 4 pre-existing failures in `slack.service.test.ts` / `webhook.service.test.ts` (Node v20 vs v24 `Error.isError` incompatibility, unrelated to this PR)

**Auth group:** registration, session, verification, password, email, org-invitation
**Workspace/User group:** workspace invitation, public invitation, user
**Misc:** discord, feedback
**Payment/Portal:** checkout, subscription, portal/license
**RabbitMQ:** server, queues, overview, definitions, infrastructure, memory, messages, policies, users, vhost

## Test plan

- [x] Run `pnpm --filter qarote-api test:run` — 896/901 pass (4 pre-existing failures)
- [x] Type check passes (`pnpm type-check`)
- [x] Each router tested for: NOT_FOUND / FORBIDDEN guards, success paths, and input validation edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)